### PR TITLE
Transactions are wrong with the connection pool, #46

### DIFF
--- a/core/src/main/scala/akka/persistence/r2dbc/ConnectionFactoryProvider.scala
+++ b/core/src/main/scala/akka/persistence/r2dbc/ConnectionFactoryProvider.scala
@@ -10,6 +10,7 @@ import java.util.concurrent.ConcurrentHashMap
 import akka.actor.typed.ActorSystem
 import akka.actor.typed.Extension
 import akka.actor.typed.ExtensionId
+import akka.persistence.r2dbc.internal.DummyConnectionPool
 import akka.persistence.r2dbc.internal.R2dbcExecutor
 import io.r2dbc.pool.ConnectionPool
 import io.r2dbc.pool.ConnectionPoolConfiguration
@@ -35,7 +36,10 @@ class ConnectionFactoryProvider(system: ActorSystem[_]) extends Extension {
       configLocation => {
         val config = system.settings.config.getConfig(configLocation)
         val settings = new ConnectionFactorySettings(config)
-        createConnectionPoolFactory(settings)
+        // FIXME connection pool is not working, see issue https://github.com/akka/akka-persistence-r2dbc/issues/46
+        // and https://github.com/akka/akka-persistence-r2dbc/issues/33
+        //createConnectionPoolFactory(settings)
+        new DummyConnectionPool(createConnectionFactory(settings), settings.maxSize)(system)
       })
   }
 

