### PR TITLE
Backtrack to the ordinary timestamp, #109

### DIFF
--- a/core/src/main/scala/akka/persistence/r2dbc/internal/BySliceQuery.scala
+++ b/core/src/main/scala/akka/persistence/r2dbc/internal/BySliceQuery.scala
@@ -48,7 +48,7 @@ import org.slf4j.Logger
       if (backtracking) latestBacktracking.timestamp
       else latest.timestamp
 
-    def nextQueryUntilTimestamp: Option[Instant] =
+    def nextQueryToTimestamp: Option[Instant] =
       if (backtracking) Some(latest.timestamp)
       else None
   }
@@ -68,7 +68,7 @@ import org.slf4j.Logger
         minSlice: Int,
         maxSlice: Int,
         fromTimestamp: Instant,
-        untilTimestamp: Option[Instant],
+        toTimestamp: Option[Instant],
         behindCurrentTime: FiniteDuration,
         backtracking: Boolean): Source[SerializedRow, NotUsed]
   }
@@ -125,7 +125,7 @@ import org.slf4j.Logger
               minSlice,
               maxSlice,
               state.latest.timestamp,
-              untilTimestamp = Some(toDbTimestamp),
+              toTimestamp = Some(toDbTimestamp),
               behindCurrentTime = Duration.Zero,
               backtracking = false)
             .via(deserializeAndAddOffset(state.latest)))
@@ -272,7 +272,7 @@ import org.slf4j.Logger
             minSlice,
             maxSlice,
             newState.nextQueryFromTimestamp,
-            newState.nextQueryUntilTimestamp,
+            newState.nextQueryToTimestamp,
             behindCurrentTime,
             backtracking = newState.backtracking)
           .via(deserializeAndAddOffset(newState.currentOffset)))

