### PR TITLE
Adjust config to reduce connection errors, #157

### DIFF
--- a/core/src/main/resources/reference.conf
+++ b/core/src/main/resources/reference.conf
@@ -99,12 +99,21 @@ akka.persistence.r2dbc {
       root-cert = ""
     }
 
+    # Initial pool size.
     initial-size = 5
+    # Maximum pool size.
     max-size = 20
+    # Maximum time to create a new connection.
     create-timeout = 3 seconds
+    # Maximum time to acquire connection from pool.
     acquire-timeout = 4 seconds
-    acquire-retry = 3
+    # Number of retries if the connection acquisition attempt fails.
+    # Use the same number as max-size in case all connections in the pool
+    # are invalid because database server was restarted.
+    acquire-retry = 20
 
+    # Maximum idle time of the connection in the pool.
+    # This value is used as an interval for background eviction of idle connections.
     max-idle-time = 30 minutes
 
     # Configures the statement cache size.
@@ -112,6 +121,11 @@ akka.persistence.r2dbc {
     # a positive value will configure a bounded cache with the passed size.
     # TODO: add more elaborated description explaining when and why to use a cache
     statement-cache-size = 100
+
+    # Validate the connection when acquired with this SQL.
+    # Enabling this has some performance overhead.
+    # A fast query for Postgres is "SELECT 1"
+    validation-query = ""
   }
 
   # If database timestamp is guaranteed to not move backwards for two subsequent

--- a/core/src/main/scala/akka/persistence/r2dbc/ConnectionFactoryProvider.scala
+++ b/core/src/main/scala/akka/persistence/r2dbc/ConnectionFactoryProvider.scala
@@ -95,13 +95,13 @@ class ConnectionFactoryProvider(system: ActorSystem[_]) extends Extension {
       .maxAcquireTime(JDuration.ofMillis(settings.acquireTimeout.toMillis))
       .acquireRetry(settings.acquireRetry)
       .maxIdleTime(JDuration.ofMillis(settings.maxIdleTime.toMillis))
-//      .validationQuery("SELECT 1") // FIXME issue #157
-      .build()
 
-    val pool = new ConnectionPool(poolConfiguration)
+    if (settings.validationQuery.nonEmpty)
+      poolConfiguration.validationQuery(settings.validationQuery)
+
+    val pool = new ConnectionPool(poolConfiguration.build())
 
     // eagerly create initialSize connections
-
     pool.warmup().asFutureDone() // don't wait for it
 
     pool

--- a/core/src/main/scala/akka/persistence/r2dbc/R2dbcSettings.scala
+++ b/core/src/main/scala/akka/persistence/r2dbc/R2dbcSettings.scala
@@ -78,11 +78,13 @@ final class ConnectionFactorySettings(config: Config) {
 
   val initialSize: Int = config.getInt("initial-size")
   val maxSize: Int = config.getInt("max-size")
+  val maxIdleTime: FiniteDuration = config.getDuration("max-idle-time").asScala
+
   val createTimeout: FiniteDuration = config.getDuration("create-timeout").asScala
   val acquireTimeout: FiniteDuration = config.getDuration("acquire-timeout").asScala
   val acquireRetry: Int = config.getInt("acquire-retry")
 
-  val maxIdleTime: FiniteDuration = config.getDuration("max-idle-time").asScala
+  val validationQuery: String = config.getString("validation-query")
 
   val statementCacheSize: Int = config.getInt("statement-cache-size")
 }


### PR DESCRIPTION
* when database server is restarted all connections in the
  pool are invalid and that is not detected until they are
  acquired
* validation of the connection is performed by the
  pool on create and it will retry with the configured
  acquire-retry
* added validation-query config


Fixes #157