--- a/core/src/main/scala/akka/persistence/r2dbc/internal/DummyConnectionPool.scala
+++ b/core/src/main/scala/akka/persistence/r2dbc/internal/DummyConnectionPool.scala
@@ -1,0 +1,121 @@
+/*
+ * Copyright (C) 2021 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.persistence.r2dbc.internal
+
+import java.lang
+import java.util
+import java.util.concurrent.ConcurrentLinkedQueue
+
+import akka.actor.typed.ActorSystem
+import io.r2dbc.spi.Batch
+import io.r2dbc.spi.Connection
+import io.r2dbc.spi.ConnectionFactory
+import io.r2dbc.spi.ConnectionFactoryMetadata
+import io.r2dbc.spi.ConnectionMetadata
+import io.r2dbc.spi.IsolationLevel
+import io.r2dbc.spi.Statement
+import io.r2dbc.spi.ValidationDepth
+import org.reactivestreams.Publisher
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
+import reactor.core.publisher.Mono
+
+object DummyConnectionPool {
+  val log: Logger = LoggerFactory.getLogger(classOf[DummyConnectionPool])
+}
+
+// FIXME Couldn't get r2dbc-pool working. Transactions are mixed up. This is just temporary workaround.
+class DummyConnectionPool(connectionFactory: ConnectionFactory, max: Int)(implicit val system: ActorSystem[_])
+    extends ConnectionFactory {
+  import DummyConnectionPool.log
+  import akka.persistence.r2dbc.internal.R2dbcExecutor.PublisherOps
+  import system.executionContext
+  private val pool = new ConcurrentLinkedQueue[PooledConnection]
+
+  (1 to max).foreach { _ =>
+    connectionFactory.create().asFuture().foreach(c => pool.offer(new PooledConnection(c, pool)))
+  }
+
+  system.whenTerminated.onComplete { _ =>
+    var c = pool.poll()
+    while (c != null) {
+      c.delegate.close().asFuture()
+      c = pool.poll()
+    }
+  }(scala.concurrent.ExecutionContext.global)
+
+  override def create(): Publisher[_ <: Connection] = {
+    pool.poll() match {
+      case null =>
+        Thread.sleep(20)
+        pool.poll() match {
+          case null =>
+            log.warn("creating additional connection outside pool because all connections are busy")
+            connectionFactory.create()
+          case c =>
+            log.debug("using pooled connection after delay, {} remaining", pool.size())
+            Mono.just(c)
+        }
+      case c =>
+        log.debug("using pooled connection, {} remaining", pool.size())
+        Mono.just(c)
+    }
+  }
+
+  override def getMetadata: ConnectionFactoryMetadata =
+    connectionFactory.getMetadata
+}
+
+class PooledConnection(val delegate: Connection, releaseTo: util.Queue[PooledConnection]) extends Connection {
+  import DummyConnectionPool.log
+
+  override def beginTransaction(): Publisher[Void] =
+    delegate.beginTransaction()
+
+  override def close(): Publisher[Void] = {
+    releaseTo.offer(this)
+    log.debug("releasing pooled connection, {} available", releaseTo.size())
+    Mono.justOrEmpty(null)
+  }
+
+  override def commitTransaction(): Publisher[Void] =
+    delegate.commitTransaction()
+
+  override def createBatch(): Batch =
+    delegate.createBatch()
+
+  override def createSavepoint(name: String): Publisher[Void] =
+    delegate.createSavepoint(name)
+
+  override def createStatement(sql: String): Statement =
+    delegate.createStatement(sql)
+
+  override def isAutoCommit: Boolean =
+    delegate.isAutoCommit
+
+  override def getMetadata: ConnectionMetadata =
+    delegate.getMetadata
+
+  override def getTransactionIsolationLevel: IsolationLevel =
+    delegate.getTransactionIsolationLevel
+
+  override def releaseSavepoint(name: String): Publisher[Void] =
+    delegate.releaseSavepoint(name)
+
+  override def rollbackTransaction(): Publisher[Void] =
+    delegate.rollbackTransaction()
+
+  override def rollbackTransactionToSavepoint(name: String): Publisher[Void] =
+    delegate.rollbackTransactionToSavepoint(name)
+
+  override def setAutoCommit(autoCommit: Boolean): Publisher[Void] =
+    delegate.setAutoCommit(autoCommit)
+
+  override def setTransactionIsolationLevel(isolationLevel: IsolationLevel): Publisher[Void] =
+    delegate.setTransactionIsolationLevel(isolationLevel)
+
+  override def validate(depth: ValidationDepth): Publisher[lang.Boolean] =
+    delegate.validate(depth)
+}

--- a/core/src/test/scala/akka/persistence/r2dbc/TestActors.scala
+++ b/core/src/test/scala/akka/persistence/r2dbc/TestActors.scala
@@ -5,6 +5,7 @@
 package akka.persistence.r2dbc
 
 import akka.Done
+import akka.actor.typed.scaladsl.Behaviors
 import akka.actor.typed.{ ActorRef, Behavior }
 import akka.persistence.typed.PersistenceId
 import akka.persistence.typed.scaladsl.{ Effect, EventSourcedBehavior }
@@ -19,25 +20,47 @@ object TestActors {
     final case class Stop(replyTo: ActorRef[Done]) extends Command
 
     def apply(pid: String): Behavior[Command] =
-      EventSourcedBehavior[Command, Any, String](
-        persistenceId = PersistenceId.ofUniqueId(pid),
-        "",
-        { (_, command) =>
-          command match {
-            case command: Persist =>
-              Effect.persist(command.payload)
-            case command: PersistWithAck =>
-              Effect.persist(command.payload).thenRun(_ => command.replyTo ! Done)
-            case command: PersistAll =>
-              Effect.persist(command.payloads)
-            case Ping(replyTo) =>
-              replyTo ! Done
-              Effect.none
-            case Stop(replyTo) =>
-              replyTo ! Done
-              Effect.stop()
-          }
-        },
-        (_, _) => "")
+      apply(PersistenceId.ofUniqueId(pid))
+
+    def apply(pid: PersistenceId): Behavior[Command] = {
+      Behaviors.setup { context =>
+        EventSourcedBehavior[Command, Any, String](
+          persistenceId = pid,
+          "",
+          { (_, command) =>
+            command match {
+              case command: Persist =>
+                context.log.debug(
+                  "Persist [{}], pid [{}], seqNr [{}]",
+                  command.payload,
+                  pid.id,
+                  EventSourcedBehavior.lastSequenceNumber(context) + 1)
+                Effect.persist(command.payload)
+              case command: PersistWithAck =>
+                context.log.debug(
+                  "Persist [{}], pid [{}], seqNr [{}]",
+                  command.payload,
+                  pid.id,
+                  EventSourcedBehavior.lastSequenceNumber(context) + 1)
+                Effect.persist(command.payload).thenRun(_ => command.replyTo ! Done)
+              case command: PersistAll =>
+                if (context.log.isDebugEnabled)
+                  context.log.debug(
+                    "PersistAll [{}], pid [{}], seqNr [{}]",
+                    command.payloads.mkString(","),
+                    pid.id,
+                    EventSourcedBehavior.lastSequenceNumber(context) + 1)
+                Effect.persist(command.payloads)
+              case Ping(replyTo) =>
+                replyTo ! Done
+                Effect.none
+              case Stop(replyTo) =>
+                replyTo ! Done
+                Effect.stop()
+            }
+          },
+          (_, _) => "")
+      }
+    }
   }
 }

--- a/core/src/test/scala/akka/persistence/r2dbc/TestData.scala
+++ b/core/src/test/scala/akka/persistence/r2dbc/TestData.scala
@@ -16,6 +16,7 @@ trait TestData {
   import TestData.entityTypeHintCounter
 
   def nextPid() = s"p-${pidCounter.incrementAndGet()}"
+  // FIXME return PersistenceId instead
   def nextPid(entityTypeHint: String) = s"$entityTypeHint|p-${pidCounter.incrementAndGet()}"
 
   def nextEntityTypeHint() = s"TestEntity-${entityTypeHintCounter.incrementAndGet()}"

--- a/core/src/test/scala/akka/persistence/r2dbc/journal/PersistTimestampSpec.scala
+++ b/core/src/test/scala/akka/persistence/r2dbc/journal/PersistTimestampSpec.scala
@@ -1,0 +1,107 @@
+/**
+ * Copyright (C) 2021 Lightbend Inc. <https://www.lightbend.com>
+ */
+package akka.persistence.r2dbc.journal
+
+import java.time.Instant
+
+import scala.concurrent.duration._
+
+import akka.Done
+import akka.actor.testkit.typed.scaladsl.LogCapturing
+import akka.actor.testkit.typed.scaladsl.ScalaTestWithActorTestKit
+import akka.actor.typed.ActorSystem
+import akka.persistence.r2dbc.R2dbcSettings
+import akka.persistence.r2dbc.TestActors.Persister
+import akka.persistence.r2dbc.TestConfig
+import akka.persistence.r2dbc.TestData
+import akka.persistence.r2dbc.TestDbLifecycle
+import akka.persistence.typed.PersistenceId
+import akka.serialization.SerializationExtension
+import org.scalatest.wordspec.AnyWordSpecLike
+
+class PersistTimestampSpec
+    extends ScalaTestWithActorTestKit(TestConfig.config)
+    with AnyWordSpecLike
+    with TestDbLifecycle
+    with TestData
+    with LogCapturing {
+
+  override def typedSystem: ActorSystem[_] = system
+  private val settings = new R2dbcSettings(system.settings.config.getConfig("akka.persistence.r2dbc"))
+  private val serialization = SerializationExtension(system)
+
+  case class Row(pid: String, seqNr: Long, dbTimestamp: Instant, writeTimestamp: Long, event: String)
+
+  "Persist timestamp" should {
+
+    "be the same for events stored in same transaction" in {
+      val numberOfEntities = 20
+      val entityTypeHint = nextEntityTypeHint()
+
+      val entities = (0 until numberOfEntities).map { n =>
+        val persistenceId = PersistenceId(entityTypeHint, s"p$n")
+        spawn(Persister(persistenceId), s"p$n")
+      }
+
+      (1 to 100).foreach { n =>
+        val p = n % numberOfEntities
+        // mix some persist 1 and persist 3 events
+        if (n % 5 == 0) {
+          // same event stored 3 times
+          val event = s"e$p-$n"
+          entities(p) ! Persister.PersistAll((0 until 3).map(_ => event).toList)
+        } else {
+          entities(p) ! Persister.Persist(s"e$p-$n")
+        }
+      }
+
+      val pingProbe = createTestProbe[Done]()
+      entities.foreach { ref =>
+        ref ! Persister.Ping(pingProbe.ref)
+      }
+      pingProbe.receiveMessages(entities.size, 20.seconds)
+
+      val rows =
+        r2dbcExecutor
+          .select[Row]("test")(
+            connection => connection.createStatement(s"select * from ${settings.journalTableWithSchema}"),
+            row => {
+              val event = serialization
+                .deserialize(
+                  row.get("event_payload", classOf[Array[Byte]]),
+                  row.get("event_ser_id", classOf[Integer]),
+                  row.get("event_ser_manifest", classOf[String]))
+                .get
+                .asInstanceOf[String]
+              Row(
+                pid = row.get("persistence_id", classOf[String]),
+                seqNr = row.get("sequence_number", classOf[java.lang.Long]),
+                dbTimestamp = row.get("db_timestamp", classOf[Instant]),
+                writeTimestamp = row.get("write_timestamp", classOf[java.lang.Long]),
+                event)
+            })
+          .futureValue
+
+      rows.groupBy(_.event).foreach { case (_, rowsByUniqueEvent) =>
+        withClue(s"pid [${rowsByUniqueEvent.head.pid}]: ") {
+          rowsByUniqueEvent.map(_.dbTimestamp).toSet shouldBe Set(rowsByUniqueEvent.head.dbTimestamp)
+          rowsByUniqueEvent.map(_.writeTimestamp).toSet shouldBe Set(rowsByUniqueEvent.head.writeTimestamp)
+        }
+      }
+
+      val rowOrdering: Ordering[Row] = Ordering.fromLessThan[Row] { (a, b) =>
+        if (a eq b) false
+        else if (a.dbTimestamp != b.dbTimestamp) a.dbTimestamp.compareTo(b.dbTimestamp) < 0
+        else a.seqNr.compareTo(b.seqNr) < 0
+      }
+
+      rows.groupBy(_.pid).foreach { case (_, rowsByPid) =>
+        withClue(s"pid [${rowsByPid.head.pid}]: ") {
+          rowsByPid.sortBy(_.seqNr) shouldBe rowsByPid.sorted(rowOrdering)
+        }
+      }
+    }
+
+  }
+}

--- a/projection/src/test/scala/akka/projection/r2dbc/TestData.scala
+++ b/projection/src/test/scala/akka/projection/r2dbc/TestData.scala
@@ -19,6 +19,7 @@ trait TestData {
   import TestData.entityTypeHintCounter
 
   def nextPid() = s"p-${pidCounter.incrementAndGet()}"
+  // FIXME return PersistenceId instead
   def nextPid(entityTypeHint: String) = s"$entityTypeHint|p-${pidCounter.incrementAndGet()}"
 
   def nextEntityTypeHint() = s"TestEntity-${entityTypeHintCounter.incrementAndGet()}"


### PR DESCRIPTION
First I thought it was the auto-commit that was interferring, but that wasn't the case. Same without auto-commit.

* test that clearly reproduces the problem
* transaction_timestamp isn't the same within the transaction
  as it is supposed to be
* many warning logs about transactions, see issue #33
* Swithing back to the DummyConnectionPool from https://github.com/akka/akka-persistence-r2dbc/pull/22

References #46
