### PR TITLE
Add support for using json/jsonb as column type for payloads (pg only)

### DIFF
--- a/core/src/main/resources/reference.conf
+++ b/core/src/main/resources/reference.conf
@@ -7,6 +7,9 @@ akka.persistence.r2dbc {
     # name of the table to use for events
     table = "event_journal"
 
+    # the column type to use for event payloads (bytea or jsonb)
+    payload-column-type = "BYTEA"
+
     # Otherwise it would be a pinned dispatcher, see https://github.com/akka/akka/issues/31058
     plugin-dispatcher = "akka.actor.default-dispatcher"
 
@@ -58,6 +61,9 @@ akka.persistence.r2dbc {
     class = "akka.persistence.r2dbc.snapshot.R2dbcSnapshotStore"
     table = "snapshot"
 
+    # the column type to use for snapshot payloads (bytea or jsonb)
+    payload-column-type = "BYTEA"
+
     # Otherwise it would be a pinned dispatcher, see https://github.com/akka/akka/issues/31058
     plugin-dispatcher = "akka.actor.default-dispatcher"
 
@@ -74,6 +80,9 @@ akka.persistence.r2dbc {
     class = "akka.persistence.r2dbc.state.R2dbcDurableStateStoreProvider"
 
     table = "durable_state"
+
+    # the column type to use for durable state payloads (bytea or jsonb)
+    payload-column-type = "BYTEA"
 
     # When this is enabled the updates verifies that the revision is +1 of
     # previous revision. There might be a small performance gain if

--- a/core/src/main/scala/akka/persistence/r2dbc/internal/PayloadCodec.scala
+++ b/core/src/main/scala/akka/persistence/r2dbc/internal/PayloadCodec.scala
@@ -1,0 +1,42 @@
+/*
+ * Copyright (C) 2022 - 2023 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.persistence.r2dbc.internal
+
+import akka.annotation.InternalApi
+import io.r2dbc.postgresql.codec.Json
+import io.r2dbc.spi.Row
+import io.r2dbc.spi.Statement
+
+/**
+ * INTERNAL API
+ */
+@InternalApi private[akka] sealed trait PayloadCodec {
+  def payloadClass: Class[_]
+  def encode(bytes: Array[Byte]): Any
+  def decode(payload: Any): Array[Byte]
+}
+
+/**
+ * INTERNAL API
+ */
+@InternalApi private[akka] object PayloadCodec {
+  case object ByteArrayCodec extends PayloadCodec {
+    override def payloadClass: Class[Array[Byte]] = classOf[Array[Byte]]
+    override def encode(bytes: Array[Byte]): Array[Byte] = bytes
+    override def decode(payload: Any): Array[Byte] = payload.asInstanceOf[Array[Byte]]
+  }
+  case object JsonCodec extends PayloadCodec {
+    override def payloadClass: Class[Json] = classOf[Json]
+    override def encode(bytes: Array[Byte]): Json = Json.of(bytes)
+    override def decode(payload: Any): Array[Byte] =
+      if (payload == null) null else payload.asInstanceOf[Json].asArray()
+  }
+  implicit class RichStatement(val statement: Statement)(implicit codec: PayloadCodec) extends AnyRef {
+    def bindPayload(index: Int, payload: Array[Byte]): Statement = statement.bind(index, codec.encode(payload))
+  }
+  implicit class RichRow(val row: Row)(implicit codec: PayloadCodec) extends AnyRef {
+    def getPayload(name: String): Array[Byte] = codec.decode(row.get(name, codec.payloadClass))
+  }
+}

--- a/core/src/main/scala/akka/persistence/r2dbc/query/scaladsl/QueryDao.scala
+++ b/core/src/main/scala/akka/persistence/r2dbc/query/scaladsl/QueryDao.scala
@@ -20,6 +20,8 @@ import akka.persistence.r2dbc.internal.Sql.Interpolation
 import akka.persistence.r2dbc.internal.BySliceQuery
 import akka.persistence.r2dbc.internal.BySliceQuery.Buckets
 import akka.persistence.r2dbc.internal.BySliceQuery.Buckets.Bucket
+import akka.persistence.r2dbc.internal.PayloadCodec
+import akka.persistence.r2dbc.internal.PayloadCodec.RichRow
 import akka.persistence.r2dbc.internal.InstantFactory
 import akka.persistence.r2dbc.internal.R2dbcExecutor
 import akka.persistence.r2dbc.journal.JournalDao
@@ -51,6 +53,7 @@ private[r2dbc] class QueryDao(settings: R2dbcSettings, connectionFactory: Connec
   import QueryDao.log
 
   private val journalTable = settings.journalTableWithSchema
+  private implicit val journalPayloadCodec: PayloadCodec = settings.journalPayloadCodec
 
   private val currentDbTimestampSql =
     "SELECT transaction_timestamp() AS db_timestamp"
@@ -201,7 +204,7 @@ private[r2dbc] class QueryDao(settings: R2dbcSettings, connectionFactory: Connec
             seqNr = row.get[java.lang.Long]("seq_nr", classOf[java.lang.Long]),
             dbTimestamp = row.get("db_timestamp", classOf[Instant]),
             readDbTimestamp = row.get("read_db_timestamp", classOf[Instant]),
-            payload = Some(row.get("event_payload", classOf[Array[Byte]])),
+            payload = Some(row.getPayload("event_payload")),
             serId = row.get[Integer]("event_ser_id", classOf[Integer]),
             serManifest = row.get("event_ser_manifest", classOf[String]),
             writerUuid = "", // not need in this query
@@ -282,7 +285,7 @@ private[r2dbc] class QueryDao(settings: R2dbcSettings, connectionFactory: Connec
           seqNr,
           dbTimestamp = row.get("db_timestamp", classOf[Instant]),
           readDbTimestamp = row.get("read_db_timestamp", classOf[Instant]),
-          payload = Some(row.get("event_payload", classOf[Array[Byte]])),
+          payload = Some(row.getPayload("event_payload")),
           serId = row.get[Integer]("event_ser_id", classOf[Integer]),
           serManifest = row.get("event_ser_manifest", classOf[String]),
           writerUuid = "", // not need in this query
@@ -310,7 +313,7 @@ private[r2dbc] class QueryDao(settings: R2dbcSettings, connectionFactory: Connec
           seqNr = row.get[java.lang.Long]("seq_nr", classOf[java.lang.Long]),
           dbTimestamp = row.get("db_timestamp", classOf[Instant]),
           readDbTimestamp = row.get("read_db_timestamp", classOf[Instant]),
-          payload = Some(row.get("event_payload", classOf[Array[Byte]])),
+          payload = Some(row.getPayload("event_payload")),
           serId = row.get[Integer]("event_ser_id", classOf[Integer]),
           serManifest = row.get("event_ser_manifest", classOf[String]),
           writerUuid = row.get("writer", classOf[String]),

--- a/core/src/test/scala/akka/persistence/r2dbc/query/EventsBySliceBacktrackingSpec.scala
+++ b/core/src/test/scala/akka/persistence/r2dbc/query/EventsBySliceBacktrackingSpec.scala
@@ -17,6 +17,8 @@ import akka.persistence.query.Offset
 import akka.persistence.query.PersistenceQuery
 import akka.persistence.query.typed.EventEnvelope
 import akka.persistence.r2dbc.R2dbcSettings
+import akka.persistence.r2dbc.internal.PayloadCodec
+import akka.persistence.r2dbc.internal.PayloadCodec.RichStatement
 import akka.persistence.r2dbc.internal.Sql.Interpolation
 import akka.persistence.r2dbc.TestConfig
 import akka.persistence.r2dbc.TestData
@@ -49,6 +51,7 @@ class EventsBySliceBacktrackingSpec
 
   override def typedSystem: ActorSystem[_] = system
   private val settings = new R2dbcSettings(system.settings.config.getConfig("akka.persistence.r2dbc"))
+  private implicit val journalPayloadCodec: PayloadCodec = settings.journalPayloadCodec
 
   private val query = PersistenceQuery(testKit.system)
     .readJournalFor[R2dbcReadJournal](R2dbcReadJournal.Identifier)
@@ -73,7 +76,7 @@ class EventsBySliceBacktrackingSpec
         .bind(3, seqNr)
         .bind(4, timestamp)
         .bind(5, stringSerializer.identifier)
-        .bind(6, stringSerializer.toBinary(event))
+        .bindPayload(6, stringSerializer.toBinary(event))
     }
     result.futureValue shouldBe 1
   }

--- a/ddl-scripts/create_tables_postgres_jsonb.sql
+++ b/ddl-scripts/create_tables_postgres_jsonb.sql
@@ -1,0 +1,95 @@
+CREATE TABLE IF NOT EXISTS event_journal(
+  slice INT NOT NULL,
+  entity_type VARCHAR(255) NOT NULL,
+  persistence_id VARCHAR(255) NOT NULL,
+  seq_nr BIGINT NOT NULL,
+  db_timestamp timestamp with time zone NOT NULL,
+
+  event_ser_id INTEGER NOT NULL,
+  event_ser_manifest VARCHAR(255) NOT NULL,
+  event_payload JSONB NOT NULL,
+
+  deleted BOOLEAN DEFAULT FALSE NOT NULL,
+  writer VARCHAR(255) NOT NULL,
+  adapter_manifest VARCHAR(255),
+  tags TEXT ARRAY,
+
+  meta_ser_id INTEGER,
+  meta_ser_manifest VARCHAR(255),
+  meta_payload BYTEA,
+
+  PRIMARY KEY(persistence_id, seq_nr)
+);
+
+-- `event_journal_slice_idx` is only needed if the slice based queries are used
+CREATE INDEX IF NOT EXISTS event_journal_slice_idx ON event_journal(slice, entity_type, db_timestamp, seq_nr);
+
+CREATE TABLE IF NOT EXISTS snapshot(
+  slice INT NOT NULL,
+  entity_type VARCHAR(255) NOT NULL,
+  persistence_id VARCHAR(255) NOT NULL,
+  seq_nr BIGINT NOT NULL,
+  write_timestamp BIGINT NOT NULL,
+  ser_id INTEGER NOT NULL,
+  ser_manifest VARCHAR(255) NOT NULL,
+  snapshot JSONB NOT NULL,
+  meta_ser_id INTEGER,
+  meta_ser_manifest VARCHAR(255),
+  meta_payload BYTEA,
+
+  PRIMARY KEY(persistence_id)
+);
+
+CREATE TABLE IF NOT EXISTS durable_state (
+  slice INT NOT NULL,
+  entity_type VARCHAR(255) NOT NULL,
+  persistence_id VARCHAR(255) NOT NULL,
+  revision BIGINT NOT NULL,
+  db_timestamp timestamp with time zone NOT NULL,
+
+  state_ser_id INTEGER NOT NULL,
+  state_ser_manifest VARCHAR(255),
+  state_payload JSONB NOT NULL,
+  tags TEXT ARRAY,
+
+  PRIMARY KEY(persistence_id, revision)
+);
+
+-- `durable_state_slice_idx` is only needed if the slice based queries are used
+CREATE INDEX IF NOT EXISTS durable_state_slice_idx ON durable_state(slice, entity_type, db_timestamp, revision);
+
+-- Primitive offset types are stored in this table.
+-- If only timestamp based offsets are used this table is optional.
+-- Configure akka.projection.r2dbc.offset-store.offset-table="" if the table is not created.
+CREATE TABLE IF NOT EXISTS akka_projection_offset_store (
+  projection_name VARCHAR(255) NOT NULL,
+  projection_key VARCHAR(255) NOT NULL,
+  current_offset VARCHAR(255) NOT NULL,
+  manifest VARCHAR(32) NOT NULL,
+  mergeable BOOLEAN NOT NULL,
+  last_updated BIGINT NOT NULL,
+  PRIMARY KEY(projection_name, projection_key)
+);
+
+-- Timestamp based offsets are stored in this table.
+CREATE TABLE IF NOT EXISTS akka_projection_timestamp_offset_store (
+  projection_name VARCHAR(255) NOT NULL,
+  projection_key VARCHAR(255) NOT NULL,
+  slice INT NOT NULL,
+  persistence_id VARCHAR(255) NOT NULL,
+  seq_nr BIGINT NOT NULL,
+  -- timestamp_offset is the db_timestamp of the original event
+  timestamp_offset timestamp with time zone NOT NULL,
+  -- timestamp_consumed is when the offset was stored
+  -- the consumer lag is timestamp_consumed - timestamp_offset
+  timestamp_consumed timestamp with time zone NOT NULL,
+  PRIMARY KEY(slice, projection_name, timestamp_offset, persistence_id, seq_nr)
+);
+
+CREATE TABLE IF NOT EXISTS akka_projection_management (
+  projection_name VARCHAR(255) NOT NULL,
+  projection_key VARCHAR(255) NOT NULL,
+  paused BOOLEAN NOT NULL,
+  last_updated BIGINT NOT NULL,
+  PRIMARY KEY(projection_name, projection_key)
+);

--- a/projection/src/test/scala/akka/projection/r2dbc/EventSourcedEndToEndSpec.scala
+++ b/projection/src/test/scala/akka/projection/r2dbc/EventSourcedEndToEndSpec.scala
@@ -22,6 +22,8 @@ import akka.actor.typed.scaladsl.Behaviors
 import akka.actor.typed.scaladsl.LoggerOps
 import akka.persistence.query.typed.EventEnvelope
 import akka.persistence.r2dbc.R2dbcSettings
+import akka.persistence.r2dbc.internal.PayloadCodec
+import akka.persistence.r2dbc.internal.PayloadCodec.RichStatement
 import akka.persistence.r2dbc.internal.Sql.Interpolation
 import akka.persistence.r2dbc.query.scaladsl.R2dbcReadJournal
 import akka.persistence.typed.PersistenceId
@@ -134,6 +136,7 @@ class EventSourcedEndToEndSpec
   private val log = LoggerFactory.getLogger(getClass)
 
   private val journalSettings = new R2dbcSettings(system.settings.config.getConfig("akka.persistence.r2dbc"))
+  private implicit val journalPayloadCodec: PayloadCodec = journalSettings.journalPayloadCodec
   private val projectionSettings = R2dbcProjectionSettings(system)
   private val stringSerializer = SerializationExtension(system).serializerFor(classOf[String])
 
@@ -161,7 +164,7 @@ class EventSourcedEndToEndSpec
         .bind(3, seqNr)
         .bind(4, timestamp)
         .bind(5, stringSerializer.identifier)
-        .bind(6, stringSerializer.toBinary(event))
+        .bindPayload(6, stringSerializer.toBinary(event))
     }
     result.futureValue shouldBe 1
   }


### PR DESCRIPTION
* All test data has been changed to be valid json (test inheriting from plugin tck classes which uses non json compatible payloads have been marked as ignored for now) 
* New settings added:
  ```
  akka.persistence.r2dbc.journal.payload-column-type = "json" | "jsonb" | "bytea"
  akka.persistence.r2dbc.snapshot.payload-column-type = "json" | "jsonb" | "bytea"
  akka.persistence.r2dbc.state.payload-column-type = "json" | "jsonb" | "bytea"
  ```

* Create the database using the jsonb ddl script variant at:
  ```
  ddl-scripts/create_tables_postgres_jsonb.sql
  ```
* Run tests with:
    ```
    sbt -Dakka.persistence.r2dbc.journal.payload-column-type=jsonb  -Dakka.persistence.r2dbc.snapshot.payload-column-type=jsonb  -Dakka.persistence.r2dbc.state.payload-column-type=jsonb test
```