### PR TITLE
Extract common by slice query logic

### DIFF
--- a/core/src/main/scala/akka/persistence/r2dbc/internal/BySliceQuery.scala
+++ b/core/src/main/scala/akka/persistence/r2dbc/internal/BySliceQuery.scala
@@ -1,0 +1,190 @@
+/*
+ * Copyright (C) 2021 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.persistence.r2dbc.internal
+
+import java.time.Instant
+
+import scala.concurrent.ExecutionContext
+import scala.concurrent.Future
+import scala.concurrent.duration.Duration
+import scala.concurrent.duration.FiniteDuration
+
+import akka.NotUsed
+import akka.annotation.InternalApi
+import akka.persistence.query.Offset
+import akka.persistence.r2dbc.R2dbcSettings
+import akka.persistence.r2dbc.query.TimestampOffset
+import akka.stream.scaladsl.Flow
+import akka.stream.scaladsl.Source
+import org.slf4j.Logger
+
+/**
+ * INTERNAL API
+ */
+@InternalApi private[r2dbc] object BySliceQuery {
+  val EmptyDbTimestamp: Instant = Instant.EPOCH
+
+  object QueryState {
+    val empty: QueryState =
+      QueryState(TimestampOffset.Zero, 0, 0, 0, backtracking = false, TimestampOffset.Zero)
+  }
+
+  final case class QueryState(
+      latest: TimestampOffset,
+      rowCount: Int,
+      queryCount: Long,
+      idleCount: Long,
+      backtracking: Boolean,
+      latestBacktracking: TimestampOffset) {
+
+    def currentOffset: TimestampOffset =
+      if (backtracking) latestBacktracking
+      else latest
+
+    def nextQueryFromTimestamp: Instant =
+      if (backtracking) latestBacktracking.timestamp
+      else latest.timestamp
+
+    def nextQueryUntilTimestamp: Option[Instant] =
+      if (backtracking) Some(latest.timestamp)
+      else None
+  }
+
+  trait SerializedRow {
+    def persistenceId: String
+    def sequenceNr: Long
+    def dbTimestamp: Instant
+    def readDbTimestamp: Instant
+  }
+
+  trait Dao[SerializedRow] {
+    def currentDbTimestamp(): Future[Instant]
+
+    def eventsBySlices(
+        entityTypeHint: String,
+        minSlice: Int,
+        maxSlice: Int,
+        fromTimestamp: Instant,
+        untilTimestamp: Option[Instant],
+        behindCurrentTime: FiniteDuration): Source[SerializedRow, NotUsed]
+  }
+}
+
+/**
+ * INTERNAL API
+ */
+@InternalApi private[r2dbc] class BySliceQuery[Row <: BySliceQuery.SerializedRow, Envelope](
+    dao: BySliceQuery.Dao[Row],
+    createEnvelope: (TimestampOffset, Row) => Envelope,
+    extractOffset: Envelope => TimestampOffset,
+    settings: R2dbcSettings,
+    log: Logger)(implicit val ec: ExecutionContext) {
+  import BySliceQuery._
+  import TimestampOffset.toTimestampOffset
+
+  def currentBySlices(
+      logPrefix: String,
+      entityTypeHint: String,
+      minSlice: Int,
+      maxSlice: Int,
+      offset: Offset): Source[Envelope, NotUsed] = {
+    val initialOffset = toTimestampOffset(offset)
+
+    def nextOffset(state: QueryState, eventEnvelope: Envelope): QueryState =
+      state.copy(latest = extractOffset(eventEnvelope), rowCount = state.rowCount + 1)
+
+    def nextQuery(state: QueryState, toDbTimestamp: Instant): (QueryState, Option[Source[Envelope, NotUsed]]) = {
+      // FIXME why is this rowCount -1 of expected?, see test EventsBySliceSpec "read in chunks"
+      if (state.queryCount == 0L || state.rowCount >= settings.querySettings.bufferSize - 1) {
+        val newState = state.copy(rowCount = 0, queryCount = state.queryCount + 1)
+
+        if (state.queryCount != 0 && log.isDebugEnabled())
+          log.debug(
+            "currentEventsBySlices query [{}] from slices [{} - {}], from time [{}] to now [{}]. Found [{}] rows in previous query.",
+            state.queryCount,
+            minSlice,
+            maxSlice,
+            state.latest.timestamp,
+            toDbTimestamp,
+            state.rowCount)
+
+        newState -> Some(
+          dao
+            .eventsBySlices(
+              entityTypeHint,
+              minSlice,
+              maxSlice,
+              state.latest.timestamp,
+              untilTimestamp = Some(toDbTimestamp),
+              behindCurrentTime = Duration.Zero)
+            .via(deserializeAndAddOffset(state.latest)))
+      } else {
+        if (log.isDebugEnabled)
+          log.debug(
+            "{} query [{}] from slices [{} - {}] completed. Found [{}] rows in previous query.",
+            logPrefix,
+            state.queryCount,
+            minSlice,
+            maxSlice,
+            state.rowCount)
+
+        state -> None
+      }
+    }
+
+    Source
+      .futureSource[Envelope, NotUsed] {
+        dao.currentDbTimestamp().map { currentDbTime =>
+          if (log.isDebugEnabled())
+            log.debug(
+              "{} query slices [{} - {}], from time [{}] until now [{}].",
+              logPrefix,
+              minSlice,
+              maxSlice,
+              initialOffset.timestamp,
+              currentDbTime)
+
+          ContinuousQuery[QueryState, Envelope](
+            initialState = QueryState.empty.copy(latest = initialOffset),
+            updateState = nextOffset,
+            delayNextQuery = _ => None,
+            nextQuery = state => nextQuery(state, currentDbTime))
+        }
+      }
+      .mapMaterializedValue(_ => NotUsed)
+  }
+
+  // TODO Unit test in isolation
+  private def deserializeAndAddOffset(timestampOffset: TimestampOffset): Flow[Row, Envelope, NotUsed] = {
+    Flow[Row].statefulMapConcat { () =>
+      var currentTimestamp = timestampOffset.timestamp
+      var currentSequenceNrs: Map[String, Long] = timestampOffset.seen
+      row => {
+        if (row.dbTimestamp == currentTimestamp) {
+          // has this already been seen?
+          if (currentSequenceNrs.get(row.persistenceId).exists(_ >= row.sequenceNr)) {
+            log.debug(
+              "filtering [{}] [{}] as db timestamp is the same as last offset and is in seen [{}]",
+              row.persistenceId,
+              row.sequenceNr,
+              currentSequenceNrs)
+            Nil
+          } else {
+            currentSequenceNrs = currentSequenceNrs.updated(row.persistenceId, row.sequenceNr)
+            val offset =
+              TimestampOffset(row.dbTimestamp, row.readDbTimestamp, currentSequenceNrs)
+            createEnvelope(offset, row) :: Nil
+          }
+        } else {
+          // ne timestamp, reset currentSequenceNrs
+          currentTimestamp = row.dbTimestamp
+          currentSequenceNrs = Map(row.persistenceId -> row.sequenceNr)
+          val offset = TimestampOffset(row.dbTimestamp, row.readDbTimestamp, currentSequenceNrs)
+          createEnvelope(offset, row) :: Nil
+        }
+      }
+    }
+  }
+}

