### PR TITLE
Upper bound on db_timestamp in eventsBySlices query, #178

### DIFF
--- a/core/src/main/scala/akka/persistence/r2dbc/state/scaladsl/DurableStateDao.scala
+++ b/core/src/main/scala/akka/persistence/r2dbc/state/scaladsl/DurableStateDao.scala
@@ -336,4 +336,13 @@ private[r2dbc] class DurableStateDao(settings: R2dbcSettings, connectionFactory:
     Source.futureSource(result.map(Source(_))).mapMaterializedValue(_ => NotUsed)
   }
 
+  override def eventCountBuckets(
+      entityType: String,
+      minSlice: Int,
+      maxSlice: Int,
+      fromTimestamp: Instant,
+      limit: Int): Future[Seq[(Long, Long)]] = {
+    // FIXME look into if this is also needed for durable state
+    Future.successful(Nil)
+  }
 }

--- a/core/src/main/scala/akka/persistence/r2dbc/state/scaladsl/DurableStateDao.scala
+++ b/core/src/main/scala/akka/persistence/r2dbc/state/scaladsl/DurableStateDao.scala
@@ -19,6 +19,7 @@ import akka.persistence.Persistence
 import akka.persistence.r2dbc.R2dbcSettings
 import akka.persistence.r2dbc.internal.Sql.Interpolation
 import akka.persistence.r2dbc.internal.BySliceQuery
+import akka.persistence.r2dbc.internal.BySliceQuery.Buckets.Bucket
 import akka.persistence.r2dbc.internal.R2dbcExecutor
 import akka.persistence.typed.PersistenceId
 import akka.stream.scaladsl.Source
@@ -341,8 +342,8 @@ private[r2dbc] class DurableStateDao(settings: R2dbcSettings, connectionFactory:
       minSlice: Int,
       maxSlice: Int,
       fromTimestamp: Instant,
-      limit: Int): Future[Seq[(Long, Long)]] = {
-    // FIXME look into if this is also needed for durable state
+      limit: Int): Future[Seq[Bucket]] = {
+    // FIXME implement this, issue https://github.com/akka/akka-persistence-r2dbc/issues/212
     Future.successful(Nil)
   }
 }

--- a/core/src/test/scala/akka/persistence/r2dbc/internal/BySliceQueryBucketsSpec.scala
+++ b/core/src/test/scala/akka/persistence/r2dbc/internal/BySliceQueryBucketsSpec.scala
@@ -7,6 +7,7 @@ package akka.persistence.r2dbc.internal
 import java.time.Instant
 
 import akka.persistence.r2dbc.internal.BySliceQuery.Buckets
+import akka.persistence.r2dbc.internal.BySliceQuery.Buckets.Bucket
 import akka.persistence.r2dbc.internal.BySliceQuery.Buckets.BucketDurationSeconds
 import org.scalatest.TestSuite
 import org.scalatest.matchers.should.Matchers
