### PR TITLE
Store tags, but no query yet

### DIFF
--- a/core/src/main/scala/akka/persistence/r2dbc/state/scaladsl/R2dbcDurableStateStore.scala
+++ b/core/src/main/scala/akka/persistence/r2dbc/state/scaladsl/R2dbcDurableStateStore.scala
@@ -95,12 +95,12 @@ class R2dbcDurableStateStore[A](system: ExtendedActorSystem, config: Config, cfg
       DurableStateDao.EmptyDbTimestamp,
       serialized,
       serializer.identifier,
-      manifest)
+      manifest,
+      if (tag.isEmpty) Set.empty else Set(tag))
 
     stateDao.writeState(serializedRow)
 
   }
-
   override def deleteObject(persistenceId: String): Future[Done] =
     stateDao.deleteState(persistenceId)
 

--- a/core/src/test/scala/akka/persistence/r2dbc/TestActors.scala
+++ b/core/src/test/scala/akka/persistence/r2dbc/TestActors.scala
@@ -33,10 +33,18 @@ object TestActors {
       apply(PersistenceId.ofUniqueId(pid))
 
     def apply(pid: PersistenceId): Behavior[Command] = {
-      apply(pid, "", "")
+      apply(pid, "", "", Set.empty)
     }
 
-    def apply(pid: PersistenceId, journalPluginId: String, snapshotPluginId: String): Behavior[Command] = {
+    def apply(pid: PersistenceId, tags: Set[String]): Behavior[Command] = {
+      apply(pid, "", "", tags)
+    }
+
+    def apply(
+        pid: PersistenceId,
+        journalPluginId: String,
+        snapshotPluginId: String,
+        tags: Set[String]): Behavior[Command] = {
       Behaviors.setup { context =>
         eventSourcedBehavior(pid, context)
           .withJournalPluginId(journalPluginId)
@@ -44,6 +52,7 @@ object TestActors {
           .snapshotWhen { case (_, event, _) =>
             event.toString.contains("snap")
           }
+          .withTagger(_ => tags)
       }
     }
 

--- a/core/src/test/scala/akka/persistence/r2dbc/journal/PersistTagsSpec.scala
+++ b/core/src/test/scala/akka/persistence/r2dbc/journal/PersistTagsSpec.scala
@@ -1,0 +1,79 @@
+/*
+ * Copyright (C) 2021 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.persistence.r2dbc.journal
+
+import scala.concurrent.duration._
+
+import akka.Done
+import akka.actor.testkit.typed.scaladsl.LogCapturing
+import akka.actor.testkit.typed.scaladsl.ScalaTestWithActorTestKit
+import akka.actor.typed.ActorSystem
+import akka.persistence.r2dbc.R2dbcSettings
+import akka.persistence.r2dbc.TestActors.Persister
+import akka.persistence.r2dbc.TestConfig
+import akka.persistence.r2dbc.TestData
+import akka.persistence.r2dbc.TestDbLifecycle
+import akka.persistence.typed.PersistenceId
+import org.scalatest.wordspec.AnyWordSpecLike
+
+class PersistTagsSpec
+    extends ScalaTestWithActorTestKit(TestConfig.config)
+    with AnyWordSpecLike
+    with TestDbLifecycle
+    with TestData
+    with LogCapturing {
+
+  override def typedSystem: ActorSystem[_] = system
+  private val settings = new R2dbcSettings(system.settings.config.getConfig("akka.persistence.r2dbc"))
+
+  case class Row(pid: String, seqNr: Long, tags: Set[String])
+
+  "Persist tags" should {
+
+    "be the same for events stored in same transaction" in {
+      val numberOfEntities = 9
+      val entityType = nextEntityType()
+
+      val entities = (0 until numberOfEntities).map { n =>
+        val persistenceId = PersistenceId(entityType, s"p$n")
+        val tags = Set(entityType, s"tag-p$n")
+        spawn(Persister(persistenceId, tags), s"p$n")
+      }
+
+      entities.foreach { ref =>
+        ref ! Persister.Persist("e1")
+      }
+
+      val pingProbe = createTestProbe[Done]()
+      entities.foreach { ref =>
+        ref ! Persister.Ping(pingProbe.ref)
+      }
+      pingProbe.receiveMessages(entities.size, 20.seconds)
+
+      val rows =
+        r2dbcExecutor
+          .select[Row]("test")(
+            connection => connection.createStatement(s"select * from ${settings.journalTableWithSchema}"),
+            row => {
+              val tags = row.get("tags", classOf[Array[String]]) match {
+                case null      => Set.empty[String]
+                case tagsArray => tagsArray.toSet
+              }
+              Row(
+                pid = row.get("persistence_id", classOf[String]),
+                seqNr = row.get("seq_nr", classOf[java.lang.Long]),
+                tags)
+            })
+          .futureValue
+
+      rows.foreach { case Row(pid, _, tags) =>
+        withClue(s"pid [$pid}]: ") {
+          tags shouldBe Set(PersistenceId.extractEntityType(pid), s"tag-${PersistenceId.extractEntityId(pid)}")
+        }
+      }
+    }
+
+  }
+}

--- a/ddl-scripts/create_tables_postgres.sql
+++ b/ddl-scripts/create_tables_postgres.sql
@@ -12,6 +12,7 @@ CREATE TABLE IF NOT EXISTS event_journal(
   deleted BOOLEAN DEFAULT FALSE NOT NULL,
   writer VARCHAR(255) NOT NULL,
   adapter_manifest VARCHAR(255),
+  tags TEXT ARRAY,
 
   meta_ser_id INTEGER,
   meta_ser_manifest VARCHAR(255),
@@ -49,6 +50,7 @@ CREATE TABLE IF NOT EXISTS durable_state (
   state_ser_id INTEGER NOT NULL,
   state_ser_manifest VARCHAR(255),
   state_payload BYTEA NOT NULL,
+  tags TEXT ARRAY,
 
   PRIMARY KEY(persistence_id, revision)
 );

--- a/ddl-scripts/create_tables_yugabyte.sql
+++ b/ddl-scripts/create_tables_yugabyte.sql
@@ -12,6 +12,7 @@ CREATE TABLE IF NOT EXISTS event_journal(
   deleted BOOLEAN DEFAULT FALSE NOT NULL,
   writer VARCHAR(255) NOT NULL,
   adapter_manifest VARCHAR(255),
+  tags TEXT ARRAY,
 
   meta_ser_id INTEGER,
   meta_ser_manifest VARCHAR(255),
@@ -50,6 +51,7 @@ CREATE TABLE IF NOT EXISTS durable_state (
   state_ser_id INTEGER NOT NULL,
   state_ser_manifest VARCHAR(255),
   state_payload BYTEA NOT NULL,
+  tags TEXT ARRAY,
 
   PRIMARY KEY(persistence_id HASH, revision ASC)
 );


### PR DESCRIPTION
* Nice to not just ignore the tags but at least store them for possible future usage.
* I think it can be useful to have a eventsBySlices query with additional tag condition
  to be able to have a filter of what entities to fetch.

Table changes:
```
ALTER TABLE event_journal ADD tags TEXT ARRAY;
ALTER TABLE durable_state ADD tags TEXT ARRAY;
```

See #82
