### PR TITLE
Update to R2DBC 0.9.0

### DIFF
--- a/core/src/main/scala/akka/persistence/r2dbc/ConnectionFactoryProvider.scala
+++ b/core/src/main/scala/akka/persistence/r2dbc/ConnectionFactoryProvider.scala
@@ -95,6 +95,8 @@ class ConnectionFactoryProvider(system: ActorSystem[_]) extends Extension {
       .maxAcquireTime(JDuration.ofMillis(settings.acquireTimeout.toMillis))
       .acquireRetry(settings.acquireRetry)
       .maxIdleTime(JDuration.ofMillis(settings.maxIdleTime.toMillis))
+      // setting lifetime due to issue https://github.com/r2dbc/r2dbc-pool/issues/129
+      .maxLifeTime(JDuration.ofDays(365 * 100))
 
     if (settings.validationQuery.nonEmpty)
       poolConfiguration.validationQuery(settings.validationQuery)

--- a/core/src/main/scala/akka/persistence/r2dbc/journal/JournalDao.scala
+++ b/core/src/main/scala/akka/persistence/r2dbc/journal/JournalDao.scala
@@ -205,7 +205,8 @@ private[r2dbc] class JournalDao(journalSettings: R2dbcSettings, connectionFactor
       val result = r2dbcExecutor.updateInBatchReturning(s"batch insert [$persistenceId], [$totalEvents] events")(
         connection =>
           events.foldLeft(connection.createStatement(insertSql)) { (stmt, write) =>
-            bind(stmt, write).add()
+            stmt.add()
+            bind(stmt, write)
           },
         row => row.get(0, classOf[Instant]))
       if (log.isDebugEnabled())

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -20,11 +20,11 @@ object Dependencies {
 
     val akkaProjectionCore = "com.lightbend.akka" %% "akka-projection-core" % AkkaProjectionVersion
 
-    val postgresql = "org.postgresql" % "postgresql" % "42.2.24"
+    val postgresql = "org.postgresql" % "postgresql" % "42.3.1"
 
-    val r2dbcSpi = "io.r2dbc" % "r2dbc-spi" % "0.8.6.RELEASE"
-    val r2dbcPool = "io.r2dbc" % "r2dbc-pool" % "0.8.7.RELEASE"
-    val r2dbcPostgres = "io.r2dbc" % "r2dbc-postgresql" % "0.8.10.RELEASE"
+    val r2dbcSpi = "io.r2dbc" % "r2dbc-spi" % "0.9.0.RELEASE"
+    val r2dbcPool = "io.r2dbc" % "r2dbc-pool" % "0.9.0.RELEASE"
+    val r2dbcPostgres = "org.postgresql" % "r2dbc-postgresql" % "0.9.0.RELEASE"
   }
 
   object TestDeps {
@@ -41,7 +41,7 @@ object Dependencies {
       "com.lightbend.akka" %% "akka-projection-durable-state" % AkkaProjectionVersion % Test
     val akkaProjectionTestKit = "com.lightbend.akka" %% "akka-projection-testkit" % AkkaProjectionVersion % Test
 
-    val logback = "ch.qos.logback" % "logback-classic" % "1.2.9" % Test // EPL 1.0 / LGPL 2.1
+    val logback = "ch.qos.logback" % "logback-classic" % "1.2.10" % Test // EPL 1.0 / LGPL 2.1
     val scalaTest = "org.scalatest" %% "scalatest" % "3.1.4" % Test // ApacheV2
     val junit = "junit" % "junit" % "4.12" % Test // Eclipse Public License 1.0
     val junitInterface = "com.novocode" % "junit-interface" % "0.11" % Test // "BSD 2-Clause"

--- a/projection/src/main/scala/akka/projection/r2dbc/internal/R2dbcOffsetStore.scala
+++ b/projection/src/main/scala/akka/projection/r2dbc/internal/R2dbcOffsetStore.scala
@@ -468,7 +468,8 @@ private[projection] class R2dbcOffsetStore(
           // TODO Try Batch without bind parameters for better performance. Risk of sql injection for these parameters is low.
           val boundStatement =
             filteredRecords.foldLeft(statement) { (stmt, rec) =>
-              bindRecord(stmt, rec).add()
+              stmt.add()
+              bindRecord(stmt, rec)
             }
           R2dbcExecutor.updateBatchInTx(boundStatement)
         }


### PR DESCRIPTION
* stmt .add() must not be at the end, any more
* workaround for connection pool bug when maxLifeTime isn't set
* verified that performance is the same