--- a/core/src/main/scala/akka/persistence/r2dbc/state/scaladsl/DurableStateDao.scala
+++ b/core/src/main/scala/akka/persistence/r2dbc/state/scaladsl/DurableStateDao.scala
@@ -237,19 +237,19 @@ private[r2dbc] class DurableStateDao(settings: R2dbcSettings, connectionFactory:
       minSlice: Int,
       maxSlice: Int,
       fromTimestamp: Instant,
-      untilTimestamp: Option[Instant],
+      toTimestamp: Option[Instant],
       behindCurrentTime: FiniteDuration,
       backtracking: Boolean): Source[SerializedStateRow, NotUsed] = {
     val result = r2dbcExecutor.select(s"select stateBySlices [$minSlice - $maxSlice]")(
       connection => {
         val stmt = connection
           .createStatement(
-            stateBySlicesRangeSql(maxDbTimestampParam = untilTimestamp.isDefined, behindCurrentTime, backtracking))
+            stateBySlicesRangeSql(maxDbTimestampParam = toTimestamp.isDefined, behindCurrentTime, backtracking))
           .bind(0, entityType)
           .bind(1, minSlice)
           .bind(2, maxSlice)
           .bind(3, fromTimestamp)
-        untilTimestamp match {
+        toTimestamp match {
           case Some(until) =>
             stmt.bind(4, until)
             stmt.bind(5, settings.querySettings.bufferSize)

--- a/core/src/test/scala/akka/persistence/r2dbc/query/EventsBySliceBacktrackingSpec.scala
+++ b/core/src/test/scala/akka/persistence/r2dbc/query/EventsBySliceBacktrackingSpec.scala
@@ -120,10 +120,6 @@ class EventsBySliceBacktrackingSpec
       // no backtracking yet
       result.expectNoMessage(settings.querySettings.refreshInterval + 100.millis)
 
-      // FIXME one case that isn't covered yet is if there is no progress (no more events) then
-      // there will not be any new backtracking query and missed events will not be found (until there are
-      // new events that move the latest offset forward)
-
       // after 1/2 of the backtracking widow, to kick off a backtracking query
       writeEvent(
         slice1,

--- a/core/src/test/scala/akka/persistence/r2dbc/query/EventsBySliceBacktrackingSpec.scala
+++ b/core/src/test/scala/akka/persistence/r2dbc/query/EventsBySliceBacktrackingSpec.scala
@@ -107,12 +107,18 @@ class EventsBySliceBacktrackingSpec
       env3.eventOption shouldBe None
       // but it can be lazy loaded
       query.loadEnvelope[String](env3.persistenceId, env3.sequenceNr).futureValue.get.eventOption shouldBe Some("e1-1")
+      // backtracking up to (and equal to) the same offset
+      val env4 = result.expectNext()
+      env4.persistenceId shouldBe pid1
+      env4.sequenceNr shouldBe 2L
+      env4.eventOption shouldBe None
+
       result.expectNoMessage(100.millis) // not e1-2
 
       writeEvent(slice1, pid1, 3L, startTime.plusMillis(3), "e1-3")
-      val env4 = result.expectNext()
-      env4.persistenceId shouldBe pid1
-      env4.sequenceNr shouldBe 3L
+      val env5 = result.expectNext()
+      env5.persistenceId shouldBe pid1
+      env5.sequenceNr shouldBe 3L
 
       // before e1-3 so it will not be found by the normal query
       writeEvent(slice2, pid2, 1L, startTime.plusMillis(2), "e2-1")
@@ -127,16 +133,12 @@ class EventsBySliceBacktrackingSpec
         4L,
         startTime.plusMillis(settings.querySettings.backtrackingWindow.toMillis / 2).plusMillis(4),
         "e1-4")
-      val env5 = result.expectNext()
-      env5.persistenceId shouldBe pid1
-      env5.sequenceNr shouldBe 4L
-
-      // backtracking finds it,  and it also emits duplicates (by design)
-      // e1-1 was already handled by previous backtracking query
       val env6 = result.expectNext()
       env6.persistenceId shouldBe pid1
-      env6.sequenceNr shouldBe 2L
+      env6.sequenceNr shouldBe 4L
 
+      // backtracking finds it,  and it also emits duplicates (by design)
+      // e1-1 and e1-2 were already handled by previous backtracking query
       val env7 = result.expectNext()
       env7.persistenceId shouldBe pid2
       env7.sequenceNr shouldBe 1L
@@ -144,8 +146,10 @@ class EventsBySliceBacktrackingSpec
       val env8 = result.expectNext()
       env8.persistenceId shouldBe pid1
       env8.sequenceNr shouldBe 3L
-      result.expectNoMessage(100.millis) // not e1-4
-      result.expectNoMessage(settings.querySettings.refreshInterval)
+
+      val env9 = result.expectNext()
+      env9.persistenceId shouldBe pid1
+      env9.sequenceNr shouldBe 4L
     }
   }
 

--- a/projection/src/test/scala/akka/projection/r2dbc/EventSourcedEndToEndSpec.scala
+++ b/projection/src/test/scala/akka/projection/r2dbc/EventSourcedEndToEndSpec.scala
@@ -310,13 +310,9 @@ class EventSourcedEndToEndSpec
 
       // pid3, seqNr 8 is missing (knows 7) when receiving 9
       writeEvent(pid3, 9L, startTime.plusMillis(4), "e3-9")
-      processedProbe.expectNoMessage(journalSettings.querySettings.refreshInterval + 500.millis)
+      processedProbe.expectNoMessage(journalSettings.querySettings.refreshInterval + 2000.millis)
 
-      // but backtracking can fill in the gaps
-      // need some progress because backtracking will not exceed the latest offset
-      writeEvent(pid1, 2L, startTime.plusMillis(5), "e1-2")
-      processedProbe.receiveMessage().envelope.event shouldBe "e1-2"
-      // backtracking will pick up pid3 seqNr 8 and 9
+      // but backtracking can fill in the gaps, backtracking will pick up pid3 seqNr 8 and 9
       writeEvent(pid3, 8L, startTime.plusMillis(3), "e3-8")
       val possibleDelay =
         journalSettings.querySettings.backtrackingBehindCurrentTime + journalSettings.querySettings.refreshInterval + processedProbe.remainingOrDefault


### PR DESCRIPTION
* <= instead of <
* because otherwise the backtracking will not find the last event
  if there is no other progress

See description of test that failed https://github.com/akka/akka-persistence-r2dbc/issues/109#issuecomment-967208120

Fixes #109
