### PR TITLE
Harden EventsBySliceSpec, #118

### DIFF
--- a/core/src/test/scala/akka/persistence/r2dbc/query/EventsBySliceBacktrackingSpec.scala
+++ b/core/src/test/scala/akka/persistence/r2dbc/query/EventsBySliceBacktrackingSpec.scala
@@ -14,8 +14,6 @@ import akka.actor.typed.ActorSystem
 import akka.persistence.query.NoOffset
 import akka.persistence.query.PersistenceQuery
 import akka.persistence.query.typed.EventEnvelope
-import akka.persistence.query.typed.scaladsl.EventsBySliceQuery
-import akka.persistence.query.typed.scaladsl.LoadEventQuery
 import akka.persistence.r2dbc.R2dbcSettings
 import akka.persistence.r2dbc.TestConfig
 import akka.persistence.r2dbc.TestData


### PR DESCRIPTION
* flaky in CI
* I looked at logs from one of the failed runs and it was missing 1 event for the
  "Live eventsBySlices should retrieve from several slices", couldn't see
  a reason from the logs

References #118
