### PR TITLE
Background eviction interval must be set

### DIFF
--- a/core/src/main/scala/akka/persistence/r2dbc/ConnectionFactoryProvider.scala
+++ b/core/src/main/scala/akka/persistence/r2dbc/ConnectionFactoryProvider.scala
@@ -106,6 +106,7 @@ class ConnectionFactoryProvider(system: ActorSystem[_]) extends Extension {
       .maxIdleTime(JDuration.ofMillis(settings.maxIdleTime.toMillis))
       // setting lifetime due to issue https://github.com/r2dbc/r2dbc-pool/issues/129
       .maxLifeTime(JDuration.ofDays(365 * 100))
+      .backgroundEvictionInterval(JDuration.ofMillis((settings.maxIdleTime / 4).toMillis))
 
     if (settings.validationQuery.nonEmpty)
       poolConfiguration.validationQuery(settings.validationQuery)


### PR DESCRIPTION
* Otherwise there will be no eviction of idle connections.

