### PR TITLE
config setting for logging of (slow) db calls

### DIFF
--- a/core/src/main/resources/reference.conf
+++ b/core/src/main/resources/reference.conf
@@ -120,5 +120,10 @@ akka.persistence.r2dbc {
   # move backwards when the system clock is adjusted.
   db-timestamp-monotonic-increasing = off
 
+  # Logs database calls that take longer than this duration at INFO level.
+  # Set to "off" to disable this logging.
+  # Set to 0 to log all calls.
+  log-db-calls-exceeding = 100 ms
+
 }
 // #connection-settings

--- a/core/src/main/scala/akka/persistence/r2dbc/R2dbcSettings.scala
+++ b/core/src/main/scala/akka/persistence/r2dbc/R2dbcSettings.scala
@@ -4,7 +4,9 @@
 
 package akka.persistence.r2dbc
 
-import scala.concurrent.duration.FiniteDuration
+import java.util.Locale
+
+import scala.concurrent.duration._
 
 import akka.annotation.InternalStableApi
 import akka.util.JavaDurationConverters._
@@ -37,6 +39,12 @@ final class R2dbcSettings(config: Config) {
   val connectionFactorySettings = new ConnectionFactorySettings(config.getConfig("connection-factory"))
 
   val dbTimestampMonotonicIncreasing: Boolean = config.getBoolean("db-timestamp-monotonic-increasing")
+
+  val logDbCallsExceeding: FiniteDuration =
+    config.getString("log-db-calls-exceeding").toLowerCase(Locale.ROOT) match {
+      case "off" => -1.millis
+      case _     => config.getDuration("log-db-calls-exceeding").asScala
+    }
 
 }
 

