### PR TITLE
Don't copy .jvmopts-ci

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -31,8 +31,7 @@ jobs:
         uses: coursier/cache-action@v5
       - name: Code style check and binary-compatibility check
         run: |-
-          cp .jvmopts-ci .jvmopts
-          sbt scalafmtCheckAll scalafmtSbtCheck headerCheck
+          sbt -jvm-opts .jvmopts-ci scalafmtCheckAll scalafmtSbtCheck headerCheck
 
   test-postgres:
     name: Run test with Postgres
@@ -124,5 +123,4 @@ jobs:
         uses: coursier/cache-action@v5
       - name: Test Maven Java
         run: |-
-          cp .jvmopts-ci .jvmopts
-          sbt docs/paradox
+          sbt -jvm-opts .jvmopts-ci docs/paradox

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -23,8 +23,7 @@ jobs:
           java-version: adopt@1.8.0-275
       - name: Publish
         run: |-
-          cp .jvmopts-ci .jvmopts
-          sbt ci-release
+          sbt -jvm-opts .jvmopts-ci ci-release
         env:
           PGP_PASSPHRASE: ${{ secrets.PGP_PASSPHRASE }}
           PGP_SECRET: ${{ secrets.PGP_SECRET }}
@@ -51,7 +50,6 @@ jobs:
           echo $SCP_SECRET | base64 -d > /tmp/id_rsa
           chmod 600 /tmp/id_rsa
           ssh-add /tmp/id_rsa
-          cp .jvmopts-ci .jvmopts
-          sbt docs/publishRsync
+          sbt -jvm-opts .jvmopts-ci docs/publishRsync
         env:
           SCP_SECRET: ${{ secrets.SCP_SECRET }}


### PR DESCRIPTION
* because the version becomes a time snapshot when publishing

