### PR TITLE
Fix connection leak caused by create-timeout, #182

### DIFF
--- a/core/src/main/resources/reference.conf
+++ b/core/src/main/resources/reference.conf
@@ -132,13 +132,14 @@ akka.persistence.r2dbc {
     # Maximum pool size.
     max-size = 20
     # Maximum time to create a new connection.
-    create-timeout = 3 seconds
+    connect-timeout = 3 seconds
     # Maximum time to acquire connection from pool.
-    acquire-timeout = 4 seconds
+    acquire-timeout = 5 seconds
     # Number of retries if the connection acquisition attempt fails.
-    # Use the same number as max-size in case all connections in the pool
-    # are invalid because database server was restarted.
-    acquire-retry = 20
+    # In the case the database server was restarted all connections in the pool will
+    # be invalid. To recover from that without failed acquire you can use the same number
+    # of retries as max-size of the pool
+    acquire-retry = 1
 
     # Maximum idle time of the connection in the pool.
     # Background eviction interval of idle connections is derived from this property

--- a/core/src/main/scala/akka/persistence/r2dbc/ConnectionFactoryProvider.scala
+++ b/core/src/main/scala/akka/persistence/r2dbc/ConnectionFactoryProvider.scala
@@ -72,6 +72,7 @@ class ConnectionFactoryProvider(system: ActorSystem[_]) extends Extension {
             .option(ConnectionFactoryOptions.USER, settings.user)
             .option(ConnectionFactoryOptions.PASSWORD, settings.password)
             .option(ConnectionFactoryOptions.DATABASE, settings.database)
+            .option(ConnectionFactoryOptions.CONNECT_TIMEOUT, JDuration.ofMillis(settings.connectTimeout.toMillis))
       }
 
     builder
@@ -114,7 +115,8 @@ class ConnectionFactoryProvider(system: ActorSystem[_]) extends Extension {
       .builder(connectionFactory)
       .initialSize(settings.initialSize)
       .maxSize(settings.maxSize)
-      .maxCreateConnectionTime(JDuration.ofMillis(settings.createTimeout.toMillis))
+      // Don't use maxCreateConnectionTime because it can cause connection leaks, see issue #182
+      // ConnectionFactoryOptions.CONNECT_TIMEOUT is used instead.
       .maxAcquireTime(JDuration.ofMillis(settings.acquireTimeout.toMillis))
       .acquireRetry(settings.acquireRetry)
       .maxIdleTime(JDuration.ofMillis(settings.maxIdleTime.toMillis))

--- a/core/src/main/scala/akka/persistence/r2dbc/R2dbcSettings.scala
+++ b/core/src/main/scala/akka/persistence/r2dbc/R2dbcSettings.scala
@@ -103,7 +103,7 @@ final class ConnectionFactorySettings(config: Config) {
   val maxIdleTime: FiniteDuration = config.getDuration("max-idle-time").asScala
   val maxLifeTime: FiniteDuration = config.getDuration("max-life-time").asScala
 
-  val createTimeout: FiniteDuration = config.getDuration("create-timeout").asScala
+  val connectTimeout: FiniteDuration = config.getDuration("connect-timeout").asScala
   val acquireTimeout: FiniteDuration = config.getDuration("acquire-timeout").asScala
   val acquireRetry: Int = config.getInt("acquire-retry")
 


### PR DESCRIPTION
* createTimeout is just a timeout on the Mono, but the underlying connection may still be established
  and not closed
* use ConnectionFactoryOptions.CONNECT_TIMEOUT instead
* also change acquire-retry to 1, and mention that it can be increased

Fixes #182
