### PR TITLE
temporarily disable query cache

### DIFF
--- a/core/src/main/scala/akka/persistence/r2dbc/ConnectionFactoryProvider.scala
+++ b/core/src/main/scala/akka/persistence/r2dbc/ConnectionFactoryProvider.scala
@@ -68,6 +68,8 @@ class ConnectionFactoryProvider(system: ActorSystem[_]) extends Extension {
         .option(ConnectionFactoryOptions.DATABASE, settings.database)
         .option(PostgresqlConnectionFactoryProvider.FORCE_BINARY, java.lang.Boolean.TRUE)
         .option(PostgresqlConnectionFactoryProvider.PREFER_ATTACHED_BUFFERS, java.lang.Boolean.TRUE)
+        // FIXME: re-enable cache when issue in driver is solved
+        .option(PostgresqlConnectionFactoryProvider.PREPARED_STATEMENT_CACHE_QUERIES, Integer.valueOf(0))
         .build())
   }
 


### PR DESCRIPTION
References #29

I believe I found a race condition in the r2dbc-postgres driver. I will report there to get confirmation. 

In the meantime, we can disable the query cache to avoid flaky tests.
