### PR TITLE
Increase buffer-size in ChaosSpec

### DIFF
--- a/projection/src/test/scala/akka/projection/r2dbc/ChaosSpec.scala
+++ b/projection/src/test/scala/akka/projection/r2dbc/ChaosSpec.scala
@@ -41,8 +41,10 @@ object ChaosSpec {
     akka.persistence.r2dbc {
       query {
         refresh-interval = 1s
-        # stress more by using a small buffer (sql limit)
-        buffer-size = 10
+        # Stress more by using a smaller buffer (sql limit) than default.
+        # Note that it shouldn't be set too small since that would prevent progress if more than
+        # this number of events are stored for the same timestamp.
+        buffer-size = 100
       }
     }
     akka.projection {


### PR DESCRIPTION
I definitely saw one test failure that could be explained by 16 events on the same timestamp.
I don't think this explains all of https://github.com/akka/akka-persistence-r2dbc/issues/44