### PR TITLE
Rewrite test for grouped async, #147

### DIFF
--- a/projection/src/test/scala/akka/projection/r2dbc/R2dbcTimestampOffsetProjectionSpec.scala
+++ b/projection/src/test/scala/akka/projection/r2dbc/R2dbcTimestampOffsetProjectionSpec.scala
@@ -751,7 +751,9 @@ class R2dbcTimestampOffsetProjectionSpec
         result2.toString shouldBe "e2-1|e2-2|e2-3|e2-4|"
       }
 
-      offsetShouldBe(envelopes2.last.offset)
+      eventually {
+        offsetShouldBe(envelopes2.last.offset)
+      }
       projectionRef ! ProjectionBehavior.Stop
     }
   }

--- a/projection/src/test/scala/akka/projection/r2dbc/R2dbcTimestampOffsetProjectionSpec.scala
+++ b/projection/src/test/scala/akka/projection/r2dbc/R2dbcTimestampOffsetProjectionSpec.scala
@@ -706,9 +706,9 @@ class R2dbcTimestampOffsetProjectionSpec
       val projectionId = genRandomProjectionId()
 
       val startTime = Instant.now()
-      val envelopes1 = createEnvelopesUnknownSequenceNumbers(startTime, pid1, pid2)
-      val sourceProvider1 = createSourceProvider(envelopes1)
-      implicit val offsetStore = createOffsetStore(projectionId, sourceProvider1)
+      val sourceProvider = new TestSourceProviderWithInput()
+      implicit val offsetStore =
+        new R2dbcOffsetStore(projectionId, Some(sourceProvider), system, settings, r2dbcExecutor)
 
       val result1 = new StringBuffer()
       val result2 = new StringBuffer()
@@ -728,10 +728,15 @@ class R2dbcTimestampOffsetProjectionSpec
         }
       }
 
-      val projection1 =
-        R2dbcProjection.groupedWithinAsync(projectionId, Some(settings), sourceProvider1, handler = () => handler())
+      val projectionRef = spawn(
+        ProjectionBehavior(
+          R2dbcProjection.groupedWithinAsync(projectionId, Some(settings), sourceProvider, handler = () => handler())))
+      val input = sourceProvider.input.futureValue
 
-      projectionTestKit.run(projection1) {
+      val envelopes1 = createEnvelopesUnknownSequenceNumbers(startTime, pid1, pid2)
+      envelopes1.foreach(input ! _)
+
+      eventually {
         result1.toString shouldBe "e1-1|e1-2|e1-3|"
         result2.toString shouldBe "e2-1|"
       }
@@ -739,18 +744,15 @@ class R2dbcTimestampOffsetProjectionSpec
       // simulate backtracking
       logger.debug("Starting backtracking")
       val envelopes2 = createEnvelopesBacktrackingUnknownSequenceNumbers(startTime, pid1, pid2)
-      val sourceProvider2 = createBacktrackingSourceProvider(envelopes2)
-      val projection2 =
-        R2dbcProjection.groupedWithinAsync(projectionId, Some(settings), sourceProvider2, handler = () => handler())
+      envelopes2.foreach(input ! _)
 
-      projectionTestKit.run(projection2) {
-        // FIXME
-//        result1.toString shouldBe "e1-1|e1-2|e1-3|e1-4|e1-5|e1-6|"
+      eventually {
+        result1.toString shouldBe "e1-1|e1-2|e1-3|e1-4|e1-5|e1-6|"
         result2.toString shouldBe "e2-1|e2-2|e2-3|e2-4|"
       }
 
       offsetShouldBe(envelopes2.last.offset)
-      pending // FIXME still pending because of result1 (see above)
+      projectionRef ! ProjectionBehavior.Stop
     }
   }
 

