### PR TITLE
Lookup timestamp of previous sequence number, #74

### DIFF
--- a/core/src/main/resources/reference.conf
+++ b/core/src/main/resources/reference.conf
@@ -36,9 +36,11 @@ akka.persistence.r2dbc {
 
     backtracking {
       enabled = on
-      window = 1 minute
+      # Backtracking queries will look back for this amount of time. It should
+      # not be larger than the akka.projection.r2dbc.offset-store.time-window.
+      window = 2 minutes
       # Backtracking queries read events up to this duration from the current database time.
-      behind-current-time = 3 seconds
+      behind-current-time = 10 seconds
     }
 
     # In-memory buffer holding events when reading from database.

--- a/core/src/main/scala/akka/persistence/query/scaladsl/EventTimestampQuery.scala
+++ b/core/src/main/scala/akka/persistence/query/scaladsl/EventTimestampQuery.scala
@@ -1,0 +1,22 @@
+/*
+ * Copyright (C) 2021 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.persistence.query.scaladsl
+
+import java.time.Instant
+
+import scala.concurrent.Future
+
+/**
+ * [[EventsBySliceQuery]] that is using a timestamp based offset should also implement this query.
+ */
+trait EventTimestampQuery {
+
+  def timestampOf(
+      entityTypeHint: String,
+      persistenceId: String,
+      slice: Int,
+      sequenceNumber: Long): Future[Option[Instant]]
+
+}

--- a/core/src/main/scala/akka/persistence/query/scaladsl/EventsBySliceQuery.scala
+++ b/core/src/main/scala/akka/persistence/query/scaladsl/EventsBySliceQuery.scala
@@ -15,6 +15,8 @@ import akka.stream.scaladsl.Source
 
 /**
  * A plugin may optionally support this query by implementing this trait.
+ *
+ * `EventsBySliceQuery` that is using a timestamp based offset should also implement [[EventTimestampQuery]].
  */
 trait EventsBySliceQuery extends ReadJournal {
 

--- a/core/src/main/scala/akka/persistence/r2dbc/query/scaladsl/R2dbcReadJournal.scala
+++ b/core/src/main/scala/akka/persistence/r2dbc/query/scaladsl/R2dbcReadJournal.scala
@@ -4,6 +4,8 @@
 
 package akka.persistence.r2dbc.query.scaladsl
 
+import java.time.Instant
+
 import scala.collection.immutable
 import scala.concurrent.Future
 import scala.concurrent.duration.FiniteDuration
@@ -39,6 +41,7 @@ final class R2dbcReadJournal(system: ExtendedActorSystem, config: Config, cfgPat
     extends ReadJournal
     with CurrentEventsBySliceQuery
     with EventsBySliceQuery
+    with EventTimestampQuery
     with CurrentEventsByPersistenceIdQuery
     with EventsByPersistenceIdQuery
     with CurrentPersistenceIdsQuery {
@@ -162,6 +165,13 @@ final class R2dbcReadJournal(system: ExtendedActorSystem, config: Config, cfgPat
       .map(deserializeRow)
       .mapMaterializedValue(_ => NotUsed)
   }
+
+  override def timestampOf(
+      entityTypeHint: String,
+      persistenceId: String,
+      slice: Int,
+      sequenceNumber: Long): Future[Option[Instant]] =
+    queryDao.timestampOfEvent(entityTypeHint, persistenceId, slice, sequenceNumber)
 
   override def eventsByPersistenceId(
       persistenceId: String,

--- a/projection/src/main/resources/reference.conf
+++ b/projection/src/main/resources/reference.conf
@@ -18,18 +18,17 @@ akka.projection.r2dbc {
     # the database table name for the projection manangement data
     management-table = "akka_projection_management"
 
+    # The offset store will keep track of persistence ids and sequence numbers
+    # within this time window from latest offset.
     time-window = 5 minutes
-    evict-interval = 10 seconds
-    delete-interval = 1 minute
 
-    # Sequence number 1 and numbers that are +1 of previously known are always accepted.
-    # Unknown persistence id is only accepted if the age of the TimestampOffset is greater
-    # than this property. Age is the readTimestamp - timestamp in TimestampOffset.
-    # The purpose is to not emit a later sequence number for a persistence id in case
-    # an earlier event was missed. The backtracking query will emit events again and
-    # those will pass this filter. In other words, new unknown sequence numbers will
-    # be delayed to ensure the ordering guarantee for a persistence id.
-    accept-new-sequence-number-after-age = 3 seconds
+    # Remove old entries outside the time-window from the offset store memory
+    # with this frequency.
+    evict-interval = 10 seconds
+
+    # Remove old entries outside the time-window from the offset store database
+    # with this frequency.
+    delete-interval = 1 minute
   }
 
   # By default it shares connection-factory with akka-persistence-r2dbc (write side),

--- a/projection/src/main/scala/akka/projection/eventsourced/scaladsl/EventSourcedProvider2.scala
+++ b/projection/src/main/scala/akka/projection/eventsourced/scaladsl/EventSourcedProvider2.scala
@@ -4,6 +4,8 @@
 
 package akka.projection.eventsourced.scaladsl
 
+import java.time.Instant
+
 import scala.collection.immutable
 import scala.concurrent.ExecutionContext
 import scala.concurrent.Future
@@ -14,6 +16,8 @@ import akka.annotation.ApiMayChange
 import akka.persistence.query.NoOffset
 import akka.persistence.query.Offset
 import akka.persistence.query.PersistenceQuery
+import akka.persistence.query.scaladsl.EventTimestampQuery
+import akka.persistence.query.scaladsl.EventTimestampQuery
 import akka.persistence.query.scaladsl.EventsBySliceQuery
 import akka.projection.eventsourced.EventEnvelope
 import akka.projection.scaladsl.SourceProvider
@@ -34,6 +38,11 @@ object EventSourcedProvider2 {
     val eventsBySlicesQuery =
       PersistenceQuery(system).readJournalFor[EventsBySliceQuery](readJournalPluginId)
 
+    if (!eventsBySlicesQuery.isInstanceOf[EventTimestampQuery])
+      throw new IllegalArgumentException(
+        s"[${eventsBySlicesQuery.getClass.getName}] with readJournalPluginId " +
+        s"[$readJournalPluginId] must implement [${classOf[EventTimestampQuery].getName}]")
+
     new EventsBySlicesSourceProvider(eventsBySlicesQuery, entityTypeHint, minSlice, maxSlice, system)
   }
 
@@ -52,7 +61,8 @@ object EventSourcedProvider2 {
       override val maxSlice: Int,
       system: ActorSystem[_])
       extends SourceProvider[Offset, EventEnvelope[Event]]
-      with TimestampOffsetBySlicesSourceProvider {
+      with TimestampOffsetBySlicesSourceProvider
+      with EventTimestampQuery {
     implicit val executionContext: ExecutionContext = system.executionContext
 
     override def source(offset: () => Future[Option[Offset]]): Future[Source[EventEnvelope[Event], NotUsed]] =
@@ -66,5 +76,19 @@ object EventSourcedProvider2 {
     override def extractOffset(envelope: EventEnvelope[Event]): Offset = envelope.offset
 
     override def extractCreationTime(envelope: EventEnvelope[Event]): Long = envelope.timestamp
+
+    override def timestampOf(
+        entityTypeHint: String,
+        persistenceId: String,
+        slice: Int,
+        sequenceNumber: Long): Future[Option[Instant]] =
+      eventsBySlicesQuery match {
+        case timestampQuery: EventTimestampQuery =>
+          timestampQuery.timestampOf(entityTypeHint, persistenceId, slice, sequenceNumber)
+        case _ =>
+          Future.failed(
+            new IllegalStateException(
+              s"[${eventsBySlicesQuery.getClass.getName}] must implement [${classOf[EventTimestampQuery].getName}]"))
+      }
   }
 }

--- a/projection/src/main/scala/akka/projection/r2dbc/R2dbcProjectionSettings.scala
+++ b/projection/src/main/scala/akka/projection/r2dbc/R2dbcProjectionSettings.scala
@@ -21,8 +21,7 @@ object R2dbcProjectionSettings {
       useConnectionFactory = config.getString("use-connection-factory"),
       timeWindow = config.getDuration("offset-store.time-window"),
       evictInterval = config.getDuration("offset-store.evict-interval"),
-      deleteInterval = config.getDuration("offset-store.delete-interval"),
-      acceptNewSequenceNumberAfterAge = config.getDuration("offset-store.accept-new-sequence-number-after-age"))
+      deleteInterval = config.getDuration("offset-store.delete-interval"))
   }
 
   def apply(system: ActorSystem[_]): R2dbcProjectionSettings =
@@ -38,8 +37,7 @@ final case class R2dbcProjectionSettings(
     useConnectionFactory: String,
     timeWindow: JDuration,
     evictInterval: JDuration,
-    deleteInterval: JDuration,
-    acceptNewSequenceNumberAfterAge: JDuration) {
+    deleteInterval: JDuration) {
   val offsetTableWithSchema: String = schema.map("." + _).getOrElse("") + offsetTable
   val timestampOffsetTableWithSchema: String = schema.map("." + _).getOrElse("") + timestampOffsetTable
   val managementTableWithSchema: String = schema.map("." + _).getOrElse("") + managementTable

--- a/projection/src/main/scala/akka/projection/r2dbc/scaladsl/R2dbcProjection.scala
+++ b/projection/src/main/scala/akka/projection/r2dbc/scaladsl/R2dbcProjection.scala
@@ -54,7 +54,7 @@ object R2dbcProjection {
     val offsetStore =
       R2dbcProjectionImpl.createOffsetStore(
         projectionId,
-        sourceProviderSliceRange(sourceProvider),
+        timestampOffsetBySlicesSourceProvider(sourceProvider),
         r2dbcSettings,
         connFactory)
     val r2dbcExecutor = new R2dbcExecutor(connFactory, R2dbcProjectionImpl.log)(system.executionContext, system)
@@ -103,7 +103,7 @@ object R2dbcProjection {
     val offsetStore =
       R2dbcProjectionImpl.createOffsetStore(
         projectionId,
-        sourceProviderSliceRange(sourceProvider),
+        timestampOffsetBySlicesSourceProvider(sourceProvider),
         r2dbcSettings,
         connFactory)
     val r2dbcExecutor = new R2dbcExecutor(connFactory, R2dbcProjectionImpl.log)(system.executionContext, system)
@@ -150,7 +150,7 @@ object R2dbcProjection {
     val offsetStore =
       R2dbcProjectionImpl.createOffsetStore(
         projectionId,
-        sourceProviderSliceRange(sourceProvider),
+        timestampOffsetBySlicesSourceProvider(sourceProvider),
         r2dbcSettings,
         connFactory)
 
@@ -190,7 +190,7 @@ object R2dbcProjection {
     val offsetStore =
       R2dbcProjectionImpl.createOffsetStore(
         projectionId,
-        sourceProviderSliceRange(sourceProvider),
+        timestampOffsetBySlicesSourceProvider(sourceProvider),
         r2dbcSettings,
         connFactory)
     val r2dbcExecutor = new R2dbcExecutor(connFactory, R2dbcProjectionImpl.log)(system.executionContext, system)
@@ -237,7 +237,7 @@ object R2dbcProjection {
     val offsetStore =
       R2dbcProjectionImpl.createOffsetStore(
         projectionId,
-        sourceProviderSliceRange(sourceProvider),
+        timestampOffsetBySlicesSourceProvider(sourceProvider),
         r2dbcSettings,
         connFactory)
 
@@ -291,7 +291,7 @@ object R2dbcProjection {
     val offsetStore =
       R2dbcProjectionImpl.createOffsetStore(
         projectionId,
-        sourceProviderSliceRange(sourceProvider),
+        timestampOffsetBySlicesSourceProvider(sourceProvider),
         r2dbcSettings,
         connFactory)
 
@@ -337,10 +337,11 @@ object R2dbcProjection {
     ConnectionFactoryProvider(system).connectionFactoryFor(r2dbcSettings.useConnectionFactory)
   }
 
-  private def sourceProviderSliceRange(sourceProvider: SourceProvider[_, _]): Option[Range] = {
+  private def timestampOffsetBySlicesSourceProvider(
+      sourceProvider: SourceProvider[_, _]): Option[TimestampOffsetBySlicesSourceProvider] = {
     sourceProvider match {
-      case s: TimestampOffsetBySlicesSourceProvider => Some(s.minSlice to s.maxSlice)
-      case _                                        => None // source provider is not using slices
+      case provider: TimestampOffsetBySlicesSourceProvider => Some(provider)
+      case _                                               => None // source provider is not using slices
     }
   }
 

--- a/projection/src/test/scala/akka/projection/r2dbc/R2dbcOffsetStoreSpec.scala
+++ b/projection/src/test/scala/akka/projection/r2dbc/R2dbcOffsetStoreSpec.scala
@@ -36,14 +36,7 @@ class R2dbcOffsetStoreSpec
   private val settings = R2dbcProjectionSettings(testKit.system)
 
   private def createOffsetStore(projectionId: ProjectionId) =
-    new R2dbcOffsetStore(
-      projectionId,
-      minSlice = 0,
-      maxSlice = R2dbcOffsetStore.MaxNumberOfSlices - 1,
-      system,
-      settings,
-      r2dbcExecutor,
-      clock)
+    new R2dbcOffsetStore(projectionId, None, system, settings, r2dbcExecutor, clock)
 
   private val table = settings.offsetTableWithSchema
 

--- a/projection/src/test/scala/akka/projection/r2dbc/R2dbcProjectionSpec.scala
+++ b/projection/src/test/scala/akka/projection/r2dbc/R2dbcProjectionSpec.scala
@@ -171,13 +171,7 @@ class R2dbcProjectionSpec
   private val logger = LoggerFactory.getLogger(getClass)
   private val settings = R2dbcProjectionSettings(testKit.system)
   private def createOffsetStore(projectionId: ProjectionId): R2dbcOffsetStore =
-    new R2dbcOffsetStore(
-      projectionId,
-      minSlice = 0,
-      maxSlice = R2dbcOffsetStore.MaxNumberOfSlices - 1,
-      system,
-      settings,
-      r2dbcExecutor)
+    new R2dbcOffsetStore(projectionId, None, system, settings, r2dbcExecutor)
   private val projectionTestKit = ProjectionTestKit(system)
 
   override protected def beforeAll(): Unit = {


### PR DESCRIPTION
This became rather invasive but I'm quite convinced that it's needed.

* When the offset store receives an unknown sequence number
  in `isAccepted` it will try to lookup the timestamp of the
  previous event. If that is older than then time window of
  the offset store it will be accepted, otherwise rejected.
* The reason for rejecting is that it previous event could
  be missing when reading from the tail based on the latest
  timestamp offset.
* Backtracking will pick up the missing event and fill the
  gap.
* This is better than the previous accept-new-sequence-number-after-age
  (3 seconds) because it will not introduce that delay for the
  "normal case" when a new event is emitted and previous event
  was older than the offset store time window.
* Also, previous solution had the the uncertainty about if
  3 seconds would be enough and backtracking.behind-current-time
  can now be increased without adding to the delay mentioned above.

Fixes #74