### PR TITLE
A way to skip envelopes but still store offset

### DIFF
--- a/projection/src/main/scala/akka/projection/r2dbc/internal/R2dbcProjectionImpl.scala
+++ b/projection/src/main/scala/akka/projection/r2dbc/internal/R2dbcProjectionImpl.scala
@@ -326,14 +326,11 @@ private[projection] object R2dbcProjectionImpl {
           .flatMap { ok =>
             if (ok) {
               if (skipEnvelope(env)) {
-                // FIXME this might not be correct? Is the offset stored or is it only added to inFlight and then ignored by the below `collect`?
-                offsetStore.addInflight(env)
-                Future.successful(None)
-              } else {
-                loadEnvelope(env, sourceProvider).map { loadedEnvelope =>
-                  offsetStore.addInflight(loadedEnvelope)
-                  Some(loadedEnvelope)
-                }
+                log.debug("atLeastOnceFlow doesn't support of skipping envelopes. Envelope [{}] still emitted.", env)
+              }
+              loadEnvelope(env, sourceProvider).map { loadedEnvelope =>
+                offsetStore.addInflight(loadedEnvelope)
+                Some(loadedEnvelope)
               }
             } else {
               Future.successful(None)

--- a/projection/src/main/scala/akka/projection/r2dbc/internal/R2dbcProjectionImpl.scala
+++ b/projection/src/main/scala/akka/projection/r2dbc/internal/R2dbcProjectionImpl.scala
@@ -13,6 +13,7 @@ import scala.concurrent.duration.FiniteDuration
 import scala.util.control.NonFatal
 
 import akka.Done
+import akka.NotUsed
 import akka.actor.typed.ActorSystem
 import akka.annotation.InternalApi
 import akka.event.Logging
@@ -84,7 +85,7 @@ private[projection] object R2dbcProjectionImpl {
   def loadEnvelope[Envelope](env: Envelope, sourceProvider: SourceProvider[_, Envelope])(implicit
       ec: ExecutionContext): Future[Envelope] = {
     env match {
-      case eventEnvelope: EventEnvelope[_] if eventEnvelope.eventOption.isEmpty =>
+      case eventEnvelope: EventEnvelope[_] if eventEnvelope.eventOption.isEmpty && !skipEnvelope(eventEnvelope) =>
         val pid = eventEnvelope.persistenceId
         val seqNr = eventEnvelope.sequenceNr
         (sourceProvider match {
@@ -154,16 +155,21 @@ private[projection] object R2dbcProjectionImpl {
         override def process(envelope: Envelope): Future[Done] = {
           offsetStore.isAccepted(envelope).flatMap {
             case true =>
-              loadEnvelope(envelope, sourceProvider).flatMap { loadedEnvelope =>
-                val offset = sourceProvider.extractOffset(loadedEnvelope)
-                r2dbcExecutor.withConnection("exactly-once handler") { conn =>
-                  // run users handler
-                  val session = new R2dbcSession(conn)
-                  delegate
-                    .process(session, loadedEnvelope)
-                    .flatMap { _ =>
-                      offsetStore.saveOffsetInTx(conn, offset)
-                    }
+              if (skipEnvelope(envelope)) {
+                val offset = sourceProvider.extractOffset(envelope)
+                offsetStore.saveOffset(offset)
+              } else {
+                loadEnvelope(envelope, sourceProvider).flatMap { loadedEnvelope =>
+                  val offset = sourceProvider.extractOffset(loadedEnvelope)
+                  r2dbcExecutor.withConnection("exactly-once handler") { conn =>
+                    // run users handler
+                    val session = new R2dbcSession(conn)
+                    delegate
+                      .process(session, loadedEnvelope)
+                      .flatMap { _ =>
+                        offsetStore.saveOffsetInTx(conn, offset)
+                      }
+                  }
                 }
               }
             case false =>
@@ -190,11 +196,16 @@ private[projection] object R2dbcProjectionImpl {
             Future.sequence(acceptedEnvelopes.map(env => loadEnvelope(env, sourceProvider))).flatMap {
               loadedEnvelopes =>
                 val offsets = loadedEnvelopes.iterator.map(sourceProvider.extractOffset).toVector
-                r2dbcExecutor.withConnection("grouped handler") { conn =>
-                  // run users handler
-                  val session = new R2dbcSession(conn)
-                  delegate.process(session, loadedEnvelopes).flatMap { _ =>
-                    offsetStore.saveOffsetsInTx(conn, offsets)
+                val filteredEnvelopes = loadedEnvelopes.filterNot(skipEnvelope)
+                if (filteredEnvelopes.isEmpty) {
+                  offsetStore.saveOffsets(offsets)
+                } else {
+                  r2dbcExecutor.withConnection("grouped handler") { conn =>
+                    // run users handler
+                    val session = new R2dbcSession(conn)
+                    delegate.process(session, filteredEnvelopes).flatMap { _ =>
+                      offsetStore.saveOffsetsInTx(conn, offsets)
+                    }
                   }
                 }
             }
@@ -214,17 +225,22 @@ private[projection] object R2dbcProjectionImpl {
         override def process(envelope: Envelope): Future[Done] = {
           offsetStore.isAccepted(envelope).flatMap {
             case true =>
-              loadEnvelope(envelope, sourceProvider).flatMap { loadedEnvelope =>
-                r2dbcExecutor
-                  .withConnection("at-least-once handler") { conn =>
-                    // run users handler
-                    val session = new R2dbcSession(conn)
-                    delegate.process(session, loadedEnvelope)
-                  }
-                  .map { _ =>
-                    offsetStore.addInflight(loadedEnvelope)
-                    Done
-                  }
+              if (skipEnvelope(envelope)) {
+                offsetStore.addInflight(envelope)
+                FutureDone
+              } else {
+                loadEnvelope(envelope, sourceProvider).flatMap { loadedEnvelope =>
+                  r2dbcExecutor
+                    .withConnection("at-least-once handler") { conn =>
+                      // run users handler
+                      val session = new R2dbcSession(conn)
+                      delegate.process(session, loadedEnvelope)
+                    }
+                    .map { _ =>
+                      offsetStore.addInflight(loadedEnvelope)
+                      Done
+                    }
+                }
               }
             case false =>
               FutureDone
@@ -242,13 +258,18 @@ private[projection] object R2dbcProjectionImpl {
         override def process(envelope: Envelope): Future[Done] = {
           offsetStore.isAccepted(envelope).flatMap {
             case true =>
-              loadEnvelope(envelope, sourceProvider).flatMap { loadedEnvelope =>
-                delegate
-                  .process(loadedEnvelope)
-                  .map { _ =>
-                    offsetStore.addInflight(loadedEnvelope)
-                    Done
-                  }
+              if (skipEnvelope(envelope)) {
+                offsetStore.addInflight(envelope)
+                FutureDone
+              } else {
+                loadEnvelope(envelope, sourceProvider).flatMap { loadedEnvelope =>
+                  delegate
+                    .process(loadedEnvelope)
+                    .map { _ =>
+                      offsetStore.addInflight(loadedEnvelope)
+                      Done
+                    }
+                }
               }
             case false =>
               FutureDone
@@ -272,12 +293,18 @@ private[projection] object R2dbcProjectionImpl {
           } else {
             Future.sequence(acceptedEnvelopes.map(env => loadEnvelope(env, sourceProvider))).flatMap {
               loadedEnvelopes =>
-                delegate
-                  .process(loadedEnvelopes)
-                  .map { _ =>
-                    offsetStore.addInflights(loadedEnvelopes)
-                    Done
-                  }
+                val filteredEnvelopes = loadedEnvelopes.filterNot(skipEnvelope)
+                if (filteredEnvelopes.isEmpty) {
+                  offsetStore.addInflights(loadedEnvelopes)
+                  FutureDone
+                } else {
+                  delegate
+                    .process(filteredEnvelopes)
+                    .map { _ =>
+                      offsetStore.addInflights(loadedEnvelopes)
+                      Done
+                    }
+                }
             }
           }
         }
@@ -298,9 +325,15 @@ private[projection] object R2dbcProjectionImpl {
           .isAccepted(env)
           .flatMap { ok =>
             if (ok) {
-              loadEnvelope(env, sourceProvider).map { loadedEnvelope =>
-                offsetStore.addInflight(loadedEnvelope)
-                Some(loadedEnvelope)
+              if (skipEnvelope(env)) {
+                // FIXME this might not be correct? Is the offset stored or is it only added to inFlight and then ignored by the below `collect`?
+                offsetStore.addInflight(env)
+                Future.successful(None)
+              } else {
+                loadEnvelope(env, sourceProvider).map { loadedEnvelope =>
+                  offsetStore.addInflight(loadedEnvelope)
+                  Some(loadedEnvelope)
+                }
               }
             } else {
               Future.successful(None)
@@ -333,6 +366,17 @@ private[projection] object R2dbcProjectionImpl {
 
     override def stop(): Future[Done] =
       delegate.stop()
+  }
+
+  private def skipEnvelope[Envelope](env: Envelope): Boolean = {
+    env match {
+      case e: EventEnvelope[_] =>
+        e.eventMetadata match {
+          case Some(NotUsed) => true
+          case _             => false
+        }
+      case _ => false
+    }
   }
 
 }

--- a/projection/src/main/scala/akka/projection/r2dbc/internal/R2dbcProjectionImpl.scala
+++ b/projection/src/main/scala/akka/projection/r2dbc/internal/R2dbcProjectionImpl.scala
@@ -326,7 +326,7 @@ private[projection] object R2dbcProjectionImpl {
           .flatMap { ok =>
             if (ok) {
               if (skipEnvelope(env)) {
-                log.debug("atLeastOnceFlow doesn't support of skipping envelopes. Envelope [{}] still emitted.", env)
+                log.info("atLeastOnceFlow doesn't support of skipping envelopes. Envelope [{}] still emitted.", env)
               }
               loadEnvelope(env, sourceProvider).map { loadedEnvelope =>
                 offsetStore.addInflight(loadedEnvelope)

--- a/projection/src/test/scala/akka/projection/r2dbc/R2dbcTimestampOffsetProjectionSpec.scala
+++ b/projection/src/test/scala/akka/projection/r2dbc/R2dbcTimestampOffsetProjectionSpec.scala
@@ -334,6 +334,18 @@ class R2dbcTimestampOffsetProjectionSpec
     }
   }
 
+  def markAsNotUsed[A](env: EventEnvelope[A]): EventEnvelope[A] = {
+    new EventEnvelope(
+      env.offset,
+      env.persistenceId,
+      env.sequenceNr,
+      env.eventOption,
+      env.timestamp,
+      eventMetadata = Some(NotUsed),
+      env.entityType,
+      env.slice)
+  }
+
   "A R2DBC exactly-once projection with TimestampOffset" must {
 
     "persist projection and offset in the same write operation (transactional)" in {
@@ -552,15 +564,7 @@ class R2dbcTimestampOffsetProjectionSpec
 
       val envelopes = createEnvelopes(pid, 6).map { env =>
         if (env.event == "e3" || env.event == "e4" || env.event == "e6")
-          new EventEnvelope(
-            env.offset,
-            env.persistenceId,
-            env.sequenceNr,
-            env.eventOption,
-            env.timestamp,
-            eventMetadata = Some(NotUsed),
-            env.entityType,
-            env.slice)
+          markAsNotUsed(env)
         else
           env
       }
@@ -678,6 +682,37 @@ class R2dbcTimestampOffsetProjectionSpec
         projectedValueShouldBe("e2-1|e2-2|e2-3|e2-4")(pid2)
       }
       offsetShouldBe(envelopes2.last.offset)
+    }
+
+    "be able to skip envelopes but still store offset" in {
+      implicit val pid = UUID.randomUUID().toString
+      val projectionId = genRandomProjectionId()
+      val envelopes = createEnvelopes(pid, 6).map { env =>
+        if (env.event == "e3" || env.event == "e4" || env.event == "e6")
+          markAsNotUsed(env)
+        else
+          env
+      }
+      val sourceProvider = createSourceProvider(envelopes)
+      implicit val offsetStore = createOffsetStore(projectionId, sourceProvider)
+
+      val handlerProbe = createTestProbe[String]("calls-to-handler")
+
+      val projection =
+        R2dbcProjection
+          .groupedWithin(projectionId, Some(settings), sourceProvider, handler = () => groupedHandler(handlerProbe.ref))
+          .withGroup(3, 3.seconds)
+
+      offsetShouldBeEmpty()
+      projectionTestKit.run(projection) {
+        projectedValueShouldBe("e1|e2|e5")
+      }
+
+      // handler probe is called twice
+      handlerProbe.expectMessage("called")
+      handlerProbe.expectMessage("called")
+
+      offsetShouldBe(envelopes.last.offset)
     }
 
     "handle grouped async projection" in {
@@ -807,6 +842,44 @@ class R2dbcTimestampOffsetProjectionSpec
       }
       projectionRef ! ProjectionBehavior.Stop
     }
+
+    "be able to skip envelopes but still store offset for grouped async projection" in {
+      implicit val pid = UUID.randomUUID().toString
+      val projectionId = genRandomProjectionId()
+      val envelopes = createEnvelopes(pid, 6).map { env =>
+        if (env.event == "e3" || env.event == "e4" || env.event == "e6")
+          markAsNotUsed(env)
+        else
+          env
+      }
+      val sourceProvider = createSourceProvider(envelopes)
+      implicit val offsetStore = createOffsetStore(projectionId, sourceProvider)
+
+      val result = new StringBuffer()
+
+      def handler(): Handler[immutable.Seq[EventEnvelope[String]]] =
+        new Handler[immutable.Seq[EventEnvelope[String]]] {
+          override def process(envelopes: immutable.Seq[EventEnvelope[String]]): Future[Done] = {
+            Future {
+              envelopes.foreach(env => result.append(env.event).append("|"))
+            }.map(_ => Done)
+          }
+        }
+
+      val projection =
+        R2dbcProjection
+          .groupedWithinAsync(projectionId, Some(settings), sourceProvider, handler = () => handler())
+          .withGroup(2, 3.seconds)
+
+      offsetShouldBeEmpty()
+      projectionTestKit.run(projection) {
+        result.toString shouldBe "e1|e2|e5|"
+      }
+
+      eventually {
+        offsetShouldBe(envelopes.last.offset)
+      }
+    }
   }
 
   "A R2DBC at-least-once projection with TimestampOffset" must {
@@ -916,6 +989,30 @@ class R2dbcTimestampOffsetProjectionSpec
 
       bogusEventHandler.attempts shouldBe 1
 
+      eventually {
+        offsetShouldBe(envelopes.last.offset)
+      }
+    }
+
+    "be able to skip envelopes but still store offset" in {
+      implicit val pid = UUID.randomUUID().toString
+      val projectionId = genRandomProjectionId()
+      val envelopes = createEnvelopes(pid, 6).map { env =>
+        if (env.event == "e3" || env.event == "e4" || env.event == "e6")
+          markAsNotUsed(env)
+        else
+          env
+      }
+      val sourceProvider = createSourceProvider(envelopes)
+      implicit val offsetStore = createOffsetStore(projectionId, sourceProvider)
+
+      val projection =
+        R2dbcProjection.atLeastOnce(projectionId, Some(settings), sourceProvider, handler = () => new ConcatHandler)
+
+      offsetShouldBeEmpty()
+      projectionTestKit.run(projection) {
+        projectedValueShouldBe("e1|e2|e5")
+      }
       eventually {
         offsetShouldBe(envelopes.last.offset)
       }
@@ -1091,15 +1188,7 @@ class R2dbcTimestampOffsetProjectionSpec
 
       val envelopes = createEnvelopes(pid, 6).map { env =>
         if (env.event == "e3" || env.event == "e4" || env.event == "e6")
-          new EventEnvelope(
-            env.offset,
-            env.persistenceId,
-            env.sequenceNr,
-            env.eventOption,
-            env.timestamp,
-            eventMetadata = Some(NotUsed),
-            env.entityType,
-            env.slice)
+          markAsNotUsed(env)
         else
           env
       }
@@ -1223,6 +1312,43 @@ class R2dbcTimestampOffsetProjectionSpec
         offsetShouldBe(envelopes2.last.offset)
       }
       projectionRef ! ProjectionBehavior.Stop
+    }
+
+    "not support skipping envelopes but still store offset" in {
+      // This is a limitation for atLeastOnceFlow and this test is just
+      // capturing current behavior of not supporting the feature of skipping
+      // envelopes that are marked with NotUsed in the eventMetadata.
+      implicit val pid = UUID.randomUUID().toString
+      val projectionId = genRandomProjectionId()
+      val envelopes = createEnvelopes(pid, 6).map { env =>
+        if (env.event == "e3" || env.event == "e4" || env.event == "e6")
+          markAsNotUsed(env)
+        else
+          env
+      }
+      val sourceProvider = createSourceProvider(envelopes)
+      implicit val offsetStore = createOffsetStore(projectionId, sourceProvider)
+
+      offsetShouldBeEmpty()
+
+      val flowHandler =
+        FlowWithContext[EventEnvelope[String], ProjectionContext]
+          .mapAsync(1) { env =>
+            withRepo(_.concatToText(env.persistenceId, env.event))
+          }
+
+      val projection =
+        R2dbcProjection
+          .atLeastOnceFlow(projectionId, Some(settings), sourceProvider, handler = flowHandler)
+          .withSaveOffset(1, 1.minute)
+
+      projectionTestKit.run(projection) {
+        // e3, e4, e6 are still included
+        projectedValueShouldBe("e1|e2|e3|e4|e5|e6")
+      }
+      eventually {
+        offsetShouldBe(envelopes.last.offset)
+      }
     }
   }
 


### PR DESCRIPTION
* if envelope is "marked" with NotUsed in the eventMetaData
