### PR TITLE
Set max-life-time to shrink pool

### DIFF
--- a/core/src/main/resources/reference.conf
+++ b/core/src/main/resources/reference.conf
@@ -141,8 +141,14 @@ akka.persistence.r2dbc {
     acquire-retry = 20
 
     # Maximum idle time of the connection in the pool.
-    # This value is used as an interval for background eviction of idle connections.
+    # Background eviction interval of idle connections is derived from this property
+    # and max-life-time.
     max-idle-time = 30 minutes
+
+    # Maximum lifetime of the connection in the pool.
+    # Background eviction interval of connections is derived from this property
+    # and max-idle-time.
+    max-life-time = 60 minutes
 
     # Configures the statement cache size.
     # 0 means no cache, negative values will select an unbounded cache

--- a/core/src/main/scala/akka/persistence/r2dbc/R2dbcSettings.scala
+++ b/core/src/main/scala/akka/persistence/r2dbc/R2dbcSettings.scala
@@ -101,6 +101,7 @@ final class ConnectionFactorySettings(config: Config) {
   val initialSize: Int = config.getInt("initial-size")
   val maxSize: Int = config.getInt("max-size")
   val maxIdleTime: FiniteDuration = config.getDuration("max-idle-time").asScala
+  val maxLifeTime: FiniteDuration = config.getDuration("max-life-time").asScala
 
   val createTimeout: FiniteDuration = config.getDuration("create-timeout").asScala
   val acquireTimeout: FiniteDuration = config.getDuration("acquire-timeout").asScala


### PR DESCRIPTION
* Even though idle connections are evicted from the pool it's
  likeley that connections in the pool are "touched" also during infrequent usage,
  i.e. they are not idle.
* By setting the max-life-time the connections are cycled out from the pool and
  the number of connections in the pool will shrink, as long as there is not demand
  for more connections.

I tested this with R2dbcJournalPerfManyActorsSpec by adding a "slow" phase at the end. Also added some temporary debug logging in r2dbc-pool `evictionPredicate`.

Number of connections can be seen with:
```
SELECT count(*)
FROM   pg_stat_activity
WHERE  datname = current_database()  -- only current database
AND    pid <> pg_backend_pid()
```