### PR TITLE
Insert offset instead of upsert, #106

### DIFF
--- a/core/src/main/scala/akka/persistence/r2dbc/state/scaladsl/DurableStateDao.scala
+++ b/core/src/main/scala/akka/persistence/r2dbc/state/scaladsl/DurableStateDao.scala
@@ -62,7 +62,8 @@ private[r2dbc] class DurableStateDao(settings: R2dbcSettings, connectionFactory:
   private val stateTable = settings.durableStateTableWithSchema
 
   private val selectStateSql: String =
-    s"SELECT * from $stateTable WHERE slice = $$1 AND entity_type = $$2 AND persistence_id = $$3"
+    "SELECT revision, state_ser_id, state_ser_manifest, state_payload, db_timestamp " +
+    s"FROM $stateTable WHERE slice = $$1 AND entity_type = $$2 AND persistence_id = $$3"
 
   private val insertStateSql: String =
     s"INSERT INTO $stateTable " +

--- a/ddl-scripts/create_tables_postgres.sql
+++ b/ddl-scripts/create_tables_postgres.sql
@@ -74,9 +74,9 @@ CREATE TABLE IF NOT EXISTS akka_projection_timestamp_offset_store (
   seq_nr BIGINT NOT NULL,
   -- timestamp_offset is the db_timestamp of the original event
   timestamp_offset timestamp with time zone NOT NULL,
-  -- last_updated is when the offset was stored
-  -- the consumer lag is last_updated - timestamp_offset
-  last_updated timestamp with time zone NOT NULL,
+  -- timestamp_consumed is when the offset was stored
+  -- the consumer lag is timestamp_consumed - timestamp_offset
+  timestamp_consumed timestamp with time zone NOT NULL,
   PRIMARY KEY(slice, projection_name, timestamp_offset, persistence_id, seq_nr)
 );
 

--- a/ddl-scripts/create_tables_postgres.sql
+++ b/ddl-scripts/create_tables_postgres.sql
@@ -77,7 +77,7 @@ CREATE TABLE IF NOT EXISTS akka_projection_timestamp_offset_store (
   -- last_updated is when the offset was stored
   -- the consumer lag is last_updated - timestamp_offset
   last_updated timestamp with time zone NOT NULL,
-  PRIMARY KEY(slice, projection_name, persistence_id)
+  PRIMARY KEY(slice, projection_name, timestamp_offset, persistence_id, seq_nr)
 );
 
 CREATE TABLE IF NOT EXISTS akka_projection_management (

--- a/ddl-scripts/create_tables_yugabyte.sql
+++ b/ddl-scripts/create_tables_yugabyte.sql
@@ -79,7 +79,7 @@ CREATE TABLE IF NOT EXISTS akka_projection_timestamp_offset_store (
   -- last_updated is when the offset was stored
   -- the consumer lag is last_updated - timestamp_offset
   last_updated timestamp with time zone NOT NULL,
-  PRIMARY KEY(slice ASC, projection_name ASC, persistence_id ASC)
+  PRIMARY KEY(slice ASC, projection_name ASC, timestamp_offset ASC, persistence_id ASC, seq_nr ASC)
 );
 
 CREATE TABLE IF NOT EXISTS akka_projection_management (

--- a/ddl-scripts/create_tables_yugabyte.sql
+++ b/ddl-scripts/create_tables_yugabyte.sql
@@ -76,9 +76,9 @@ CREATE TABLE IF NOT EXISTS akka_projection_timestamp_offset_store (
   seq_nr BIGINT NOT NULL,
   -- timestamp_offset is the db_timestamp of the original event
   timestamp_offset timestamp with time zone NOT NULL,
-  -- last_updated is when the offset was stored
-  -- the consumer lag is last_updated - timestamp_offset
-  last_updated timestamp with time zone NOT NULL,
+  -- timestamp_consumed is when the offset was stored
+  -- the consumer lag is timestamp_consumed - timestamp_offset
+  timestamp_consumed timestamp with time zone NOT NULL,
   PRIMARY KEY(slice ASC, projection_name ASC, timestamp_offset ASC, persistence_id ASC, seq_nr ASC)
 );
 

--- a/projection/src/main/scala/akka/projection/r2dbc/internal/R2dbcOffsetStore.scala
+++ b/projection/src/main/scala/akka/projection/r2dbc/internal/R2dbcOffsetStore.scala
@@ -84,7 +84,7 @@ object R2dbcOffsetStore {
               if (r.seqNr > existingRecord.seqNr)
                 acc.byPid.updated(r.pid, r)
               else
-                acc.byPid // older or same seqNr (not expected, but handled)
+                acc.byPid // older or same seqNr
             case None =>
               acc.byPid.updated(r.pid, r)
           }
@@ -101,7 +101,7 @@ object R2dbcOffsetStore {
           if (acc.oldestTimestamp == Instant.EPOCH)
             r.timestamp // first record
           else if (r.timestamp.isBefore(acc.oldestTimestamp))
-            r.timestamp // not expected, but handled
+            r.timestamp
           else
             acc.oldestTimestamp // this is the normal case
 
@@ -166,12 +166,11 @@ private[projection] class R2dbcOffsetStore(
 
   private val selectTimestampOffsetSql: String =
     "SELECT persistence_id, seq_nr, timestamp_offset " +
-    s"FROM $timestampOffsetTable WHERE slice BETWEEN $$1 AND $$2 AND projection_name = $$3 " +
-    "ORDER BY timestamp_offset"
+    s"FROM $timestampOffsetTable WHERE slice BETWEEN $$1 AND $$2 AND projection_name = $$3 "
 
   private val insertTimestampOffsetSql: String =
     s"INSERT INTO $timestampOffsetTable " +
-    "(projection_name, projection_key, slice, persistence_id, seq_nr, timestamp_offset, last_updated)  " +
+    "(projection_name, projection_key, slice, persistence_id, seq_nr, timestamp_offset, timestamp_consumed)  " +
     "VALUES ($1,$2,$3,$4,$5,$6, transaction_timestamp())"
 
   private val deleteTimestampOffsetSql: String =

--- a/projection/src/test/scala/akka/projection/r2dbc/R2dbcOffsetStoreSpec.scala
+++ b/projection/src/test/scala/akka/projection/r2dbc/R2dbcOffsetStoreSpec.scala
@@ -60,7 +60,7 @@ class R2dbcOffsetStoreSpec
 
   "The R2dbcOffsetStore" must {
 
-    s"create and update offsets" in {
+    s"save and read offsets" in {
       val projectionId = genRandomProjectionId()
       val offsetStore = createOffsetStore(projectionId)
 


### PR DESCRIPTION
* should make the deletes <= timestamp faster since
  it can use the prefix of the primary key
* note that primary key of akka_projection_timestamp_offset_store
  was changed, so existing tables must be recreated (can be populated
  with old data with 'insert into .. select * from'

References #106
