### PR TITLE
Migration of events and snapshots from any Akka Persistence plugin

### DIFF
--- a/core/src/test/scala/akka/persistence/r2dbc/TestConfig.scala
+++ b/core/src/test/scala/akka/persistence/r2dbc/TestConfig.scala
@@ -39,6 +39,7 @@ object TestConfig {
 
     // using load here so that connection-factory can be overridden
     ConfigFactory.load(dialectConfig.withFallback(ConfigFactory.parseString("""
+    akka.loglevel = DEBUG
     akka.persistence.journal.plugin = "akka.persistence.r2dbc.journal"
     akka.persistence.snapshot-store.plugin = "akka.persistence.r2dbc.snapshot"
     akka.persistence.state.plugin = "akka.persistence.r2dbc.state"

--- a/migration/src/main/resources/reference.conf
+++ b/migration/src/main/resources/reference.conf
@@ -1,0 +1,25 @@
+akka.persistence.r2dbc.migration {
+
+  # Akka Persistence plugin to migrate from.
+  # You must also define plugin specific configuration
+  # and application specific serializers for events and snapshots.
+  source {
+    journal-plugin-id = "jdbc-journal"
+    snapshot-plugin-id = "jdbc-snapshot-store"
+    query-plugin-id = "jdbc-read-journal"
+  }
+
+  # R2DBC Akka Persistence plugin to migrate to.
+  # You must also define akka-persistence-r2dbc specific configuration.
+  target {
+    # this must be a configuration path of akka-persistence-r2dbc
+    persistence-plugin-id = "akka.persistence.r2dbc"
+
+    # Events are stored in batches of this size.
+    batch = 10
+  }
+
+  # How many persistence ids to migrate concurrently.
+  parallelism = 10
+
+}

--- a/migration/src/main/resources/reference.conf
+++ b/migration/src/main/resources/reference.conf
@@ -4,9 +4,8 @@ akka.persistence.r2dbc.migration {
   # You must also define plugin specific configuration
   # and application specific serializers for events and snapshots.
   source {
-    journal-plugin-id = "jdbc-journal"
-    snapshot-plugin-id = "jdbc-snapshot-store"
     query-plugin-id = "jdbc-read-journal"
+    snapshot-plugin-id = "jdbc-snapshot-store"
   }
 
   # R2DBC Akka Persistence plugin to migrate to.

--- a/migration/src/main/scala/akka/persistence/r2dbc/migration/MigrationTool.scala
+++ b/migration/src/main/scala/akka/persistence/r2dbc/migration/MigrationTool.scala
@@ -1,0 +1,322 @@
+/*
+ * Copyright (C) 2021 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.persistence.r2dbc.migration
+
+import java.time.Instant
+
+import scala.concurrent.ExecutionContext
+import scala.concurrent.Future
+import scala.concurrent.duration._
+import scala.util.Failure
+import scala.util.Success
+import scala.util.Try
+
+import akka.Done
+import akka.actor.typed.ActorSystem
+import akka.actor.typed.Behavior
+import akka.actor.typed.scaladsl.Behaviors
+import akka.pattern.ask
+import akka.persistence.Persistence
+import akka.persistence.SelectedSnapshot
+import akka.persistence.SnapshotProtocol.LoadSnapshot
+import akka.persistence.SnapshotProtocol.LoadSnapshotResult
+import akka.persistence.SnapshotSelectionCriteria
+import akka.persistence.query.EventEnvelope
+import akka.persistence.query.PersistenceQuery
+import akka.persistence.query.scaladsl.CurrentEventsByPersistenceIdQuery
+import akka.persistence.query.scaladsl.CurrentPersistenceIdsQuery
+import akka.persistence.query.scaladsl.ReadJournal
+import akka.persistence.r2dbc.ConnectionFactoryProvider
+import akka.persistence.r2dbc.R2dbcSettings
+import akka.persistence.r2dbc.journal.JournalDao
+import akka.persistence.r2dbc.journal.JournalDao.SerializedEventMetadata
+import akka.persistence.r2dbc.journal.JournalDao.SerializedJournalRow
+import akka.persistence.r2dbc.migration.MigrationToolDao.CurrentProgress
+import akka.persistence.r2dbc.snapshot.SnapshotDao
+import akka.persistence.r2dbc.snapshot.SnapshotDao.SerializedSnapshotMetadata
+import akka.persistence.r2dbc.snapshot.SnapshotDao.SerializedSnapshotRow
+import akka.serialization.Serialization
+import akka.serialization.SerializationExtension
+import akka.serialization.Serializers
+import akka.stream.scaladsl.Sink
+import akka.util.Timeout
+import io.r2dbc.spi.R2dbcDataIntegrityViolationException
+import org.slf4j.LoggerFactory
+
+object MigrationTool {
+  def main(args: Array[String]): Unit = {
+    ActorSystem(MigrationTool(), "MigrationTool")
+  }
+
+  object Result {
+    val empty: Result = Result(0, 0, 0)
+  }
+
+  final case class Result(persistenceIds: Long, events: Long, snapshots: Long)
+
+  private def apply(): Behavior[Try[Result]] = {
+    Behaviors.setup { context =>
+      val migration = new MigrationTool(context.system)
+      context.pipeToSelf(migration.migrateAll()) { result =>
+        result
+      }
+
+      Behaviors.receiveMessage {
+        case Success(_) =>
+          // result already logged by migrateAll
+          Behaviors.stopped
+        case Failure(_) =>
+          Behaviors.stopped
+      }
+    }
+  }
+
+}
+
+/**
+ * Migration from another Akka Persistence plugin to the R2DBC plugin. Converts events and snapshots. It has been tested
+ * with `akka-persistence-jdbc` as source plugin, but it should work with any plugin that has support for
+ * `CurrentPersistenceIdsQuery` and `CurrentEventsByPersistenceIdQuery`.
+ *
+ * It can be run as a main class `akka.persistence.r2dbc.migration.MigrationTool` with configuration in
+ * `application.conf` or embedded in an application by creating an instance of `MigrationTool` and invoking
+ * `migrateAll`.
+ *
+ * It can be run while the source system is still active and it can be run multiple times with idempotent result. To
+ * speed up processing of subsequent runs it stores migrated persistence ids and sequence numbers in the table
+ * `migration_progress`. In a subsequent run it will only migrate new events and snapshots compared to what was stored
+ * in `migration_progress`. It will also find and migrate new persistence ids in a subsequent run. You can delete from
+ * `migration_progress` if you want to re-run the full migration.
+ */
+class MigrationTool(system: ActorSystem[_]) {
+  import MigrationTool.Result
+  import system.executionContext
+  private implicit val sys: ActorSystem[_] = system
+
+  private val log = LoggerFactory.getLogger(getClass)
+
+  private val migrationConfig = system.settings.config.getConfig("akka.persistence.r2dbc.migration")
+
+  private val parallelism = migrationConfig.getInt("parallelism")
+
+  private val targetPluginId = migrationConfig.getString("target.persistence-plugin-id")
+  private val targetR2dbcSettings = new R2dbcSettings(system.settings.config.getConfig(targetPluginId))
+
+  private val serialization: Serialization = SerializationExtension(system)
+
+  private val targetConnectionFactory = ConnectionFactoryProvider(system)
+    .connectionFactoryFor(targetPluginId + ".connection-factory")
+  private val targetJournalDao =
+    new JournalDao(targetR2dbcSettings, targetConnectionFactory)
+  private val targetSnapshotDao =
+    new SnapshotDao(targetR2dbcSettings, targetConnectionFactory)
+
+  private val targetBatch = migrationConfig.getInt("target.batch")
+
+  private val sourceQueryPluginId = migrationConfig.getString("source.query-plugin-id")
+  private val sourceReadJournal = PersistenceQuery(system).readJournalFor[ReadJournal](sourceQueryPluginId)
+  private val sourcePersistenceIdsQuery = sourceReadJournal.asInstanceOf[CurrentPersistenceIdsQuery]
+  private val sourceEventsByPersistenceIdQuery = sourceReadJournal.asInstanceOf[CurrentEventsByPersistenceIdQuery]
+
+  private val sourceSnapshotPluginId = migrationConfig.getString("source.snapshot-plugin-id")
+  private lazy val sourceSnapshotStore = Persistence(system).snapshotStoreFor(sourceSnapshotPluginId)
+
+  private[r2dbc] val migrationDao = new MigrationToolDao(targetConnectionFactory)
+
+  private lazy val createProgressTable: Future[Done] =
+    migrationDao.createProgressTable()
+
+  /**
+   * Migrates events and snapshots for all persistence ids.
+   * @return
+   */
+  def migrateAll(): Future[Result] = {
+    log.info("Migration started.")
+    val result =
+      sourcePersistenceIdsQuery
+        .currentPersistenceIds()
+        .mapAsyncUnordered(parallelism) { persistenceId =>
+          for {
+            _ <- createProgressTable
+            currentProgress <- migrationDao.currentProgress(persistenceId)
+            eventCount <- migrateEvents(persistenceId, currentProgress)
+            snapshotCount <- migrateSnapshot(persistenceId, currentProgress)
+          } yield persistenceId -> Result(1, eventCount, snapshotCount)
+        }
+        .map { case (pid, result @ Result(_, events, snapshots)) =>
+          log.debug(
+            "Migrated persistenceId [{}] with [{}] events{}.",
+            pid,
+            events,
+            if (snapshots == 0) "" else " and snapshot")
+          result
+        }
+        .runWith(Sink.fold(Result.empty) { case (acc, Result(_, events, snapshots)) =>
+          val result = Result(acc.persistenceIds + 1, acc.events + events, acc.snapshots + snapshots)
+          if (result.persistenceIds % 100 == 0)
+            log.info(
+              "Migrated [{}] persistenceIds with [{}] events and [{}] snapshots.",
+              result.persistenceIds,
+              result.events,
+              result.snapshots)
+          result
+        })
+
+    result.transform {
+      case s @ Success(Result(persistenceIds, events, snapshots)) =>
+        log.info(
+          "Migration successful. Migrated [{}] persistenceIds with [{}] events and [{}] snapshots.",
+          persistenceIds,
+          events,
+          snapshots)
+        s
+      case f @ Failure(exc) =>
+        log.error("Migration failed.", exc)
+        f
+    }
+  }
+
+  /**
+   * Migrate events for a single persistence id.
+   */
+  def migrateEvents(persistenceId: String): Future[Long] = {
+    for {
+      _ <- createProgressTable
+      currentProgress <- migrationDao.currentProgress(persistenceId)
+      eventCount <- migrateEvents(persistenceId, currentProgress)
+    } yield eventCount
+  }
+
+  private def migrateEvents(persistenceId: String, currentProgress: Option[CurrentProgress]): Future[Long] = {
+    val progressSeqNr = currentProgress.map(_.eventSeqNr).getOrElse(0L)
+    sourceEventsByPersistenceIdQuery
+      .currentEventsByPersistenceId(persistenceId, progressSeqNr + 1, Long.MaxValue)
+      .map(serializedJournalRow)
+      .grouped(targetBatch)
+      .mapAsync(1) { events =>
+        targetJournalDao
+          .writeEvents(events)
+          .recoverWith { case _: R2dbcDataIntegrityViolationException =>
+            // events already exists, which is ok, but since the batch
+            // failed we must try again one-by-one
+            Future.sequence(events.map { event =>
+              targetJournalDao
+                .writeEvents(List(event))
+                .recoverWith { case _: R2dbcDataIntegrityViolationException =>
+                  // ok, already exists
+                  log
+                    .debug(
+                      "event already exists, persistenceId [{}], seqNr [{}]",
+                      event.persistenceId,
+                      event.sequenceNr)
+                  Future.successful(())
+                }
+            })
+          }
+          .map(_ => events.last.sequenceNr -> events.size)
+      }
+      .mapAsync(1) { case (seqNr, count) =>
+        migrationDao
+          .updateEventProgress(persistenceId, seqNr)
+          .map(_ => count)
+      }
+      .runWith(Sink.fold(0L) { case (acc, count) => acc + count })
+  }
+
+  private def serializedJournalRow(env: EventEnvelope): SerializedJournalRow = {
+    val event = env.event.asInstanceOf[AnyRef]
+    val serialized = serialization.serialize(event).get
+    val serializer = serialization.findSerializerFor(event)
+    val manifest = Serializers.manifestFor(serializer, event)
+
+    val metadata =
+      env.eventMetadata.map { meta =>
+        val m = meta.asInstanceOf[AnyRef]
+        val serializedMeta = serialization.serialize(m).get
+        val metaSerializer = serialization.findSerializerFor(m)
+        val metaManifest = Serializers.manifestFor(metaSerializer, m)
+        SerializedEventMetadata(metaSerializer.identifier, metaManifest, serializedMeta)
+      }
+
+    SerializedJournalRow(
+      env.persistenceId,
+      env.sequenceNr,
+      Instant.ofEpochMilli(env.timestamp),
+      JournalDao.EmptyDbTimestamp,
+      serialized,
+      serializer.identifier,
+      manifest,
+      "",
+      metadata)
+  }
+
+  /**
+   * Migrate latest snapshot for a single persistence id.
+   */
+  def migrateSnapshot(persistenceId: String): Future[Int] = {
+    for {
+      _ <- createProgressTable
+      currentProgress <- migrationDao.currentProgress(persistenceId)
+      snapCount <- migrateSnapshot(persistenceId, currentProgress)
+    } yield snapCount
+  }
+
+  private def migrateSnapshot(persistenceId: String, currentProgress: Option[CurrentProgress]): Future[Int] = {
+    val progressSeqNr = currentProgress.map(_.snapshotSeqNr).getOrElse(0L)
+    loadSourceSnapshot(persistenceId, progressSeqNr + 1).flatMap {
+      case None => Future.successful(0)
+      case Some(selectedSnapshot @ SelectedSnapshot(snapshotMetadata, _)) =>
+        for {
+          seqNr <- {
+            val serializedRow = serializedSnapotRow(selectedSnapshot)
+            targetSnapshotDao
+              .store(serializedRow)
+              .map(_ => snapshotMetadata.sequenceNr)(ExecutionContext.parasitic)
+          }
+          _ <- migrationDao.updateSnapshotProgress(persistenceId, seqNr)
+        } yield 1
+    }
+  }
+
+  private def serializedSnapotRow(selectedSnapshot: SelectedSnapshot): SerializedSnapshotRow = {
+    val snapshotMetadata = selectedSnapshot.metadata
+    val snapshotAnyRef = selectedSnapshot.snapshot.asInstanceOf[AnyRef]
+    val serializedSnapshot = serialization.serialize(snapshotAnyRef).get
+    val snapshotSerializer = serialization.findSerializerFor(snapshotAnyRef)
+    val snapshotManifest = Serializers.manifestFor(snapshotSerializer, snapshotAnyRef)
+
+    val serializedMeta: Option[SerializedSnapshotMetadata] = snapshotMetadata.metadata.map { meta =>
+      val metaRef = meta.asInstanceOf[AnyRef]
+      val serializedMeta = serialization.serialize(metaRef).get
+      val metaSerializer = serialization.findSerializerFor(metaRef)
+      val metaManifest = Serializers.manifestFor(metaSerializer, metaRef)
+      SerializedSnapshotMetadata(serializedMeta, metaSerializer.identifier, metaManifest)
+    }
+
+    val serializedRow = SerializedSnapshotRow(
+      snapshotMetadata.persistenceId,
+      snapshotMetadata.sequenceNr,
+      snapshotMetadata.timestamp,
+      serializedSnapshot,
+      snapshotSerializer.identifier,
+      snapshotManifest,
+      serializedMeta)
+    serializedRow
+  }
+
+  private def loadSourceSnapshot(persistenceId: String, minSequenceNr: Long): Future[Option[SelectedSnapshot]] = {
+    if (sourceSnapshotPluginId == "")
+      Future.successful(None)
+    else {
+      implicit val timeout: Timeout = 10.seconds
+      val criteria = SnapshotSelectionCriteria.Latest
+      (sourceSnapshotStore ? LoadSnapshot(persistenceId, criteria, Long.MaxValue))
+        .mapTo[LoadSnapshotResult]
+        .map(result => result.snapshot.flatMap(s => if (s.metadata.sequenceNr >= minSequenceNr) Some(s) else None))
+    }
+
+  }
+
+}

--- a/migration/src/main/scala/akka/persistence/r2dbc/migration/MigrationToolDao.scala
+++ b/migration/src/main/scala/akka/persistence/r2dbc/migration/MigrationToolDao.scala
@@ -1,0 +1,93 @@
+/*
+ * Copyright (C) 2021 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.persistence.r2dbc.migration
+
+import scala.concurrent.ExecutionContext
+import scala.concurrent.Future
+
+import akka.Done
+import akka.actor.typed.ActorSystem
+import akka.annotation.InternalApi
+import akka.persistence.r2dbc.internal.R2dbcExecutor
+import akka.persistence.r2dbc.journal.JournalDao.log
+import io.r2dbc.spi.ConnectionFactory
+
+/**
+ * INTERNAL API
+ */
+@InternalApi private[r2dbc] object MigrationToolDao {
+  final case class CurrentProgress(persistenceId: String, eventSeqNr: Long, snapshotSeqNr: Long)
+}
+
+/**
+ * INTERNAL API
+ */
+@InternalApi private[r2dbc] class MigrationToolDao(connectionFactory: ConnectionFactory)(implicit
+    ec: ExecutionContext,
+    system: ActorSystem[_]) {
+  import MigrationToolDao.CurrentProgress
+
+  private val r2dbcExecutor = new R2dbcExecutor(connectionFactory, log)(ec, system)
+
+  def createProgressTable(): Future[Done] = {
+    r2dbcExecutor.executeDdl("create migration progress table") { connection =>
+      connection.createStatement("""CREATE TABLE IF NOT EXISTS migration_progress(
+        | persistence_id VARCHAR(255) NOT NULL,
+        | event_sequence_number BIGINT,
+        | snapshot_sequence_number BIGINT,
+        | PRIMARY KEY(persistence_id)
+        |)""".stripMargin)
+    }
+  }
+
+  def updateEventProgress(persistenceId: String, seqNr: Long): Future[Done] = {
+    r2dbcExecutor
+      .updateOne(s"upsert migration progress [$persistenceId]") { connection =>
+        connection
+          .createStatement(
+            "INSERT INTO migration_progress " +
+            "(persistence_id, event_sequence_number)  " +
+            "VALUES ($1, $2) " +
+            "ON CONFLICT (persistence_id) " +
+            "DO UPDATE SET " +
+            "event_sequence_number = excluded.event_sequence_number")
+          .bind(0, persistenceId)
+          .bind(1, seqNr)
+      }
+      .map(_ => Done)(ExecutionContext.parasitic)
+  }
+
+  def updateSnapshotProgress(persistenceId: String, seqNr: Long): Future[Done] = {
+    r2dbcExecutor
+      .updateOne(s"upsert migration progress [$persistenceId]") { connection =>
+        connection
+          .createStatement(
+            "INSERT INTO migration_progress " +
+            "(persistence_id, snapshot_sequence_number)  " +
+            "VALUES ($1, $2) " +
+            "ON CONFLICT (persistence_id) " +
+            "DO UPDATE SET " +
+            "snapshot_sequence_number = excluded.snapshot_sequence_number")
+          .bind(0, persistenceId)
+          .bind(1, seqNr)
+      }
+      .map(_ => Done)(ExecutionContext.parasitic)
+  }
+
+  def currentProgress(persistenceId: String): Future[Option[CurrentProgress]] = {
+    r2dbcExecutor.selectOne(s"read migration progress [$persistenceId]")(
+      _.createStatement("SELECT * FROM migration_progress WHERE persistence_id = $1")
+        .bind(0, persistenceId),
+      row =>
+        CurrentProgress(
+          persistenceId,
+          eventSeqNr = zeroIfNull(row.get("event_sequence_number", classOf[java.lang.Long])),
+          snapshotSeqNr = zeroIfNull(row.get("snapshot_sequence_number", classOf[java.lang.Long]))))
+  }
+
+  private def zeroIfNull(n: java.lang.Long): Long =
+    if (n eq null) 0L else n
+
+}

--- a/migration/src/test/resources/application.conf
+++ b/migration/src/test/resources/application.conf
@@ -1,8 +1,7 @@
 akka.persistence.r2dbc.migration {
   source {
-    journal-plugin-id = "jdbc-journal"
-    snapshot-plugin-id = "jdbc-snapshot-store"
     query-plugin-id = "jdbc-read-journal"
+    snapshot-plugin-id = "jdbc-snapshot-store"
   }
 }
 

--- a/migration/src/test/resources/application.conf
+++ b/migration/src/test/resources/application.conf
@@ -1,0 +1,54 @@
+akka.persistence.r2dbc.migration {
+  source {
+    journal-plugin-id = "jdbc-journal"
+    snapshot-plugin-id = "jdbc-snapshot-store"
+    query-plugin-id = "jdbc-read-journal"
+  }
+}
+
+akka.persistence.r2dbc {
+  # use different table names or schema
+  journal.table = "event_journal2"
+  snapshot.table = "snapshot2"
+  state.table = "durable_state2"
+}
+
+akka.persistence.r2dbc.connection-factory {
+  driver = "postgres"
+  host = "localhost"
+  port = 5432
+  user = "postgres"
+  password = "postgres"
+  database = "postgres"
+}
+
+akka-persistence-jdbc {
+  shared-databases {
+    default {
+      profile = "slick.jdbc.PostgresProfile$"
+      db {
+        host = "localhost"
+        url = "jdbc:postgresql://localhost:5432/postgres?reWriteBatchedInserts=true"
+        user = postgres
+        password = postgres
+        driver = "org.postgresql.Driver"
+        numThreads = 20
+        maxConnections = 20
+        minConnections = 5
+      }
+    }
+  }
+}
+
+jdbc-journal {
+  use-shared-db = "default"
+}
+jdbc-snapshot-store {
+  use-shared-db = "default"
+}
+jdbc-read-journal {
+  use-shared-db = "default"
+}
+
+# application specific serializers for events and snapshots
+# must also be configured and included in classpath

--- a/migration/src/test/resources/logback-main.xml
+++ b/migration/src/test/resources/logback-main.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>[%date{ISO8601}] [%level] [%logger] [%X{akkaAddress}] [%marker] [%thread] - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+
+<!--    <logger name="akka.persistence.r2dbc.migration.MigrationTool" level="DEBUG" />-->
+
+<!--    <logger name="akka.persistence.r2dbc" level="DEBUG" />-->
+<!--    <logger name="io.r2dbc.postgresql.QUERY" level="DEBUG" />-->
+<!--    <logger name="io.r2dbc.pool" level="DEBUG" />-->
+
+    <root level="INFO">
+        <appender-ref ref="STDOUT"/>
+    </root>
+
+</configuration>

--- a/migration/src/test/scala/akka/persistence/r2dbc/migration/MigrationToolSpec.scala
+++ b/migration/src/test/scala/akka/persistence/r2dbc/migration/MigrationToolSpec.scala
@@ -1,0 +1,277 @@
+/*
+ * Copyright (C) 2021 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.persistence.r2dbc.migration
+
+import scala.concurrent.Await
+import scala.concurrent.duration._
+
+import akka.Done
+import akka.actor.testkit.typed.scaladsl.LogCapturing
+import akka.actor.testkit.typed.scaladsl.ScalaTestWithActorTestKit
+import akka.actor.typed.ActorSystem
+import akka.persistence.r2dbc.TestActors.Persister
+import akka.persistence.r2dbc.TestConfig
+import akka.persistence.r2dbc.TestData
+import akka.persistence.r2dbc.TestDbLifecycle
+import akka.persistence.typed.PersistenceId
+import com.typesafe.config.Config
+import com.typesafe.config.ConfigFactory
+import org.scalatest.wordspec.AnyWordSpecLike
+
+object MigrationToolSpec {
+  val config: Config = ConfigFactory
+    .parseString("""
+    akka-persistence-jdbc {
+      shared-databases {
+        default {
+          profile = "slick.jdbc.PostgresProfile$"
+          db {
+            host = "127.0.0.1"
+            url = "jdbc:postgresql://127.0.0.1:5432/postgres?reWriteBatchedInserts=true"
+            user = postgres
+            password = postgres
+            driver = "org.postgresql.Driver"
+            numThreads = 20
+            maxConnections = 20
+            minConnections = 5
+          }
+        }
+      }
+    }
+
+    jdbc-journal {
+      use-shared-db = "default"
+      tables.event_journal.tableName = "jdbc_event_journal"
+    }
+    jdbc-snapshot-store {
+      use-shared-db = "default"
+      tables.snapshot.tableName = "jdbc_snapshot"
+    }
+    jdbc-read-journal {
+      use-shared-db = "default"
+      tables.event_journal.tableName = "jdbc_event_journal"
+    }
+    """)
+    .withFallback(TestConfig.config)
+}
+
+class MigrationToolSpec
+    extends ScalaTestWithActorTestKit(MigrationToolSpec.config)
+    with AnyWordSpecLike
+    with TestDbLifecycle
+    with TestData
+    with LogCapturing {
+
+  override def typedSystem: ActorSystem[_] = system
+
+  private val migrationConfig = system.settings.config.getConfig("akka.persistence.r2dbc.migration")
+  private val sourceJournalPluginId = migrationConfig.getString("source.journal-plugin-id")
+  private val sourceSnapshotPluginId = migrationConfig.getString("source.snapshot-plugin-id")
+
+  private val targetPluginId = migrationConfig.getString("target.persistence-plugin-id")
+
+  private val migration = new MigrationTool(system)
+
+  private val testEnabled: Boolean = {
+    // don't run this for Yugabyte since it is using akka-persistence-jdbc
+    system.settings.config.getString("akka.persistence.r2dbc.dialect") == "postgres"
+  }
+
+  override protected def beforeAll(): Unit = {
+    super.beforeAll()
+
+    if (testEnabled) {
+      Await.result(
+        r2dbcExecutor.executeDdl("beforeAll create jdbc tables") { connection =>
+          connection.createStatement("""CREATE TABLE IF NOT EXISTS jdbc_event_journal(
+                                       |  ordering BIGSERIAL,
+                                       |  persistence_id VARCHAR(255) NOT NULL,
+                                       |  sequence_number BIGINT NOT NULL,
+                                       |  deleted BOOLEAN DEFAULT FALSE NOT NULL,
+                                       |
+                                       |  writer VARCHAR(255) NOT NULL,
+                                       |  write_timestamp BIGINT,
+                                       |  adapter_manifest VARCHAR(255),
+                                       |
+                                       |  event_ser_id INTEGER NOT NULL,
+                                       |  event_ser_manifest VARCHAR(255) NOT NULL,
+                                       |  event_payload BYTEA NOT NULL,
+                                       |
+                                       |  meta_ser_id INTEGER,
+                                       |  meta_ser_manifest VARCHAR(255),
+                                       |  meta_payload BYTEA,
+                                       |
+                                       |  PRIMARY KEY(persistence_id, sequence_number)
+                                       |)""".stripMargin)
+        },
+        10.seconds)
+
+      Await.result(
+        r2dbcExecutor.executeDdl("beforeAll create jdbc tables") { connection =>
+          connection.createStatement("""CREATE TABLE IF NOT EXISTS jdbc_snapshot (
+                                       |  persistence_id VARCHAR(255) NOT NULL,
+                                       |  sequence_number BIGINT NOT NULL,
+                                       |  created BIGINT NOT NULL,
+                                       |
+                                       |  snapshot_ser_id INTEGER NOT NULL,
+                                       |  snapshot_ser_manifest VARCHAR(255) NOT NULL,
+                                       |  snapshot_payload BYTEA NOT NULL,
+                                       |
+                                       |  meta_ser_id INTEGER,
+                                       |  meta_ser_manifest VARCHAR(255),
+                                       |  meta_payload BYTEA,
+                                       |
+                                       |  PRIMARY KEY(persistence_id, sequence_number)
+                                       |)""".stripMargin)
+        },
+        10.seconds)
+
+      Await.result(
+        r2dbcExecutor.updateOne("beforeAll delete jdbc")(_.createStatement("delete from jdbc_event_journal")),
+        10.seconds)
+      Await.result(
+        r2dbcExecutor.updateOne("beforeAll delete jdbc")(_.createStatement("delete from jdbc_snapshot")),
+        10.seconds)
+
+      Await.result(migration.migrationDao.createProgressTable(), 10.seconds)
+      Await.result(
+        r2dbcExecutor.updateOne("beforeAll migration_progress")(_.createStatement("delete from migration_progress")),
+        10.seconds)
+    }
+  }
+
+  private def persistEvents(pid: PersistenceId, events: Seq[String]): Unit = {
+    val probe = testKit.createTestProbe[Done]()
+    val persister = testKit.spawn(Persister(pid, sourceJournalPluginId, sourceSnapshotPluginId))
+    events.foreach { event =>
+      persister ! Persister.Persist(event)
+    }
+    persister ! Persister.Stop(probe.ref)
+    probe.expectMessage(Done)
+  }
+
+  private def assertEvents(pid: PersistenceId, expectedEvents: Seq[String]): Unit =
+    assertState(pid, expectedEvents.mkString("|"))
+
+  private def assertState(pid: PersistenceId, expectedState: String): Unit = {
+    val probe = testKit.createTestProbe[Any]()
+    val targetPersister = testKit.spawn(Persister(pid, targetPluginId + ".journal", targetPluginId + ".snapshot"))
+    targetPersister ! Persister.GetState(probe.ref)
+    probe.expectMessage(expectedState)
+    targetPersister ! Persister.Stop(probe.ref)
+    probe.expectMessage(Done)
+  }
+
+  "MigrationTool" should {
+    if (!testEnabled) {
+      info(s"MigrationToolSpec not enabled for ${system.settings.config.getString("akka.persistence.r2dbc.dialect")}")
+      pending
+    }
+
+    "migrate events of one persistenceId" in {
+      val pid = PersistenceId.ofUniqueId(nextPid())
+
+      val events = List("e-1", "e-2", "e-3")
+      persistEvents(pid, events)
+
+      migration.migrateEvents(pid.id).futureValue shouldBe 3L
+
+      assertEvents(pid, events)
+    }
+
+    "migrate events of a persistenceId several times" in {
+      val pid = PersistenceId.ofUniqueId(nextPid())
+
+      val events = List("e-1", "e-2", "e-3")
+      persistEvents(pid, events)
+
+      migration.migrateEvents(pid.id).futureValue shouldBe 3L
+      assertEvents(pid, events)
+      // running again should be idempotent and not fail
+      migration.migrateEvents(pid.id).futureValue shouldBe 0L
+      assertEvents(pid, events)
+
+      // and running again should find new events
+      val moreEvents = List("e-4", "e-5")
+      persistEvents(pid, moreEvents)
+      migration.migrateEvents(pid.id).futureValue shouldBe 2L
+
+      assertEvents(pid, events ++ moreEvents)
+    }
+
+    "migrate snapshot of one persistenceId" in {
+      val pid = PersistenceId.ofUniqueId(nextPid())
+
+      persistEvents(pid, List("e-1", "e-2-snap", "e-3"))
+
+      migration.migrateSnapshot(pid.id).futureValue shouldBe 1L
+
+      assertState(pid, "e-1|e-2-snap")
+    }
+
+    "migrate snapshot of a persistenceId several times" in {
+      val pid = PersistenceId.ofUniqueId(nextPid())
+
+      persistEvents(pid, List("e-1", "e-2-snap", "e-3"))
+
+      migration.migrateSnapshot(pid.id).futureValue shouldBe 1L
+      assertState(pid, "e-1|e-2-snap")
+      // running again should be idempotent and not fail
+      migration.migrateSnapshot(pid.id).futureValue shouldBe 0L
+      assertState(pid, "e-1|e-2-snap")
+
+      // and running again should find new snapshot
+      persistEvents(pid, List("e-4-snap", "e-5"))
+      migration.migrateSnapshot(pid.id).futureValue shouldBe 1L
+
+      assertState(pid, "e-1|e-2-snap|e-3|e-4-snap")
+    }
+
+    "update event migration_progress" in {
+      val pid = PersistenceId.ofUniqueId(nextPid())
+      migration.migrationDao.currentProgress(pid.id).futureValue.map(_.eventSeqNr) shouldBe None
+
+      persistEvents(pid, List("e-1", "e-2", "e-3"))
+      migration.migrateEvents(pid.id).futureValue shouldBe 3L
+      migration.migrationDao.currentProgress(pid.id).futureValue.map(_.eventSeqNr) shouldBe Some(3L)
+
+      // store and migration some more
+      persistEvents(pid, List("e-4", "e-5"))
+      migration.migrateEvents(pid.id).futureValue shouldBe 2L
+      migration.migrationDao.currentProgress(pid.id).futureValue.map(_.eventSeqNr) shouldBe Some(5L)
+    }
+
+    "update snapshot migration_progress" in {
+      val pid = PersistenceId.ofUniqueId(nextPid())
+      migration.migrationDao.currentProgress(pid.id).futureValue.map(_.snapshotSeqNr) shouldBe None
+
+      persistEvents(pid, List("e-1", "e-2-snap", "e-3"))
+      migration.migrateSnapshot(pid.id).futureValue shouldBe 1L
+      migration.migrationDao.currentProgress(pid.id).futureValue.map(_.snapshotSeqNr) shouldBe Some(2L)
+
+      // store and migration some more
+      persistEvents(pid, List("e-4", "e-5-snap", "e-6"))
+      migration.migrateSnapshot(pid.id).futureValue shouldBe 1L
+      migration.migrationDao.currentProgress(pid.id).futureValue.map(_.snapshotSeqNr) shouldBe Some(5L)
+    }
+
+    "migrate all persistenceIds" in {
+      val numberOfPids = 10
+      val pids = (1 to numberOfPids).map(_ => PersistenceId.ofUniqueId(nextPid()))
+      val events = List("e-1", "e-2", "e-3", "e-4-snap", "e-5", "e-6-snap", "e-7", "e-8", "e-9")
+
+      pids.foreach { pid =>
+        persistEvents(pid, events)
+      }
+
+      migration.migrateAll().futureValue
+
+      pids.foreach { pid =>
+        assertEvents(pid, events)
+      }
+    }
+
+  }
+}

--- a/migration/src/test/scala/akka/persistence/r2dbc/migration/MigrationToolSpec.scala
+++ b/migration/src/test/scala/akka/persistence/r2dbc/migration/MigrationToolSpec.scala
@@ -67,7 +67,7 @@ class MigrationToolSpec
   override def typedSystem: ActorSystem[_] = system
 
   private val migrationConfig = system.settings.config.getConfig("akka.persistence.r2dbc.migration")
-  private val sourceJournalPluginId = migrationConfig.getString("source.journal-plugin-id")
+  private val sourceJournalPluginId = "jdbc-journal"
   private val sourceSnapshotPluginId = migrationConfig.getString("source.snapshot-plugin-id")
 
   private val targetPluginId = migrationConfig.getString("target.persistence-plugin-id")

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -5,14 +5,10 @@
 import sbt._
 
 object Dependencies {
-  val Scala212 = "2.12.14"
-  val Scala213 = "2.13.1"
-  val AkkaVersion = System.getProperty("override.akka.version", "2.6.16")
+  val Scala212 = "2.12.15"
+  val Scala213 = "2.13.6"
+  val AkkaVersion = System.getProperty("override.akka.version", "2.6.17")
   val AkkaVersionInDocs = AkkaVersion.take(3)
-  // for example
-  val AkkaHttpVersion = "10.2.6"
-  val AkkaManagementVersion = "1.0.6"
-  val R2dbcVersion = "0.9.0.M2"
   val AkkaProjectionVersion = "1.2.2+4-6602699f-SNAPSHOT"
 
   object Compile {
@@ -32,9 +28,6 @@ object Dependencies {
     val akkaProjectionCore = "com.lightbend.akka" %% "akka-projection-core" % AkkaProjectionVersion
 
     val postgresql = "org.postgresql" % "postgresql" % "42.2.24"
-//    val r2dbcSpi = "io.r2dbc" % "r2dbc-spi" % R2dbcVersion
-//    val r2dbcPool = "io.r2dbc" % "r2dbc-pool" % R2dbcVersion
-//    val r2dbcPostgres = "org.postgresql" % "r2dbc-postgresql" % R2dbcVersion
 
     val r2dbcSpi = "io.r2dbc" % "r2dbc-spi" % "0.8.6.RELEASE"
     val r2dbcPool = "io.r2dbc" % "r2dbc-pool" % "0.8.7.RELEASE"
@@ -85,4 +78,7 @@ object Dependencies {
     TestDeps.akkaJackson,
     TestDeps.logback,
     TestDeps.scalaTest)
+
+  val migration =
+    Seq("com.lightbend.akka" %% "akka-persistence-jdbc" % "5.0.4" % Test, TestDeps.logback, TestDeps.scalaTest)
 }


### PR DESCRIPTION
* It has been tested with akka-persistence-jdbc as source plugin, but it should
  work with any plugin that has support for `CurrentPersistenceIdsQuery` and
  `CurrentEventsByPersistenceIdQuery`
* It can be run while the source system is still active and it can be run multiple
  times with idempotent result.
