### PR TITLE
API sketch of DAO extension for durable state, #90

### DIFF
--- a/core/src/main/resources/reference.conf
+++ b/core/src/main/resources/reference.conf
@@ -79,6 +79,13 @@ akka.persistence.r2dbc {
     # previous revision. There might be a small performance gain if
     # this is disabled.
     assert-single-writer = on
+
+    # Fully qualified class name of a DaoExtension that can define
+    # additional processing for Durable State upserts or deletes.
+    # The class must implement akka.persistence.r2dbc.state.javadsl.DaoExtension
+    # or akka.persistence.r2dbc.state.scaladsl.DaoExtension.
+    # It may optionally define an ActorSystem constructor parameter.
+    dao-extension = ""
   }
 }
 // #durable-state-settings

--- a/core/src/main/scala/akka/persistence/r2dbc/state/javadsl/DaoExtension.scala
+++ b/core/src/main/scala/akka/persistence/r2dbc/state/javadsl/DaoExtension.scala
@@ -1,0 +1,74 @@
+/*
+ * Copyright (C) 2021 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.persistence.r2dbc.state.javadsl
+
+import java.util.Collections
+import java.util.concurrent.CompletableFuture
+import java.util.concurrent.CompletionStage
+import java.util.{ List => JList }
+import java.util.function.{ Function => JFunction }
+
+import akka.Done
+
+object DaoExtension {
+  final class Upsert[A](
+      val persistenceId: String,
+      val entityType: String,
+      val slice: Int,
+      val revision: Long,
+      val value: A)
+
+  final class Delete(val persistenceId: String, val entityType: String, val slice: Int, revision: Long)
+
+  final class AdditionalColumn[A](name: String, bind: JFunction[Upsert[A], AnyRef])
+
+  /**
+   * To bind a column to `null` this can be returned from the `bind` function in [[AdditionalColumn]].
+   */
+  final class BindNull(columnType: Class[_])
+}
+
+/**
+ * A `DaoExtension` is a way to define additional processing for Durable State upserts or deletes.
+ *
+ * Implementation of this class can be registered in configuration property
+ * `akka.persistence.r2dbc.state.dao-extension`. The implementation may optionally define an ActorSystem constructor
+ * parameter.
+ */
+abstract class DaoExtension {
+
+  /**
+   * Override this method to use a different table for a specific `entityType`. Return `""` to use (default) configured
+   * table name.
+   */
+  def tableName(entityType: String): String = ""
+
+  /**
+   * Override this method to define additional columns that will be updated together with the Durable State upsert
+   * (insert/update). Such columns can be useful for queries on other fields than the primary key.
+   *
+   * When defining additional columns you have to amend the table definition to match those additional columns, and
+   * typically add a secondary index on the columns. You can use a different table for a specific `entityType` by
+   * defining the table name with [[DaoExtension.tableName]].
+   */
+  def additionalColumns(entityType: String): JList[DaoExtension.AdditionalColumn] =
+    Collections.emptyList()
+
+  /**
+   * Override this method to perform additional processing in the same transaction as the Durable State upsert.
+   */
+  def processOnUpsert(upsert: DaoExtension.Upsert[AnyRef], session: R2dbcSession): CompletionStage[Done] =
+    CompletableFuture.completedFuture(Done)
+
+  /**
+   * Override this method to perform additional processing in the same transaction as the Durable State delete.
+   */
+  def processOnDelete(delete: DaoExtension.Delete, session: R2dbcSession): CompletionStage[Done] =
+    CompletableFuture.completedFuture(Done)
+
+}
+
+// FIXME move R2dbcSession from akka-projection-r2dbc
+final class R2dbcSession

--- a/core/src/main/scala/akka/persistence/r2dbc/state/scaladsl/DaoExtension.scala
+++ b/core/src/main/scala/akka/persistence/r2dbc/state/scaladsl/DaoExtension.scala
@@ -1,14 +1,11 @@
 /*
- * Copyright (C) 2021 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2022 Lightbend Inc. <https://www.lightbend.com>
  */
 
-package akka.persistence.r2dbc.state.javadsl
+package akka.persistence.r2dbc.state.scaladsl
 
-import java.util.Collections
-import java.util.concurrent.CompletableFuture
-import java.util.concurrent.CompletionStage
-import java.util.{ List => JList }
-import java.util.function.{ Function => JFunction }
+import scala.collection.immutable
+import scala.concurrent.Future
 
 import akka.Done
 