@@ -31,12 +32,12 @@ class BySliceQueryBucketsSpec extends AnyWordSpec with TestSuite with Matchers {
     Buckets.empty
       .add(
         List(
-          bucketStartEpochSeconds(0) -> 101,
-          bucketStartEpochSeconds(1) -> 202,
-          bucketStartEpochSeconds(2) -> 303,
-          bucketStartEpochSeconds(3) -> 304,
-          bucketStartEpochSeconds(4) -> 305,
-          bucketStartEpochSeconds(5) -> 306))
+          Bucket(bucketStartEpochSeconds(0), 101),
+          Bucket(bucketStartEpochSeconds(1), 202),
+          Bucket(bucketStartEpochSeconds(2), 303),
+          Bucket(bucketStartEpochSeconds(3), 304),
+          Bucket(bucketStartEpochSeconds(4), 305),
+          Bucket(bucketStartEpochSeconds(5), 306)))
   }
 
   "BySliceQuery.Buckets" should {

--- a/core/src/test/scala/akka/persistence/r2dbc/internal/BySliceQueryBucketsSpec.scala
+++ b/core/src/test/scala/akka/persistence/r2dbc/internal/BySliceQueryBucketsSpec.scala
@@ -1,0 +1,79 @@
+/*
+ * Copyright (C) 2021 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.persistence.r2dbc.internal
+
+import java.time.Instant
+
+import akka.persistence.r2dbc.internal.BySliceQuery.Buckets
+import akka.persistence.r2dbc.internal.BySliceQuery.Buckets.BucketDurationSeconds
+import org.scalatest.TestSuite
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+
+class BySliceQueryBucketsSpec extends AnyWordSpec with TestSuite with Matchers {
+
+  private val startTime = Instant.now()
+  private val firstBucketStartTime = startTime.plusSeconds(60)
+  private val firstBucketStartEpochSeconds = firstBucketStartTime.toEpochMilli / 1000
+
+  private def bucketStartEpochSeconds(bucketIndex: Int): Long =
+    firstBucketStartEpochSeconds + BucketDurationSeconds * bucketIndex
+
+  private def bucketEndEpochSeconds(bucketIndex: Int): Long =
+    bucketStartEpochSeconds(bucketIndex) + BucketDurationSeconds
+
+  private def bucketEndTime(bucketIndex: Int): Instant =
+    Instant.ofEpochSecond(bucketEndEpochSeconds(bucketIndex))
+
+  private val buckets = {
+    Buckets.empty
+      .add(
+        List(
+          bucketStartEpochSeconds(0) -> 101,
+          bucketStartEpochSeconds(1) -> 202,
+          bucketStartEpochSeconds(2) -> 303,
+          bucketStartEpochSeconds(3) -> 304,
+          bucketStartEpochSeconds(4) -> 305,
+          bucketStartEpochSeconds(5) -> 306))
+  }
+
+  "BySliceQuery.Buckets" should {
+    "find time for events limit" in {
+      buckets.findTimeForEventsLimit(startTime, 100) shouldBe Some(bucketEndTime(0))
+
+      // not including the bucket that includes the `from` time
+      buckets.findTimeForEventsLimit(firstBucketStartTime, 100) shouldBe Some(bucketEndTime(1))
+      buckets.findTimeForEventsLimit(firstBucketStartTime.plusSeconds(9), 100) shouldBe Some(bucketEndTime(1))
+      buckets.findTimeForEventsLimit(firstBucketStartTime.plusSeconds(10), 100) shouldBe Some(bucketEndTime(2))
+      buckets.findTimeForEventsLimit(firstBucketStartTime.plusSeconds(11), 100) shouldBe Some(bucketEndTime(2))
+
+      // 202 + 303 >= 500
+      buckets.findTimeForEventsLimit(firstBucketStartTime.plusSeconds(3), 500) shouldBe Some(bucketEndTime(2))
+      // 202 + 303 >= 505
+      buckets.findTimeForEventsLimit(firstBucketStartTime.plusSeconds(3), 505) shouldBe Some(bucketEndTime(2))
+      // 202 + 303 + 304 >= 506
+      buckets.findTimeForEventsLimit(firstBucketStartTime.plusSeconds(3), 506) shouldBe Some(bucketEndTime(3))
+
+      buckets.findTimeForEventsLimit(firstBucketStartTime.plusSeconds(3), 1000) shouldBe Some(bucketEndTime(4))
+      buckets.findTimeForEventsLimit(firstBucketStartTime.plusSeconds(3), 1400) shouldBe Some(bucketEndTime(5))
+      buckets.findTimeForEventsLimit(firstBucketStartTime.plusSeconds(3), 1500) shouldBe None
+    }
+
+    "clear until time" in {
+      buckets.clearUntil(startTime).size shouldBe buckets.size
+      buckets.clearUntil(firstBucketStartTime).size shouldBe buckets.size
+      buckets.clearUntil(firstBucketStartTime.plusSeconds(9)).size shouldBe buckets.size
+
+      buckets.clearUntil(firstBucketStartTime.plusSeconds(10)).size shouldBe buckets.size - 1
+      buckets.clearUntil(firstBucketStartTime.plusSeconds(11)).size shouldBe buckets.size - 1
+      buckets.clearUntil(firstBucketStartTime.plusSeconds(19)).size shouldBe buckets.size - 1
+
+      buckets.clearUntil(firstBucketStartTime.plusSeconds(31)).size shouldBe buckets.size - 3
+      buckets.clearUntil(firstBucketStartTime.plusSeconds(100)).size shouldBe 1 // keep last
+    }
+
+  }
+
+}

--- a/core/src/test/scala/akka/persistence/r2dbc/journal/TestDataGenerator.scala
+++ b/core/src/test/scala/akka/persistence/r2dbc/journal/TestDataGenerator.scala
@@ -1,0 +1,91 @@
+/*
+ * Copyright (C) 2021 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.persistence.r2dbc.journal
+
+import java.util.UUID
+
+import scala.concurrent.duration._
+import scala.util.Failure
+import scala.util.Random
+import scala.util.Success
+
+import akka.Done
+import akka.actor.typed.ActorRef
+import akka.actor.typed.ActorSystem
+import akka.actor.typed.Behavior
+import akka.actor.typed.scaladsl.Behaviors
+import akka.persistence.r2dbc.TestActors.Persister
+import akka.persistence.r2dbc.TestConfig
+import akka.persistence.typed.PersistenceId
+import akka.util.Timeout
+import com.typesafe.config.ConfigFactory
+
+/**
+ * App to store many events as test data. Useful when analyzing query plans and performance.
+ *
+ * Before running this you must:
+ *   - Create the table (and index) `test_journal` corresponding to `event_journal`
+ *   - Change logback-test.xml to only use STDOUT (no capturing)
+ */
+object TestDataGenerator {
+
+  def main(args: Array[String]): Unit = {
+    val config = ConfigFactory
+      .parseString("""
+      akka.persistence.r2dbc {
+        journal.table = test_journal
+      }
+      """)
+      .withFallback(TestConfig.config)
+    ActorSystem(Generator(), "GenerateData", config)
+  }
+
+  object Generator {
+    sealed trait Command
+    case object Next extends Command
+
+    val parallelism = 10
+    val numEntities = 10000
+    val numEvents = 100000
+
+    val rnd = new Random(seed = 0)
+    implicit val askTimeout: Timeout = 10.seconds
+
+    def apply(): Behavior[Command] = {
+      Behaviors.setup { context =>
+        (0 until parallelism).foreach(_ => context.self ! Next)
+        behavior(numEvents, Map.empty)
+      }
+    }
+
+    private def behavior(remaining: Int, entities: Map[Int, ActorRef[Persister.Command]]): Behavior[Command] = {
+      Behaviors.receive { case (context, Next) =>
+        if (remaining == 0)
+          Behaviors.stopped
+        else {
+          if (remaining % 1000 == 0)
+            context.log.info("Remaining [{}]", remaining)
+
+          val i = rnd.nextInt(numEntities)
+          val ref = entities.getOrElse(
+            i, {
+              val entityId = UUID.randomUUID().toString
+              val pid = PersistenceId("test", entityId)
+              context.spawn(Persister(pid), entityId)
+            })
+
+          val event = s"evt-${UUID.randomUUID()}"
+          context.ask[Persister.PersistWithAck, Done](ref, Persister.PersistWithAck(event, _)) {
+            case Success(_)   => Next
+            case Failure(exc) => throw exc
+          }
+
+          behavior(remaining - 1, entities.updated(i, ref))
+        }
+      }
+    }
+  }
+
+}

--- a/ddl-scripts/create_tables_postgres.sql
+++ b/ddl-scripts/create_tables_postgres.sql
@@ -1,4 +1,4 @@
-CREATE TABLE IF NOT EXISTS event_journal(
+CREATE TABLE IF NOT EXISTS test_journal(
   slice INT NOT NULL,
   entity_type VARCHAR(255) NOT NULL,
   persistence_id VARCHAR(255) NOT NULL,
@@ -22,7 +22,7 @@ CREATE TABLE IF NOT EXISTS event_journal(
 );
 
 -- `event_journal_slice_idx` is only needed if the slice based queries are used
-CREATE INDEX IF NOT EXISTS event_journal_slice_idx ON event_journal(slice, entity_type, db_timestamp);
+CREATE INDEX IF NOT EXISTS event_journal_slice_idx ON event_journal(slice, entity_type, db_timestamp, seq_nr);
 
 CREATE TABLE IF NOT EXISTS snapshot(
   slice INT NOT NULL,
@@ -56,7 +56,7 @@ CREATE TABLE IF NOT EXISTS durable_state (
 );
 
 -- `durable_state_slice_idx` is only needed if the slice based queries are used
-CREATE INDEX IF NOT EXISTS durable_state_slice_idx ON durable_state(slice, entity_type, db_timestamp);
+CREATE INDEX IF NOT EXISTS durable_state_slice_idx ON durable_state(slice, entity_type, db_timestamp, revision);
 
 -- Primitive offset types are stored in this table.
 -- If only timestamp based offsets are used this table is optional.

--- a/ddl-scripts/create_tables_postgres.sql
+++ b/ddl-scripts/create_tables_postgres.sql
@@ -1,4 +1,4 @@
-CREATE TABLE IF NOT EXISTS test_journal(
+CREATE TABLE IF NOT EXISTS event_journal(
   slice INT NOT NULL,
   entity_type VARCHAR(255) NOT NULL,
   persistence_id VARCHAR(255) NOT NULL,

--- a/ddl-scripts/create_tables_yugabyte.sql
+++ b/ddl-scripts/create_tables_yugabyte.sql
@@ -22,7 +22,7 @@ CREATE TABLE IF NOT EXISTS event_journal(
 );
 
 -- `event_journal_slice_idx` is only needed if the slice based queries are used
-CREATE INDEX IF NOT EXISTS event_journal_slice_idx ON event_journal(slice ASC, entity_type ASC, db_timestamp ASC)
+CREATE INDEX IF NOT EXISTS event_journal_slice_idx ON event_journal(slice ASC, entity_type ASC, db_timestamp ASC, seq_nr ASC, persistence_id, deleted)
   SPLIT AT VALUES ((127), (255), (383), (511), (639), (767), (895));
 
 CREATE TABLE IF NOT EXISTS snapshot(
@@ -57,7 +57,7 @@ CREATE TABLE IF NOT EXISTS durable_state (
 );
 
 -- `durable_state_slice_idx` is only needed if the slice based queries are used
-CREATE INDEX IF NOT EXISTS durable_state_slice_idx ON durable_state(slice ASC, entity_type ASC, db_timestamp ASC)
+CREATE INDEX IF NOT EXISTS durable_state_slice_idx ON durable_state(slice ASC, entity_type ASC, db_timestamp ASC, revision ASC, persistence_id)
   SPLIT AT VALUES ((127), (255), (383), (511), (639), (767), (895));
 
 -- Primitive offset types are stored in this table.


### PR DESCRIPTION
* reduce result set that is sorted before limit is applied
* fetch event counts in buckets with aggregate query and use that
  to estimate the `db_timestamp < ?` that is needed to reach the limit
* also include some more columns in index to make the backtracking
  query IndexOnly Scan (no fetch from parent table)

Fixes #178
