### PR TITLE
updated documentation for durable state store

### DIFF
--- a/docs/src/main/paradox/durable-state-store.md
+++ b/docs/src/main/paradox/durable-state-store.md
@@ -13,7 +13,7 @@ The `durable_state_slice_idx` index is only needed if the slice based @ref:[quer
 To enable the journal plugin to be used by default, add the following line to your Akka `application.conf`:
 
 ```
-akka.persistence.state.plugin = "akka.persistence.r2dbc.durable-state-store"
+akka.persistence.state.plugin = "akka.persistence.r2dbc.state"
 ```
 
 It can also be enabled with the `durableStateStorePluginId` for a specific `DurableStateBehavior` and multiple

--- a/docs/src/main/paradox/getting-started.md
+++ b/docs/src/main/paradox/getting-started.md
@@ -21,7 +21,7 @@ To enable the plugins to be used by default, add the following line to your Akka
 ```
 akka.persistence.journal.plugin = "akka.persistence.r2dbc.journal"
 akka.persistence.snapshot-store.plugin = "akka.persistence.r2dbc.snapshot"
-akka.persistence.state.plugin = "akka.persistence.r2dbc.durable-state-store"
+akka.persistence.state.plugin = "akka.persistence.r2dbc.state"
 ```
 
 More information in:

--- a/docs/src/test/resources/application-postgres.conf
+++ b/docs/src/test/resources/application-postgres.conf
@@ -1,7 +1,7 @@
 
 akka.persistence.journal.plugin = "akka.persistence.r2dbc.journal"
 akka.persistence.snapshot-store.plugin = "akka.persistence.r2dbc.snapshot"
-akka.persistence.state.plugin = "akka.persistence.r2dbc.durable-state-store"
+akka.persistence.state.plugin = "akka.persistence.r2dbc.state"
 
 // #connection-settings
 akka.persistence.r2dbc {


### PR DESCRIPTION
From what I can [tell](https://github.com/akka/akka-persistence-r2dbc/blob/main/core/src/main/resources/reference.conf#L43) The plugin is called `state` not `durable-state-store`