--- a/core/src/main/scala/akka/persistence/r2dbc/journal/JournalDao.scala
+++ b/core/src/main/scala/akka/persistence/r2dbc/journal/JournalDao.scala
@@ -72,7 +72,7 @@ private[r2dbc] class JournalDao(journalSettings: R2dbcSettings, connectionFactor
   import JournalDao.SerializedJournalRow
   import JournalDao.log
 
-  private val r2dbcExecutor = new R2dbcExecutor(connectionFactory, log)(ec, system)
+  private val r2dbcExecutor = new R2dbcExecutor(connectionFactory, log, journalSettings.logDbCallsExceeding)(ec, system)
 
   private val journalTable = journalSettings.journalTableWithSchema
 

--- a/core/src/main/scala/akka/persistence/r2dbc/query/scaladsl/QueryDao.scala
+++ b/core/src/main/scala/akka/persistence/r2dbc/query/scaladsl/QueryDao.scala
@@ -104,7 +104,7 @@ private[r2dbc] class QueryDao(settings: R2dbcSettings, connectionFactory: Connec
   private val allPersistenceIdsAfterSql =
     s"SELECT DISTINCT(persistence_id) from $journalTable WHERE persistence_id > $$1 ORDER BY persistence_id LIMIT $$2"
 
-  private val r2dbcExecutor = new R2dbcExecutor(connectionFactory, log)(ec, system)
+  private val r2dbcExecutor = new R2dbcExecutor(connectionFactory, log, settings.logDbCallsExceeding)(ec, system)
 
   def currentDbTimestamp(): Future[Instant] = {
     r2dbcExecutor

--- a/core/src/main/scala/akka/persistence/r2dbc/snapshot/SnapshotDao.scala
+++ b/core/src/main/scala/akka/persistence/r2dbc/snapshot/SnapshotDao.scala
@@ -68,7 +68,7 @@ private[r2dbc] final class SnapshotDao(settings: R2dbcSettings, connectionFactor
   import SnapshotDao._
 
   private val snapshotTable = settings.snapshotsTableWithSchema
-  private val r2dbcExecutor = new R2dbcExecutor(connectionFactory, log)(ec, system)
+  private val r2dbcExecutor = new R2dbcExecutor(connectionFactory, log, settings.logDbCallsExceeding)(ec, system)
 
   private val upsertSql =
     s"INSERT INTO $snapshotTable " +

--- a/core/src/main/scala/akka/persistence/r2dbc/state/scaladsl/DurableStateDao.scala
+++ b/core/src/main/scala/akka/persistence/r2dbc/state/scaladsl/DurableStateDao.scala
@@ -57,7 +57,7 @@ private[r2dbc] class DurableStateDao(settings: R2dbcSettings, connectionFactory:
     extends BySliceQuery.Dao[DurableStateDao.SerializedStateRow] {
   import DurableStateDao._
 
-  private val r2dbcExecutor = new R2dbcExecutor(connectionFactory, log)(ec, system)
+  private val r2dbcExecutor = new R2dbcExecutor(connectionFactory, log, settings.logDbCallsExceeding)(ec, system)
 
   private val stateTable = settings.durableStateTableWithSchema
 

--- a/core/src/test/resources/logback-test.xml
+++ b/core/src/test/resources/logback-test.xml
@@ -19,7 +19,7 @@
 
     <root level="INFO">
         <appender-ref ref="CapturingAppender"/>
-<!--        <appender-ref ref="STDOUT"/>-->
+        <appender-ref ref="STDOUT"/>
     </root>
 
 </configuration>

--- a/core/src/test/scala/akka/persistence/r2dbc/TestDbLifecycle.scala
+++ b/core/src/test/scala/akka/persistence/r2dbc/TestDbLifecycle.scala
@@ -25,7 +25,8 @@ trait TestDbLifecycle extends BeforeAndAfterAll { this: Suite =>
   lazy val r2dbcExecutor: R2dbcExecutor = {
     new R2dbcExecutor(
       ConnectionFactoryProvider(typedSystem).connectionFactoryFor(testConfigPath + ".connection-factory"),
-      LoggerFactory.getLogger(getClass))(typedSystem.executionContext, typedSystem)
+      LoggerFactory.getLogger(getClass),
+      r2dbcSettings.logDbCallsExceeding)(typedSystem.executionContext, typedSystem)
   }
 
   override protected def beforeAll(): Unit = {

--- a/migration/src/main/scala/akka/persistence/r2dbc/migration/MigrationTool.scala
+++ b/migration/src/main/scala/akka/persistence/r2dbc/migration/MigrationTool.scala
@@ -127,7 +127,8 @@ class MigrationTool(system: ActorSystem[_]) {
   private val sourceSnapshotPluginId = migrationConfig.getString("source.snapshot-plugin-id")
   private lazy val sourceSnapshotStore = Persistence(system).snapshotStoreFor(sourceSnapshotPluginId)
 
-  private[r2dbc] val migrationDao = new MigrationToolDao(targetConnectionFactory)
+  private[r2dbc] val migrationDao =
+    new MigrationToolDao(targetConnectionFactory, targetR2dbcSettings.logDbCallsExceeding)
 
   private lazy val createProgressTable: Future[Done] =
     migrationDao.createProgressTable()

--- a/migration/src/main/scala/akka/persistence/r2dbc/migration/MigrationToolDao.scala
+++ b/migration/src/main/scala/akka/persistence/r2dbc/migration/MigrationToolDao.scala
@@ -6,6 +6,7 @@ package akka.persistence.r2dbc.migration
 
 import scala.concurrent.ExecutionContext
 import scala.concurrent.Future
+import scala.concurrent.duration.FiniteDuration
 
 import akka.Done
 import akka.actor.typed.ActorSystem
@@ -24,12 +25,12 @@ import io.r2dbc.spi.ConnectionFactory
 /**
  * INTERNAL API
  */
-@InternalApi private[r2dbc] class MigrationToolDao(connectionFactory: ConnectionFactory)(implicit
-    ec: ExecutionContext,
-    system: ActorSystem[_]) {
+@InternalApi private[r2dbc] class MigrationToolDao(
+    connectionFactory: ConnectionFactory,
+    logDbCallsExceeding: FiniteDuration)(implicit ec: ExecutionContext, system: ActorSystem[_]) {
   import MigrationToolDao.CurrentProgress
 
-  private val r2dbcExecutor = new R2dbcExecutor(connectionFactory, log)(ec, system)
+  private val r2dbcExecutor = new R2dbcExecutor(connectionFactory, log, logDbCallsExceeding)(ec, system)
 
   def createProgressTable(): Future[Done] = {
     r2dbcExecutor.executeDdl("create migration progress table") { connection =>

--- a/projection/src/main/resources/reference.conf
+++ b/projection/src/main/resources/reference.conf
@@ -37,5 +37,9 @@ akka.projection.r2dbc {
   # akka.persistence.r2dbc.connection-factory.
   use-connection-factory = "akka.persistence.r2dbc.connection-factory"
 
+  # Logs database calls that take longer than this duration at INFO level.
+  # Set to "off" to disable this logging.
+  # Set to 0 to log all calls.
+  log-db-calls-exceeding = 100 ms
 }
 //#projection-config

--- a/projection/src/main/scala/akka/projection/r2dbc/internal/R2dbcProjectionImpl.scala
+++ b/projection/src/main/scala/akka/projection/r2dbc/internal/R2dbcProjectionImpl.scala
@@ -72,7 +72,8 @@ private[projection] object R2dbcProjectionImpl {
       sourceProvider: Option[BySlicesSourceProvider],
       settings: R2dbcProjectionSettings,
       connectionFactory: ConnectionFactory)(implicit system: ActorSystem[_]) = {
-    val r2dbcExecutor = new R2dbcExecutor(connectionFactory, log)(system.executionContext, system)
+    val r2dbcExecutor =
+      new R2dbcExecutor(connectionFactory, log, settings.logDbCallsExceeding)(system.executionContext, system)
     new R2dbcOffsetStore(projectionId, sourceProvider, system, settings, r2dbcExecutor)
   }
 

--- a/projection/src/main/scala/akka/projection/r2dbc/scaladsl/R2dbcProjection.scala
+++ b/projection/src/main/scala/akka/projection/r2dbc/scaladsl/R2dbcProjection.scala
@@ -56,7 +56,9 @@ object R2dbcProjection {
         timestampOffsetBySlicesSourceProvider(sourceProvider),
         r2dbcSettings,
         connFactory)
-    val r2dbcExecutor = new R2dbcExecutor(connFactory, R2dbcProjectionImpl.log)(system.executionContext, system)
+    val r2dbcExecutor = new R2dbcExecutor(connFactory, R2dbcProjectionImpl.log, r2dbcSettings.logDbCallsExceeding)(
+      system.executionContext,
+      system)
 
     val adaptedHandler =
       R2dbcProjectionImpl.adaptedHandlerForExactlyOnce(sourceProvider, handler, offsetStore, r2dbcExecutor)(
@@ -104,7 +106,9 @@ object R2dbcProjection {
         timestampOffsetBySlicesSourceProvider(sourceProvider),
         r2dbcSettings,
         connFactory)
-    val r2dbcExecutor = new R2dbcExecutor(connFactory, R2dbcProjectionImpl.log)(system.executionContext, system)
+    val r2dbcExecutor = new R2dbcExecutor(connFactory, R2dbcProjectionImpl.log, r2dbcSettings.logDbCallsExceeding)(
+      system.executionContext,
+      system)
 
     val adaptedHandler =
       R2dbcProjectionImpl.adaptedHandlerForAtLeastOnce(sourceProvider, handler, offsetStore, r2dbcExecutor)(
@@ -193,7 +197,9 @@ object R2dbcProjection {
         timestampOffsetBySlicesSourceProvider(sourceProvider),
         r2dbcSettings,
         connFactory)
-    val r2dbcExecutor = new R2dbcExecutor(connFactory, R2dbcProjectionImpl.log)(system.executionContext, system)
+    val r2dbcExecutor = new R2dbcExecutor(connFactory, R2dbcProjectionImpl.log, r2dbcSettings.logDbCallsExceeding)(
+      system.executionContext,
+      system)
 
     val adaptedHandler =
       R2dbcProjectionImpl.adaptedHandlerForGrouped(sourceProvider, handler, offsetStore, r2dbcExecutor)(

--- a/projection/src/test/scala/akka/projection/r2dbc/TestDbLifecycle.scala
+++ b/projection/src/test/scala/akka/projection/r2dbc/TestDbLifecycle.scala
@@ -27,7 +27,8 @@ trait TestDbLifecycle extends BeforeAndAfterAll { this: Suite =>
   lazy val r2dbcExecutor: R2dbcExecutor = {
     new R2dbcExecutor(
       ConnectionFactoryProvider(typedSystem).connectionFactoryFor(r2dbcProjectionSettings.useConnectionFactory),
-      LoggerFactory.getLogger(getClass))(typedSystem.executionContext, typedSystem)
+      LoggerFactory.getLogger(getClass),
+      r2dbcProjectionSettings.logDbCallsExceeding)(typedSystem.executionContext, typedSystem)
   }
 
   override protected def beforeAll(): Unit = {


### PR DESCRIPTION
it can also be good to know that logging of slow queries can be enabled on the Yugabyte server side: https://docs.yugabyte.com/latest/explore/query-1-performance/query-tuning-intro/#log-slow-queries