@@ -22,7 +19,7 @@ object DaoExtension {
 
   final class Delete(val persistenceId: String, val entityType: String, val slice: Int, revision: Long)
 
-  final class AdditionalColumn[A](name: String, bind: JFunction[Upsert[A], AnyRef])
+  final class AdditionalColumn[A](name: String, bind: Upsert[A] => AnyRef)
 
   /**
    * To bind a column to `null` this can be returned from the `bind` function in [[AdditionalColumn]].
@@ -53,20 +50,20 @@ abstract class DaoExtension {
    * typically add a secondary index on the columns. You can use a different table for a specific `entityType` by
    * defining the table name with [[DaoExtension.tableName]].
    */
-  def additionalColumns(entityType: String): JList[DaoExtension.AdditionalColumn] =
-    Collections.emptyList()
+  def additionalColumns(entityType: String): immutable.IndexedSeq[DaoExtension.AdditionalColumn[_]] =
+    Vector.empty
 
   /**
    * Override this method to perform additional processing in the same transaction as the Durable State upsert.
    */
-  def processOnUpsert(upsert: DaoExtension.Upsert[AnyRef], session: R2dbcSession): CompletionStage[Done] =
-    CompletableFuture.completedFuture(Done)
+  def processOnUpsert(upsert: DaoExtension.Upsert[AnyRef], session: R2dbcSession): Future[Done] =
+    Future.successful(Done)
 
   /**
    * Override this method to perform additional processing in the same transaction as the Durable State delete.
    */
-  def processOnDelete(delete: DaoExtension.Delete, session: R2dbcSession): CompletionStage[Done] =
-    CompletableFuture.completedFuture(Done)
+  def processOnDelete(delete: DaoExtension.Delete, session: R2dbcSession): Future[Done] =
+    Future.successful(Done)
 
 }
 