--- a/core/src/main/scala/akka/persistence/r2dbc/internal/BySliceQuery.scala
+++ b/core/src/main/scala/akka/persistence/r2dbc/internal/BySliceQuery.scala
@@ -5,6 +5,7 @@
 package akka.persistence.r2dbc.internal
 
 import java.time.Instant
+import java.time.{ Duration => JDuration }
 
 import scala.concurrent.ExecutionContext
 import scala.concurrent.Future
@@ -62,7 +63,7 @@ import org.slf4j.Logger
   trait Dao[SerializedRow] {
     def currentDbTimestamp(): Future[Instant]
 
-    def eventsBySlices(
+    def rowsBySlices(
         entityTypeHint: String,
         minSlice: Int,
         maxSlice: Int,
@@ -84,6 +85,11 @@ import org.slf4j.Logger
   import BySliceQuery._
   import TimestampOffset.toTimestampOffset
 
+  private val backtrackingWindow = JDuration.ofMillis(settings.querySettings.backtrackingWindow.toMillis)
+  private val halfBacktrackingWindow = backtrackingWindow.dividedBy(2)
+  private val firstBacktrackingQueryWindow =
+    backtrackingWindow.plus(JDuration.ofMillis(settings.querySettings.backtrackingBehindCurrentTime.toMillis))
+
   def currentBySlices(
       logPrefix: String,
       entityTypeHint: String,
@@ -92,8 +98,8 @@ import org.slf4j.Logger
       offset: Offset): Source[Envelope, NotUsed] = {
     val initialOffset = toTimestampOffset(offset)
 
-    def nextOffset(state: QueryState, eventEnvelope: Envelope): QueryState =
-      state.copy(latest = extractOffset(eventEnvelope), rowCount = state.rowCount + 1)
+    def nextOffset(state: QueryState, envelope: Envelope): QueryState =
+      state.copy(latest = extractOffset(envelope), rowCount = state.rowCount + 1)
 
     def nextQuery(state: QueryState, toDbTimestamp: Instant): (QueryState, Option[Source[Envelope, NotUsed]]) = {
       // FIXME why is this rowCount -1 of expected?, see test EventsBySliceSpec "read in chunks"
@@ -102,7 +108,8 @@ import org.slf4j.Logger
 
         if (state.queryCount != 0 && log.isDebugEnabled())
           log.debug(
-            "currentEventsBySlices query [{}] from slices [{} - {}], from time [{}] to now [{}]. Found [{}] rows in previous query.",
+            "{} query [{}] from slices [{} - {}], from time [{}] to now [{}]. Found [{}] rows in previous query.",
+            logPrefix,
             state.queryCount,
             minSlice,
             maxSlice,
@@ -112,7 +119,7 @@ import org.slf4j.Logger
 
         newState -> Some(
           dao
-            .eventsBySlices(
+            .rowsBySlices(
               entityTypeHint,
               minSlice,
               maxSlice,
@@ -154,6 +161,136 @@ import org.slf4j.Logger
         }
       }
       .mapMaterializedValue(_ => NotUsed)
+  }
+
+  def liveBySlices(
+      logPrefix: String,
+      entityTypeHint: String,
+      minSlice: Int,
+      maxSlice: Int,
+      offset: Offset): Source[Envelope, NotUsed] = {
+    val initialOffset = toTimestampOffset(offset)
+    val someRefreshInterval = Some(settings.querySettings.refreshInterval)
+
+    if (log.isDebugEnabled())
+      log.debug(
+        "Starting {} query from slices [{} - {}], from time [{}].",
+        logPrefix,
+        minSlice,
+        maxSlice,
+        initialOffset.timestamp)
+
+    def nextOffset(state: QueryState, envelope: Envelope): QueryState = {
+      val offset = extractOffset(envelope)
+      if (state.backtracking) {
+        if (offset.timestamp.isBefore(state.latestBacktracking.timestamp))
+          throw new IllegalArgumentException(
+            s"Unexpected offset [$offset] before latestBacktracking [${state.latestBacktracking}].")
+
+        state.copy(latestBacktracking = offset, rowCount = state.rowCount + 1)
+      } else {
+        if (offset.timestamp.isBefore(state.latest.timestamp))
+          throw new IllegalArgumentException(s"Unexpected offset [$offset] before latest [${state.latest}].")
+
+        state.copy(latest = offset, rowCount = state.rowCount + 1)
+      }
+    }
+
+    def delayNextQuery(state: QueryState): Option[FiniteDuration] = {
+      // FIXME verify that this is correct
+      // the same row comes back and is filtered due to how the offset works
+      val delay =
+        if (0 <= state.rowCount && state.rowCount <= 1) someRefreshInterval
+        else None // immediately if there might be more rows to fetch
+
+      // TODO we could have different delays here depending on how many rows that were found.
+      // e.g. a short delay if rowCount is < some threshold
+
+      if (log.isDebugEnabled)
+        delay.foreach { d =>
+          log.debug(
+            "{} query [{}] from slices [{} - {}] delay next [{}] ms.",
+            logPrefix,
+            state.queryCount,
+            minSlice,
+            maxSlice,
+            d.toMillis)
+        }
+
+      delay
+    }
+
+    def nextQuery(state: QueryState): (QueryState, Option[Source[Envelope, NotUsed]]) = {
+      val newIdleCount = if (state.rowCount == 0) state.idleCount + 1 else 0
+      val newState =
+        if (settings.querySettings.backtrackingEnabled && !state.backtracking &&
+          (newIdleCount >= 5 || JDuration
+            .between(state.latestBacktracking.timestamp, state.latest.timestamp)
+            .compareTo(halfBacktrackingWindow) > 0)) {
+          // FIXME config for newIdleCount >= 5 and maybe something like `newIdleCount % 5 == 0`
+
+          // switching to backtracking
+          val fromOffset =
+            if (state.latestBacktracking == TimestampOffset.Zero && initialOffset == TimestampOffset.Zero)
+              TimestampOffset.Zero
+            else if (state.latestBacktracking == TimestampOffset.Zero)
+              TimestampOffset.Zero.copy(timestamp = initialOffset.timestamp.minus(firstBacktrackingQueryWindow))
+            else
+              state.latestBacktracking
+
+          // FIXME the backtracking until offset is state.latest (not equal), but we should probably have an
+          // additional lag to support async (at-least-once) projections without too many duplicates from
+          // backtracking. For exactly-once I think all duplicates are filtered as expected.
+
+          state.copy(
+            rowCount = 0,
+            queryCount = state.queryCount + 1,
+            idleCount = newIdleCount,
+            backtracking = true,
+            latestBacktracking = fromOffset)
+        } else if (state.backtracking && state.rowCount < settings.querySettings.bufferSize - 1) {
+          // switch from backtracking
+          state.copy(rowCount = 0, queryCount = state.queryCount + 1, idleCount = newIdleCount, backtracking = false)
+        } else {
+          state.copy(rowCount = 0, queryCount = state.queryCount + 1, idleCount = newIdleCount)
+        }
+
+      // FIXME for backtracking we could consider to use behind latest offset instead of behind current db time
+      val behindCurrentTime =
+        if (newState.backtracking) settings.querySettings.backtrackingBehindCurrentTime
+        else settings.querySettings.behindCurrentTime
+
+      if (log.isDebugEnabled())
+        log.debug(
+          "{} query [{}]{} from slices [{} - {}], from time [{}]. {}",
+          logPrefix,
+          newState.queryCount,
+          if (newState.backtracking) " in backtracking mode" else "",
+          minSlice,
+          maxSlice,
+          newState.nextQueryFromTimestamp,
+          if (newIdleCount >= 3) s"Idle in [$newIdleCount] queries."
+          else if (state.backtracking) s"Found [${state.rowCount}] rows in previous backtracking query."
+          else s"Found [${state.rowCount}] rows in previous query.")
+
+      newState ->
+      Some(
+        dao
+          .rowsBySlices(
+            entityTypeHint,
+            minSlice,
+            maxSlice,
+            newState.nextQueryFromTimestamp,
+            newState.nextQueryUntilTimestamp,
+            behindCurrentTime)
+          .via(deserializeAndAddOffset(newState.currentOffset)))
+    }
+
+    ContinuousQuery[QueryState, Envelope](
+      initialState = QueryState.empty.copy(latest = initialOffset),
+      updateState = nextOffset,
+      delayNextQuery = delayNextQuery,
+      nextQuery = nextQuery)
   }
 
   // TODO Unit test in isolation

--- a/core/src/main/scala/akka/persistence/r2dbc/journal/JournalDao.scala
+++ b/core/src/main/scala/akka/persistence/r2dbc/journal/JournalDao.scala
@@ -14,6 +14,7 @@ import akka.actor.typed.ActorSystem
 import akka.annotation.InternalApi
 import akka.persistence.PersistentRepr
 import akka.persistence.r2dbc.R2dbcSettings
+import akka.persistence.r2dbc.internal.BySliceQuery
 import akka.persistence.r2dbc.internal.R2dbcExecutor
 import akka.persistence.r2dbc.internal.SliceUtils
 import akka.serialization.Serialization
@@ -42,6 +43,7 @@ private[r2dbc] object JournalDao {
       timestamp: Long,
       tags: Set[String],
       metadata: Option[SerializedEventMetadata])
+      extends BySliceQuery.SerializedRow
 
   final case class SerializedEventMetadata(serId: Int, serManifest: String, payload: Array[Byte])
 

--- a/core/src/main/scala/akka/persistence/r2dbc/query/scaladsl/QueryDao.scala
+++ b/core/src/main/scala/akka/persistence/r2dbc/query/scaladsl/QueryDao.scala
@@ -15,6 +15,7 @@ import akka.NotUsed
 import akka.actor.typed.ActorSystem
 import akka.annotation.InternalApi
 import akka.persistence.r2dbc.R2dbcSettings
+import akka.persistence.r2dbc.internal.BySliceQuery
 import akka.persistence.r2dbc.internal.R2dbcExecutor
 import akka.persistence.r2dbc.journal.JournalDao.SerializedJournalRow
 import akka.stream.scaladsl.Source
@@ -32,7 +33,8 @@ object QueryDao {
 @InternalApi
 private[r2dbc] class QueryDao(settings: R2dbcSettings, connectionFactory: ConnectionFactory)(implicit
     ec: ExecutionContext,
-    system: ActorSystem[_]) {
+    system: ActorSystem[_])
+    extends BySliceQuery.Dao[SerializedJournalRow] {
   import QueryDao.log
 
   private val journalTable = settings.journalTableWithSchema

--- a/core/src/main/scala/akka/persistence/r2dbc/query/scaladsl/QueryDao.scala
+++ b/core/src/main/scala/akka/persistence/r2dbc/query/scaladsl/QueryDao.scala
@@ -79,7 +79,7 @@ private[r2dbc] class QueryDao(settings: R2dbcSettings, connectionFactory: Connec
       }
   }
 
-  def eventsBySlices(
+  def rowsBySlices(
       entityTypeHint: String,
       minSlice: Int,
       maxSlice: Int,

--- a/core/src/main/scala/akka/persistence/r2dbc/query/scaladsl/R2dbcReadJournal.scala
+++ b/core/src/main/scala/akka/persistence/r2dbc/query/scaladsl/R2dbcReadJournal.scala
@@ -4,17 +4,10 @@
 
 package akka.persistence.r2dbc.query.scaladsl
 
-import java.time.Instant
-import java.time.{ Duration => JDuration }
-
 import scala.collection.immutable
-import scala.concurrent.ExecutionContext
-import scala.concurrent.duration.Duration
-import scala.concurrent.duration.FiniteDuration
 
 import akka.NotUsed
 import akka.actor.ExtendedActorSystem
-import akka.actor.typed.scaladsl.LoggerOps
 import akka.actor.typed.scaladsl.adapter._
 import akka.persistence.query.EventEnvelope
 import akka.persistence.query.Offset
@@ -22,54 +15,22 @@ import akka.persistence.query.scaladsl._
 import akka.persistence.r2dbc.ConnectionFactoryProvider
 import akka.persistence.r2dbc.R2dbcSettings
 import akka.persistence.r2dbc.internal.BySliceQuery
-import akka.persistence.r2dbc.internal.ContinuousQuery
 import akka.persistence.r2dbc.internal.SliceUtils
 import akka.persistence.r2dbc.journal.JournalDao.SerializedJournalRow
 import akka.persistence.r2dbc.query.TimestampOffset
 import akka.serialization.SerializationExtension
-import akka.stream.scaladsl.Flow
 import akka.stream.scaladsl.Source
 import com.typesafe.config.Config
 import org.slf4j.LoggerFactory
 
 object R2dbcReadJournal {
   val Identifier = "akka.persistence.r2dbc.query"
-
-  private object EventsBySlicesState {
-    val empty: EventsBySlicesState =
-      EventsBySlicesState(TimestampOffset.Zero, 0, 0, 0, backtracking = false, TimestampOffset.Zero)
-  }
-
-  private final case class EventsBySlicesState(
-      latest: TimestampOffset,
-      rowCount: Int,
-      queryCount: Long,
-      idleCount: Long,
-      backtracking: Boolean,
-      latestBacktracking: TimestampOffset) {
-
-    def currentOffset: TimestampOffset =
-      if (backtracking) latestBacktracking
-      else latest
-
-    def nextQueryFromTimestamp: Instant =
-      if (backtracking) latestBacktracking.timestamp
-      else latest.timestamp
-
-    def nextQueryUntilTimestamp: Option[Instant] =
-      if (backtracking) Some(latest.timestamp)
-      else None
-  }
-
 }
 
 final class R2dbcReadJournal(system: ExtendedActorSystem, config: Config, cfgPath: String)
     extends ReadJournal
     with CurrentEventsBySliceQuery
     with EventsBySliceQuery {
-
-  import R2dbcReadJournal.EventsBySlicesState
-  import TimestampOffset.toTimestampOffset
 
   private val log = LoggerFactory.getLogger(getClass)
   private val sharedConfigPath = cfgPath.replaceAll("""\.query$""", "")
@@ -84,11 +45,6 @@ final class R2dbcReadJournal(system: ExtendedActorSystem, config: Config, cfgPat
       settings,
       ConnectionFactoryProvider(typedSystem)
         .connectionFactoryFor(sharedConfigPath + ".connection-factory"))(typedSystem.executionContext, typedSystem)
-
-  private val backtrackingWindow = JDuration.ofMillis(settings.querySettings.backtrackingWindow.toMillis)
-  private val halfBacktrackingWindow = backtrackingWindow.dividedBy(2)
-  private val firstBacktrackingQueryWindow =
-    backtrackingWindow.plus(JDuration.ofMillis(settings.querySettings.backtrackingBehindCurrentTime.toMillis))
 
   private val bySlice: BySliceQuery[SerializedJournalRow, EventEnvelope] = {
     val createEnvelope: (TimestampOffset, SerializedJournalRow) => EventEnvelope = (offset, row) => {
@@ -128,169 +84,6 @@ final class R2dbcReadJournal(system: ExtendedActorSystem, config: Config, cfgPat
       entityTypeHint: String,
       minSlice: Int,
       maxSlice: Int,
-      offset: Offset): Source[EventEnvelope, NotUsed] = {
-    val initialOffset = toTimestampOffset(offset)
-    val someRefreshInterval = Some(settings.querySettings.refreshInterval)
-
-    if (log.isDebugEnabled())
-      log.debugN(
-        "Starting eventsBySlices query from slices [{} - {}], from time [{}].",
-        minSlice,
-        maxSlice,
-        initialOffset.timestamp)
-
-    def nextOffset(state: EventsBySlicesState, eventEnvelope: EventEnvelope): EventsBySlicesState = {
-      if (state.backtracking) {
-        val offset = eventEnvelope.offset.asInstanceOf[TimestampOffset]
-        if (offset.timestamp.isBefore(state.latestBacktracking.timestamp))
-          throw new IllegalArgumentException(
-            s"Unexpected offset [$offset] before latestBacktracking [${state.latestBacktracking}].")
-
-        state.copy(latestBacktracking = offset, rowCount = state.rowCount + 1)
-      } else {
-        val offset = eventEnvelope.offset.asInstanceOf[TimestampOffset]
-        if (offset.timestamp.isBefore(state.latest.timestamp))
-          throw new IllegalArgumentException(s"Unexpected offset [$offset] before latest [${state.latest}].")
-
-        state.copy(latest = offset, rowCount = state.rowCount + 1)
-      }
-    }
-
-    def delayNextQuery(state: EventsBySlicesState): Option[FiniteDuration] = {
-      // FIXME verify that this is correct
-      // the same row comes back and is filtered due to how the offset works
-      val delay =
-        if (0 <= state.rowCount && state.rowCount <= 1) someRefreshInterval
-        else None // immediately if there might be more rows to fetch
-
-      // TODO we could have different delays here depending on how many rows that were found.
-      // e.g. a short delay if rowCount is < some threshold
-
-      if (log.isDebugEnabled)
-        delay.foreach { d =>
-          log.debug(
-            "eventsBySlices query [{}] from slices [{} - {}] delay next [{}] ms.",
-            state.queryCount,
-            minSlice,
-            maxSlice,
-            d.toMillis)
-        }
-
-      delay
-    }
-
-    def nextQuery(state: EventsBySlicesState): (EventsBySlicesState, Option[Source[EventEnvelope, NotUsed]]) = {
-      val newIdleCount = if (state.rowCount == 0) state.idleCount + 1 else 0
-      val newState =
-        if (settings.querySettings.backtrackingEnabled && !state.backtracking &&
-          (newIdleCount >= 5 || JDuration
-            .between(state.latestBacktracking.timestamp, state.latest.timestamp)
-            .compareTo(halfBacktrackingWindow) > 0)) {
-          // FIXME config for newIdleCount >= 5 and maybe something like `newIdleCount % 5 == 0`
-
-          // switching to backtracking
-          val fromOffset =
-            if (state.latestBacktracking == TimestampOffset.Zero && initialOffset == TimestampOffset.Zero)
-              TimestampOffset.Zero
-            else if (state.latestBacktracking == TimestampOffset.Zero)
-              TimestampOffset.Zero.copy(timestamp = initialOffset.timestamp.minus(firstBacktrackingQueryWindow))
-            else
-              state.latestBacktracking
-
-          // FIXME the backtracking until offset is state.latest (not equal), but we should probably have an
-          // additional lag to support async (at-least-once) projections without too many duplicates from
-          // backtracking. For exactly-once I think all duplicates are filtered as expected.
-
-          state.copy(
-            rowCount = 0,
-            queryCount = state.queryCount + 1,
-            idleCount = newIdleCount,
-            backtracking = true,
-            latestBacktracking = fromOffset)
-        } else if (state.backtracking && state.rowCount < settings.querySettings.bufferSize - 1) {
-          // switch from backtracking
-          state.copy(rowCount = 0, queryCount = state.queryCount + 1, idleCount = newIdleCount, backtracking = false)
-        } else {
-          state.copy(rowCount = 0, queryCount = state.queryCount + 1, idleCount = newIdleCount)
-        }
-
-      // FIXME for backtracking we could consider to use behind latest offset instead of behind current db time
-      val behindCurrentTime =
-        if (newState.backtracking) settings.querySettings.backtrackingBehindCurrentTime
-        else settings.querySettings.behindCurrentTime
-
-      if (log.isDebugEnabled())
-        log.debugN(
-          "eventsBySlices query [{}]{} from slices [{} - {}], from time [{}]. {}",
-          newState.queryCount,
-          if (newState.backtracking) " in backtracking mode" else "",
-          minSlice,
-          maxSlice,
-          newState.nextQueryFromTimestamp,
-          if (newIdleCount >= 3) s"Idle in [$newIdleCount] queries."
-          else if (state.backtracking) s"Found [${state.rowCount}] rows in previous backtracking query."
-          else s"Found [${state.rowCount}] rows in previous query.")
-
-      newState ->
-      Some(
-        queryDao
-          .eventsBySlices(
-            entityTypeHint,
-            minSlice,
-            maxSlice,
-            newState.nextQueryFromTimestamp,
-            newState.nextQueryUntilTimestamp,
-            behindCurrentTime)
-          .via(deserializeAndAddOffset(newState.currentOffset)))
-    }
-
-    ContinuousQuery[EventsBySlicesState, EventEnvelope](
-      initialState = EventsBySlicesState.empty.copy(latest = initialOffset),
-      updateState = nextOffset,
-      delayNextQuery = delayNextQuery,
-      nextQuery = nextQuery)
-  }
-
-  // TODO Unit test in isolation
-  private def deserializeAndAddOffset(
-      timestampOffset: TimestampOffset): Flow[SerializedJournalRow, EventEnvelope, NotUsed] = {
-    Flow[SerializedJournalRow].statefulMapConcat { () =>
-      var currentTimestamp = timestampOffset.timestamp
-      var currentSequenceNrs: Map[String, Long] = timestampOffset.seen
-      row => {
-        def toEnvelope(offset: TimestampOffset): EventEnvelope = {
-          val payload = serialization.deserialize(row.payload, row.serId, row.serManifest).get
-          val envelope = EventEnvelope(offset, row.persistenceId, row.sequenceNr, payload, row.timestamp)
-          row.metadata match {
-            case None => envelope
-            case Some(meta) =>
-              envelope.withMetadata(serialization.deserialize(meta.payload, meta.serId, meta.serManifest).get)
-          }
-        }
-
-        if (row.dbTimestamp == currentTimestamp) {
-          // has this already been seen?
-          if (currentSequenceNrs.get(row.persistenceId).exists(_ >= row.sequenceNr)) {
-            log.debugN(
-              "filtering [{}] [{}] as db timestamp is the same as last offset and is in seen [{}]",
-              row.persistenceId,
-              row.sequenceNr,
-              currentSequenceNrs)
-            Nil
-          } else {
-            currentSequenceNrs = currentSequenceNrs.updated(row.persistenceId, row.sequenceNr)
-            val offset =
-              TimestampOffset(row.dbTimestamp, row.readDbTimestamp, currentSequenceNrs)
-            toEnvelope(offset) :: Nil
-          }
-        } else {
-          // ne timestamp, reset currentSequenceNrs
-          currentTimestamp = row.dbTimestamp
-          currentSequenceNrs = Map(row.persistenceId -> row.sequenceNr)
-          val offset = TimestampOffset(row.dbTimestamp, row.readDbTimestamp, currentSequenceNrs)
-          toEnvelope(offset) :: Nil
-        }
-      }
-    }
-  }
+      offset: Offset): Source[EventEnvelope, NotUsed] =
+    bySlice.liveBySlices("eventsBySlices", entityTypeHint, minSlice, maxSlice, offset)
 }

--- a/core/src/main/scala/akka/persistence/r2dbc/state/scaladsl/R2dbcDurableStateStore.scala
+++ b/core/src/main/scala/akka/persistence/r2dbc/state/scaladsl/R2dbcDurableStateStore.scala
@@ -4,14 +4,9 @@
 
 package akka.persistence.r2dbc.state.scaladsl
 
-import java.time.Instant
-import java.time.{ Duration => JDuration }
-
 import scala.collection.immutable
 import scala.concurrent.ExecutionContext
 import scala.concurrent.Future
-import scala.concurrent.duration.Duration
-import scala.concurrent.duration.FiniteDuration
 
 import akka.Done
 import akka.NotUsed
@@ -23,7 +18,7 @@ import akka.persistence.query.UpdatedDurableState
 import akka.persistence.query.scaladsl.DurableStateStoreBySliceQuery
 import akka.persistence.r2dbc.ConnectionFactoryProvider
 import akka.persistence.r2dbc.R2dbcSettings
-import akka.persistence.r2dbc.internal.ContinuousQuery
+import akka.persistence.r2dbc.internal.BySliceQuery
 import akka.persistence.r2dbc.internal.SliceUtils
 import akka.persistence.r2dbc.query.TimestampOffset
 import akka.persistence.r2dbc.state.scaladsl.DurableStateDao.SerializedStateRow
@@ -31,46 +26,17 @@ import akka.persistence.state.scaladsl.DurableStateUpdateStore
 import akka.persistence.state.scaladsl.GetObjectResult
 import akka.serialization.SerializationExtension
 import akka.serialization.Serializers
-import akka.stream.scaladsl.Flow
 import akka.stream.scaladsl.Source
 import com.typesafe.config.Config
 import org.slf4j.LoggerFactory
 
 object R2dbcDurableStateStore {
   val Identifier = "akka.persistence.r2dbc.state"
-
-  private object ChangesBySlicesState {
-    val empty: ChangesBySlicesState =
-      ChangesBySlicesState(TimestampOffset.Zero, 0, 0, 0, backtracking = false, TimestampOffset.Zero)
-  }
-
-  private final case class ChangesBySlicesState(
-      latest: TimestampOffset,
-      rowCount: Int,
-      queryCount: Long,
-      idleCount: Long,
-      backtracking: Boolean,
-      latestBacktracking: TimestampOffset) {
-
-    def currentOffset: TimestampOffset =
-      if (backtracking) latestBacktracking
-      else latest
-
-    def nextQueryFromTimestamp: Instant =
-      if (backtracking) latestBacktracking.timestamp
-      else latest.timestamp
-
-    def nextQueryUntilTimestamp: Option[Instant] =
-      if (backtracking) Some(latest.timestamp)
-      else None
-  }
 }
 
 class R2dbcDurableStateStore[A](system: ExtendedActorSystem, config: Config, cfgPath: String)
     extends DurableStateUpdateStore[A]
     with DurableStateStoreBySliceQuery[A] {
-  import R2dbcDurableStateStore.ChangesBySlicesState
-  import TimestampOffset.toTimestampOffset
 
   private val log = LoggerFactory.getLogger(getClass)
   private val sharedConfigPath = cfgPath.replaceAll("""\.state$""", "")
@@ -86,10 +52,16 @@ class R2dbcDurableStateStore[A](system: ExtendedActorSystem, config: Config, cfg
       typedSystem.executionContext,
       typedSystem)
 
-  private val backtrackingWindow = JDuration.ofMillis(settings.querySettings.backtrackingWindow.toMillis)
-  private val halfBacktrackingWindow = backtrackingWindow.dividedBy(2)
-  private val firstBacktrackingQueryWindow =
-    backtrackingWindow.plus(JDuration.ofMillis(settings.querySettings.backtrackingBehindCurrentTime.toMillis))
+  private val bySlice: BySliceQuery[SerializedStateRow, DurableStateChange[A]] = {
+    val createEnvelope: (TimestampOffset, SerializedStateRow) => DurableStateChange[A] = (offset, row) => {
+      val payload = serialization.deserialize(row.payload, row.serId, row.serManifest).get.asInstanceOf[A]
+      new UpdatedDurableState(row.persistenceId, row.revision, payload, offset, row.timestamp)
+    }
+
+    val extractOffset: DurableStateChange[A] => TimestampOffset = env => env.offset.asInstanceOf[TimestampOffset]
+
+    new BySliceQuery(stateDao, createEnvelope, extractOffset, settings, log)(typedSystem.executionContext)
+  }
 
   override def getObject(persistenceId: String): Future[GetObjectResult[A]] = {
     implicit val ec: ExecutionContext = system.dispatcher
@@ -138,237 +110,14 @@ class R2dbcDurableStateStore[A](system: ExtendedActorSystem, config: Config, cfg
       entityTypeHint: String,
       minSlice: Int,
       maxSlice: Int,
-      offset: Offset): Source[DurableStateChange[A], NotUsed] = {
-    val initialOffset = toTimestampOffset(offset)
-    implicit val ec: ExecutionContext = system.dispatcher
-
-    def nextOffset(state: ChangesBySlicesState, change: DurableStateChange[A]): ChangesBySlicesState = {
-      state.copy(latest = change.offset.asInstanceOf[TimestampOffset], rowCount = state.rowCount + 1)
-    }
-
-    def nextQuery(
-        state: ChangesBySlicesState,
-        toDbTimestamp: Instant): (ChangesBySlicesState, Option[Source[DurableStateChange[A], NotUsed]]) = {
-      if (state.queryCount == 0L || state.rowCount >= settings.querySettings.bufferSize - 1) {
-        val newState = state.copy(rowCount = 0, queryCount = state.queryCount + 1)
-
-        if (state.queryCount != 0 && log.isDebugEnabled())
-          log.debug(
-            "currentChangesBySlices query [{}] from slices [{} - {}], from time [{}] to now [{}]. Found [{}] rows in previous query.",
-            state.queryCount,
-            minSlice,
-            maxSlice,
-            state.latest.timestamp,
-            toDbTimestamp,
-            state.rowCount)
-
-        newState -> Some(
-          stateDao
-            .stateBySlices(
-              entityTypeHint,
-              minSlice,
-              maxSlice,
-              state.latest.timestamp,
-              untilTimestamp = Some(toDbTimestamp),
-              behindCurrentTime = Duration.Zero)
-            .via(deserializeAndAddOffset(state.latest)))
-      } else {
-        if (log.isDebugEnabled)
-          log.debug(
-            "currentChangesBySlices query [{}] from slices [{} - {}] completed. Found [{}] rows in previous query.",
-            state.queryCount,
-            minSlice,
-            maxSlice,
-            state.rowCount)
-
-        state -> None
-      }
-    }
-
-    Source
-      .futureSource[DurableStateChange[A], NotUsed] {
-        stateDao.currentDbTimestamp().map { currentDbTime =>
-          if (log.isDebugEnabled())
-            log.debug(
-              "currentChangesBySlices query slices [{} - {}], from time [{}] until now [{}].",
-              minSlice,
-              maxSlice,
-              initialOffset.timestamp,
-              currentDbTime)
-
-          ContinuousQuery[ChangesBySlicesState, DurableStateChange[A]](
-            initialState = ChangesBySlicesState.empty.copy(latest = initialOffset),
-            updateState = nextOffset,
-            delayNextQuery = _ => None,
-            nextQuery = state => nextQuery(state, currentDbTime))
-        }
-      }
-      .mapMaterializedValue(_ => NotUsed)
-  }
+      offset: Offset): Source[DurableStateChange[A], NotUsed] =
+    bySlice.currentBySlices("currentChangesBySlices", entityTypeHint, minSlice, maxSlice, offset)
 
   override def changesBySlices(
       entityTypeHint: String,
       minSlice: Int,
       maxSlice: Int,
-      offset: Offset): Source[DurableStateChange[A], NotUsed] = {
-    val initialOffset = toTimestampOffset(offset)
-    val someRefreshInterval = Some(settings.querySettings.refreshInterval)
-
-    if (log.isDebugEnabled())
-      log.debug(
-        "Starting changesBySlices query from slices [{} - {}], from time [{}].",
-        minSlice,
-        maxSlice,
-        initialOffset.timestamp)
-
-    def nextOffset(state: ChangesBySlicesState, change: DurableStateChange[A]): ChangesBySlicesState = {
-      if (state.backtracking) {
-        val offset = change.offset.asInstanceOf[TimestampOffset]
-        if (offset.timestamp.isBefore(state.latestBacktracking.timestamp))
-          throw new IllegalArgumentException(
-            s"Unexpected offset [$offset] before latestBacktracking [${state.latestBacktracking}].")
-
-        state.copy(latestBacktracking = offset, rowCount = state.rowCount + 1)
-      } else {
-        val offset = change.offset.asInstanceOf[TimestampOffset]
-        if (offset.timestamp.isBefore(state.latest.timestamp))
-          throw new IllegalArgumentException(s"Unexpected offset [$offset] before latest [${state.latest}].")
-
-        state.copy(latest = offset, rowCount = state.rowCount + 1)
-      }
-    }
-
-    def delayNextQuery(state: ChangesBySlicesState): Option[FiniteDuration] = {
-      // FIXME verify that this is correct
-      // the same row comes back and is filtered due to how the offset works
-      val delay =
-        if (0 <= state.rowCount && state.rowCount <= 1) someRefreshInterval
-        else None // immediately if there might be more rows to fetch
-
-      // TODO we could have different delays here depending on how many rows that were found.
-      // e.g. a short delay if rowCount is < some threshold
-
-      if (log.isDebugEnabled)
-        delay.foreach { d =>
-          log.debug(
-            "changesBySlices query [{}] from slices [{} - {}] delay next [{}] ms.",
-            state.queryCount,
-            minSlice,
-            maxSlice,
-            d.toMillis)
-        }
-
-      delay
-    }
-
-    def nextQuery(
-        state: ChangesBySlicesState): (ChangesBySlicesState, Option[Source[DurableStateChange[A], NotUsed]]) = {
-      val newIdleCount = if (state.rowCount == 0) state.idleCount + 1 else 0
-      val newState =
-        if (settings.querySettings.backtrackingEnabled && !state.backtracking &&
-          (newIdleCount >= 5 || JDuration
-            .between(state.latestBacktracking.timestamp, state.latest.timestamp)
-            .compareTo(halfBacktrackingWindow) > 0)) {
-          // FIXME config for newIdleCount >= 5 and maybe something like `newIdleCount % 5 == 0`
-
-          // switching to backtracking
-          val fromOffset =
-            if (state.latestBacktracking == TimestampOffset.Zero && initialOffset == TimestampOffset.Zero)
-              TimestampOffset.Zero
-            else if (state.latestBacktracking == TimestampOffset.Zero)
-              TimestampOffset.Zero.copy(timestamp = initialOffset.timestamp.minus(firstBacktrackingQueryWindow))
-            else
-              state.latestBacktracking
-
-          // FIXME the backtracking until offset is state.latest (not equal), but we should probably have an
-          // additional lag to support async (at-least-once) projections without too many duplicates from
-          // backtracking. For exactly-once I think all duplicates are filtered as expected.
-
-          state.copy(
-            rowCount = 0,
-            queryCount = state.queryCount + 1,
-            idleCount = newIdleCount,
-            backtracking = true,
-            latestBacktracking = fromOffset)
-        } else if (state.backtracking && state.rowCount < settings.querySettings.bufferSize - 1) {
-          // switch from backtracking
-          state.copy(rowCount = 0, queryCount = state.queryCount + 1, idleCount = newIdleCount, backtracking = false)
-        } else {
-          state.copy(rowCount = 0, queryCount = state.queryCount + 1, idleCount = newIdleCount)
-        }
-
-      // FIXME for backtracking we could consider to use behind latest offset instead of behind current db time
-      val behindCurrentTime =
-        if (newState.backtracking) settings.querySettings.backtrackingBehindCurrentTime
-        else settings.querySettings.behindCurrentTime
-
-      if (log.isDebugEnabled())
-        log.debug(
-          "changesBySlices query [{}]{} from slices [{} - {}], from time [{}]. {}",
-          newState.queryCount,
-          if (newState.backtracking) " in backtracking mode" else "",
-          minSlice,
-          maxSlice,
-          newState.nextQueryFromTimestamp,
-          if (newIdleCount >= 3) s"Idle in [$newIdleCount] queries."
-          else if (state.backtracking) s"Found [${state.rowCount}] rows in previous backtracking query."
-          else s"Found [${state.rowCount}] rows in previous query.")
-
-      newState ->
-      Some(
-        stateDao
-          .stateBySlices(
-            entityTypeHint,
-            minSlice,
-            maxSlice,
-            newState.nextQueryFromTimestamp,
-            newState.nextQueryUntilTimestamp,
-            behindCurrentTime)
-          .via(deserializeAndAddOffset(newState.currentOffset)))
-    }
-
-    ContinuousQuery[ChangesBySlicesState, DurableStateChange[A]](
-      initialState = ChangesBySlicesState.empty.copy(latest = initialOffset),
-      updateState = nextOffset,
-      delayNextQuery = delayNextQuery,
-      nextQuery = nextQuery)
-  }
-
-  private def deserializeAndAddOffset(
-      timestampOffset: TimestampOffset): Flow[SerializedStateRow, DurableStateChange[A], NotUsed] = {
-    Flow[SerializedStateRow].statefulMapConcat { () =>
-      var currentTimestamp = timestampOffset.timestamp
-      var currentSequenceNrs: Map[String, Long] = timestampOffset.seen
-      row => {
-        def toEnvelope(offset: TimestampOffset): DurableStateChange[A] = {
-          val payload = serialization.deserialize(row.payload, row.serId, row.serManifest).get.asInstanceOf[A]
-          new UpdatedDurableState[A](row.persistenceId, row.revision, payload, offset, row.timestamp)
-        }
-
-        if (row.dbTimestamp == currentTimestamp) {
-          // has this already been seen?
-          if (currentSequenceNrs.get(row.persistenceId).exists(_ >= row.revision)) {
-            log.debug(
-              "filtering [{}] [{}] as db timestamp is the same as last offset and is in seen [{}]",
-              row.persistenceId,
-              row.revision,
-              currentSequenceNrs)
-            Nil
-          } else {
-            currentSequenceNrs = currentSequenceNrs.updated(row.persistenceId, row.revision)
-            val offset =
-              TimestampOffset(row.dbTimestamp, row.readDbTimestamp, currentSequenceNrs)
-            toEnvelope(offset) :: Nil
-          }
-        } else {
-          // ne timestamp, reset currentSequenceNrs
-          currentTimestamp = row.dbTimestamp
-          currentSequenceNrs = Map(row.persistenceId -> row.revision)
-          val offset = TimestampOffset(row.dbTimestamp, row.readDbTimestamp, currentSequenceNrs)
-          toEnvelope(offset) :: Nil
-        }
-      }
-    }
-  }
+      offset: Offset): Source[DurableStateChange[A], NotUsed] =
+    bySlice.liveBySlices("changesBySlices", entityTypeHint, minSlice, maxSlice, offset)
 
 }

--- a/ddl-scripts/create_tables_yugabyte.sql
+++ b/ddl-scripts/create_tables_yugabyte.sql
@@ -38,7 +38,7 @@ CREATE TABLE IF NOT EXISTS durable_state (
   PRIMARY KEY((slice, entity_type_hint) HASH, persistence_id, revision ASC)
 );
 
-CREATE INDEX IF NOT EXISTS durable_state ON durable_state(entity_type_hint ASC, slice ASC, db_timestamp ASC);
+CREATE INDEX IF NOT EXISTS durable_state_slice_idx ON durable_state(entity_type_hint ASC, slice ASC, db_timestamp ASC);
 
 CREATE TABLE IF NOT EXISTS akka_projection_offset_store (
   projection_name VARCHAR(255) NOT NULL,


### PR DESCRIPTION
As can be seen in #97 the query logic for events and durable state are pretty much identical. This moves that to a common generic class.

I have only extracted one of four so far and would like feedback before completing.