### PR TITLE
Option to use application timestamp

### DIFF
--- a/core/src/main/resources/reference.conf
+++ b/core/src/main/resources/reference.conf
@@ -134,6 +134,10 @@ akka.persistence.r2dbc {
   # move backwards when the system clock is adjusted.
   db-timestamp-monotonic-increasing = off
 
+  # Enable this for testing or workaround of https://github.com/yugabyte/yugabyte-db/issues/10995
+  # FIXME: This property will be removed when the Yugabyte issue has been resolved.
+  use-app-timestamp = off
+
   # Logs database calls that take longer than this duration at INFO level.
   # Set to "off" to disable this logging.
   # Set to 0 to log all calls.

--- a/core/src/main/scala/akka/persistence/r2dbc/R2dbcSettings.scala
+++ b/core/src/main/scala/akka/persistence/r2dbc/R2dbcSettings.scala
@@ -8,6 +8,7 @@ import java.util.Locale
 
 import scala.concurrent.duration._
 
+import akka.annotation.InternalApi
 import akka.annotation.InternalStableApi
 import akka.util.JavaDurationConverters._
 import com.typesafe.config.Config
@@ -37,6 +38,11 @@ final class R2dbcSettings(config: Config) {
   val connectionFactorySettings = new ConnectionFactorySettings(config.getConfig("connection-factory"))
 
   val dbTimestampMonotonicIncreasing: Boolean = config.getBoolean("db-timestamp-monotonic-increasing")
+
+  /**
+   * INTERNAL API FIXME remove when https://github.com/yugabyte/yugabyte-db/issues/10995 has been resolved
+   */
+  @InternalApi private[akka] val useAppTimestamp: Boolean = config.getBoolean("use-app-timestamp")
 
   val logDbCallsExceeding: FiniteDuration =
     config.getString("log-db-calls-exceeding").toLowerCase(Locale.ROOT) match {


### PR DESCRIPTION
* as temporary workaround for performance testing