--- a/core/src/test/scala/demo/BlogPost.scala
+++ b/core/src/test/scala/demo/BlogPost.scala
@@ -1,0 +1,106 @@
+/*
+ * Copyright (C) 2022 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package demo
+
+import akka.Done
+import akka.actor.typed.ActorRef
+import akka.actor.typed.Behavior
+import akka.actor.typed.scaladsl.Behaviors
+import akka.pattern.StatusReply
+import akka.persistence.typed.PersistenceId
+import akka.persistence.typed.state.scaladsl.Effect
+import akka.persistence.typed.state.scaladsl.DurableStateBehavior
+
+object BlogPost {
+  val EntityTypeName = "BlogPost"
+
+  sealed trait State
+
+  case object BlankState extends State
+
+  final case class DraftState(content: PostContent) extends State {
+    def withBody(newBody: String): DraftState =
+      copy(content = content.copy(body = newBody))
+
+    def postId: String = content.postId
+  }
+
+  final case class PublishedState(content: PostContent) extends State {
+    def postId: String = content.postId
+  }
+
+  sealed trait Command
+  final case class AddPost(content: PostContent, replyTo: ActorRef[StatusReply[AddPostDone]]) extends Command
+  final case class AddPostDone(postId: String)
+  final case class GetPost(replyTo: ActorRef[PostContent]) extends Command
+  final case class ChangeBody(newBody: String, replyTo: ActorRef[Done]) extends Command
+  final case class Publish(replyTo: ActorRef[Done]) extends Command
+  final case class PostContent(postId: String, title: String, body: String)
+
+  def apply(entityId: String, persistenceId: PersistenceId): Behavior[Command] = {
+    Behaviors.setup { context =>
+      context.log.info("Starting BlogPostEntityDurableState {}", entityId)
+      DurableStateBehavior[Command, State](persistenceId, emptyState = BlankState, commandHandler)
+    }
+  }
+
+  private val commandHandler: (State, Command) => Effect[State] = { (state, command) =>
+    state match {
+
+      case BlankState =>
+        command match {
+          case cmd: AddPost => addPost(cmd)
+          case _            => Effect.unhandled
+        }
+
+      case draftState: DraftState =>
+        command match {
+          case cmd: ChangeBody  => changeBody(draftState, cmd)
+          case Publish(replyTo) => publish(draftState, replyTo)
+          case GetPost(replyTo) => getPost(draftState, replyTo)
+          case AddPost(_, replyTo) =>
+            Effect.unhandled[State].thenRun(_ => replyTo ! StatusReply.Error("Cannot add post while in draft state"))
+        }
+
+      case publishedState: PublishedState =>
+        command match {
+          case GetPost(replyTo) => getPost(publishedState, replyTo)
+          case AddPost(_, replyTo) =>
+            Effect.unhandled[State].thenRun(_ => replyTo ! StatusReply.Error("Cannot add post, already published"))
+          case _ => Effect.unhandled
+        }
+    }
+  }
+
+  private def addPost(cmd: AddPost): Effect[State] = {
+    Effect.persist(DraftState(cmd.content)).thenRun { _ =>
+      cmd.replyTo ! StatusReply.Success(AddPostDone(cmd.content.postId))
+    }
+  }
+
+  private def changeBody(state: DraftState, cmd: ChangeBody): Effect[State] = {
+    Effect.persist(state.withBody(cmd.newBody)).thenRun { _ =>
+      cmd.replyTo ! Done
+    }
+  }
+
+  private def publish(state: DraftState, replyTo: ActorRef[Done]): Effect[State] = {
+    Effect.persist(PublishedState(state.content)).thenRun { _ =>
+      println(s"Blog post ${state.postId} was published")
+      replyTo ! Done
+    }
+  }
+
+  private def getPost(state: DraftState, replyTo: ActorRef[PostContent]): Effect[State] = {
+    replyTo ! state.content
+    Effect.none
+  }
+
+  private def getPost(state: PublishedState, replyTo: ActorRef[PostContent]): Effect[State] = {
+    replyTo ! state.content
+    Effect.none
+  }
+
+}

--- a/core/src/test/scala/demo/DemoAdditionalColumn.scala
+++ b/core/src/test/scala/demo/DemoAdditionalColumn.scala
@@ -1,0 +1,38 @@
+/*
+ * Copyright (C) 2022 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package demo
+
+import akka.persistence.r2dbc.state.scaladsl.DaoExtension
+
+object DemoAdditionalColumn {
+  class CustomDurableState extends DaoExtension {
+    override def tableName(entityType: String): String = {
+      if (entityType == BlogPost.EntityTypeName)
+        "durable_state_blog_post"
+      else
+        super.tableName(entityType)
+    }
+
+    override def additionalColumns(entityType: String): IndexedSeq[DaoExtension.AdditionalColumn[_]] =
+      if (entityType == BlogPost.EntityTypeName) {
+        val titleColumn =
+          DaoExtension.AdditionalColumn[BlogPost.State](
+            "title",
+            stateUpsert =>
+              stateUpsert.value match {
+                case BlogPost.BlankState =>
+                  DaoExtension.BindNull(classOf[String])
+                case s: BlogPost.DraftState =>
+                  s.content.title
+                case _: BlogPost.PublishedState =>
+                  DaoExtension.Skip
+              })
+        Vector(titleColumn)
+      } else {
+        super.additionalColumns(entityType)
+      }
+  }
+
+}

--- a/core/src/test/scala/demo/DemoAdditionalTable.scala
+++ b/core/src/test/scala/demo/DemoAdditionalTable.scala
@@ -1,0 +1,69 @@
+/*
+ * Copyright (C) 2022 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package demo
+
+import scala.concurrent.ExecutionContext
+import scala.concurrent.Future
+
+import akka.Done
+import akka.actor.typed.ActorSystem
+import akka.persistence.r2dbc.state.scaladsl.DaoExtension
+import akka.persistence.r2dbc.state.scaladsl.R2dbcSession
+import akka.persistence.r2dbc.internal.Sql.Interpolation
+
+object DemoAdditionalTable {
+
+  /**
+   * Keep track of number of published blog posts. Count per slice.
+   *
+   * {{{
+   * CREATE TABLE post_count (slice INT NOT NULL, cnt BIGINT NOT NULL, PRIMARY KEY(slice));
+   * }}}
+   */
+  class CustomDurableState(system: ActorSystem[_]) extends DaoExtension {
+    val incrementSql = sql"""
+        INSERT INTO post_count
+        (slice, cnt)
+        VALUES (?, 1)
+        ON CONFLICT (slice)
+        DO UPDATE SET
+          cnt = excluded.cnt + 1
+        """
+
+    val decrementSql = sql"""
+        UPDATE post_count SET cnt = cnt - 1 WHERE slice = ?;
+        """
+
+    private implicit val ec: ExecutionContext = system.executionContext
+
+    override def processOnUpsert(upsert: DaoExtension.Upsert[AnyRef], session: R2dbcSession): Future[Done] = {
+      if (upsert.entityType == BlogPost.EntityTypeName) {
+        upsert.value match {
+          case _: BlogPost.PublishedState =>
+            val stmt = session
+              .createStatement(incrementSql)
+              .bind(0, upsert.slice)
+            session.updateOne(stmt).map(_ => Done)
+          case _ =>
+            Future.successful(Done)
+        }
+      } else {
+        super.processOnUpsert(upsert, session)
+      }
+    }
+
+    override def processOnDelete(delete: DaoExtension.Delete, session: R2dbcSession): Future[Done] = {
+      if (delete.entityType == BlogPost.EntityTypeName) {
+        val stmt = session
+          .createStatement(decrementSql)
+          .bind(0, delete.slice)
+        session.updateOne(stmt).map(_ => Done)
+      } else {
+        super.processOnDelete(delete, session)
+      }
+    }
+  }
+
+}


### PR DESCRIPTION
* for storing query representation from the write side
* in same transaction as the upsert
* support for additional columns in the durable_state table, for secondary indexes
* support for any additional statements for storing more complex
  representations, such as in a secondary table

@ihostage would this cover what you requested in https://github.com/akka/akka-persistence-r2dbc/issues/90 ?