--- a/projection/src/test/scala/akka/projection/r2dbc/TestSourceProviderWithInput.scala
+++ b/projection/src/test/scala/akka/projection/r2dbc/TestSourceProviderWithInput.scala
@@ -1,0 +1,89 @@
+/*
+ * Copyright (C) 2021 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.projection.r2dbc
+
+import java.time.Instant
+import java.util.concurrent.ConcurrentLinkedQueue
+import java.util.concurrent.atomic.AtomicReference
+
+import scala.concurrent.ExecutionContext
+import scala.concurrent.Future
+import scala.concurrent.Promise
+import scala.jdk.CollectionConverters._
+
+import akka.NotUsed
+import akka.actor.typed.ActorRef
+import akka.actor.typed.scaladsl.adapter._
+import akka.persistence.query.typed.EventEnvelope
+import akka.persistence.query.typed.scaladsl.EventTimestampQuery
+import akka.persistence.query.typed.scaladsl.LoadEventQuery
+import akka.persistence.r2dbc.query.TimestampOffset
+import akka.projection.eventsourced.scaladsl.TimestampOffsetBySlicesSourceProvider
+import akka.projection.r2dbc.internal.R2dbcOffsetStore
+import akka.projection.scaladsl.SourceProvider
+import akka.stream.OverflowStrategy
+import akka.stream.scaladsl.Source
+
+class TestSourceProviderWithInput()(implicit val ec: ExecutionContext)
+    extends SourceProvider[TimestampOffset, EventEnvelope[String]]
+    with TimestampOffsetBySlicesSourceProvider
+    with EventTimestampQuery
+    with LoadEventQuery {
+
+  private val _input = new AtomicReference[Promise[ActorRef[EventEnvelope[String]]]](Promise())
+
+  def input: Future[ActorRef[EventEnvelope[String]]] = _input.get().future
+
+  private val envelopes = new ConcurrentLinkedQueue[EventEnvelope[String]]
+
+  override def source(offset: () => Future[Option[TimestampOffset]]): Future[Source[EventEnvelope[String], NotUsed]] = {
+    val oldPromise = _input.get()
+    _input.set(Promise())
+    offset().map { _ =>
+      Source
+        .actorRef[EventEnvelope[String]](
+          PartialFunction.empty,
+          PartialFunction.empty,
+          bufferSize = 1024,
+          OverflowStrategy.fail)
+        .map { env =>
+          envelopes.offer(env)
+          env
+        }
+        .mapMaterializedValue { ref =>
+          val typedRef = ref.toTyped[EventEnvelope[String]]
+          oldPromise.trySuccess(typedRef)
+          _input.get().trySuccess(typedRef)
+          NotUsed
+        }
+    }
+  }
+
+  override def extractOffset(envelope: EventEnvelope[String]): TimestampOffset =
+    envelope.offset.asInstanceOf[TimestampOffset]
+
+  override def extractCreationTime(envelope: EventEnvelope[String]): Long =
+    envelope.timestamp
+
+  override def minSlice: Int = 0
+
+  override def maxSlice: Int = R2dbcOffsetStore.MaxNumberOfSlices - 1
+
+  override def timestampOf(persistenceId: String, sequenceNr: Long): Future[Option[Instant]] = {
+    Future.successful(envelopes.iterator().asScala.collectFirst {
+      case env
+          if env.persistenceId == persistenceId && env.sequenceNr == sequenceNr && env.offset
+            .isInstanceOf[TimestampOffset] =>
+        env.offset.asInstanceOf[TimestampOffset].timestamp
+    })
+  }
+
+  override def loadEnvelope[Event](persistenceId: String, sequenceNr: Long): Future[Option[EventEnvelope[Event]]] = {
+    Future.successful(envelopes.iterator().asScala.collectFirst {
+      case env if env.persistenceId == persistenceId && env.sequenceNr == sequenceNr =>
+        env.asInstanceOf[EventEnvelope[Event]]
+    })
+  }
+}


### PR DESCRIPTION
* problem was that projectionTestKit.run resets the OffsetStore for each
  run and therefore the inflight was not kept
* use a new TestSourceProvider that can be feeded with
  envelopes rather than just emitting a fixed collection

I might rewrite some of the other tests that could have similar async problem (even though we might not have seen it yet).

Fixes #147
