### PR TITLE
Less aggressive eviction

### DIFF
--- a/projection/src/main/resources/reference.conf
+++ b/projection/src/main/resources/reference.conf
@@ -23,6 +23,10 @@ akka.projection.r2dbc {
     # within this time window from latest offset.
     time-window = 5 minutes
 
+    # Keep this number of entries. Don't evict old entries until this threshold
+    # has been reached.
+    keep-number-of-entries = 10000
+
     # Remove old entries outside the time-window from the offset store memory
     # with this frequency.
     evict-interval = 10 seconds

--- a/projection/src/main/scala/akka/projection/r2dbc/R2dbcProjectionSettings.scala
+++ b/projection/src/main/scala/akka/projection/r2dbc/R2dbcProjectionSettings.scala
@@ -31,6 +31,7 @@ object R2dbcProjectionSettings {
       managementTable = config.getString("offset-store.management-table"),
       useConnectionFactory = config.getString("use-connection-factory"),
       timeWindow = config.getDuration("offset-store.time-window"),
+      keepNumberOfEntries = config.getInt("offset-store.keep-number-of-entries"),
       evictInterval = config.getDuration("offset-store.evict-interval"),
       deleteInterval = config.getDuration("offset-store.delete-interval"),
       logDbCallsExceeding)
@@ -48,6 +49,7 @@ final case class R2dbcProjectionSettings(
     managementTable: String,
     useConnectionFactory: String,
     timeWindow: JDuration,
+    keepNumberOfEntries: Int,
     evictInterval: JDuration,
     deleteInterval: JDuration,
     logDbCallsExceeding: FiniteDuration) {

--- a/projection/src/main/scala/akka/projection/r2dbc/internal/R2dbcOffsetStore.scala
+++ b/projection/src/main/scala/akka/projection/r2dbc/internal/R2dbcOffsetStore.scala
@@ -128,10 +128,14 @@ object R2dbcOffsetStore {
     def window: JDuration =
       JDuration.between(oldestTimestamp, latestTimestamp)
 
-    def evict(until: Instant): State = {
-      if (oldestTimestamp.isBefore(until))
-        State(byPid.valuesIterator.filterNot(_.timestamp.isBefore(until)).toVector)
-      else
+    def evict(until: Instant, keepNumberOfEntries: Int): State = {
+      if (oldestTimestamp.isBefore(until) && size > keepNumberOfEntries) {
+        val sorted = byPid.valuesIterator.toVector.sortBy(_.timestamp)
+        State(
+          sorted
+            .take(size - keepNumberOfEntries)
+            .filterNot(_.timestamp.isBefore(until)) :++ sorted.takeRight(keepNumberOfEntries))
+      } else
         this
     }
   }
@@ -159,6 +163,7 @@ private[projection] class R2dbcOffsetStore(
   private val logger = LoggerFactory.getLogger(this.getClass)
 
   private val evictWindow = settings.timeWindow.plus(settings.evictInterval)
+  private val evictKeepNumberOfEntriesThreshold = (settings.keepNumberOfEntries * 1.1).toInt
 
   private val offsetSerialization = new OffsetSerialization(system)
   import offsetSerialization.fromStorageRepresentation
@@ -320,11 +325,10 @@ private[projection] class R2dbcOffsetStore(
     recordsFut.map { records =>
       val newState = State(records)
       logger.debug(
-        "readTimestampOffset state with [{}] persistenceIds, oldest [{}], latest [{}], records {}",
+        "readTimestampOffset state with [{}] persistenceIds, oldest [{}], latest [{}]",
         newState.byPid.size,
         newState.oldestTimestamp,
-        newState.latestTimestamp,
-        records)
+        newState.latestTimestamp)
       if (!state.compareAndSet(oldState, newState))
         throw new IllegalStateException("Unexpected concurrent modification of state from readOffset.")
       clearInflight()
@@ -446,9 +450,15 @@ private[projection] class R2dbcOffsetStore(
 
       // accumulate some more than the timeWindow before evicting
       val evictedNewState =
-        if (newState.window.compareTo(evictWindow) > 0) {
-          val s = newState.evict(newState.latestTimestamp.minus(settings.timeWindow))
-          logger.debug("Evicted [{}] records, keeping [{}] records.", newState.size - s.size, s.size)
+        if (newState.size > evictKeepNumberOfEntriesThreshold && newState.window.compareTo(evictWindow) > 0) {
+          val evictUntil = newState.latestTimestamp.minus(settings.timeWindow)
+          val s = newState.evict(evictUntil, settings.keepNumberOfEntries)
+          logger.debug(
+            "Evicted [{}] records until [{}], keeping [{}] records. Latest [{}].",
+            newState.size - s.size,
+            evictUntil,
+            s.size,
+            newState.latestTimestamp)
           s
         } else
           newState
@@ -682,7 +692,15 @@ private[projection] class R2dbcOffsetStore(
         // Backtracking will emit missed event again.
         timestampOf(pid, seqNr - 1).map {
           case Some(previousTimestamp) =>
-            if (previousTimestamp.isBefore(currentState.latestTimestamp.minus(settings.timeWindow))) {
+            val before = currentState.latestTimestamp.minus(settings.timeWindow)
+            if (previousTimestamp.isBefore(before)) {
+              logger.debug(
+                "Accepting envelope with pid [{}], seqNr [{}], where previous event timestamp [{}] " +
+                "is before time window [{}].",
+                pid,
+                seqNr,
+                previousTimestamp,
+                before)
               true
             } else if (recordWithOffset.envelopeLoaded) {
               logUnknown()
@@ -761,7 +779,7 @@ private[projection] class R2dbcOffsetStore(
       Future.successful(0)
     } else {
       val currentState = getState()
-      if (currentState.window.compareTo(settings.timeWindow) < 0) {
+      if (currentState.size <= settings.keepNumberOfEntries || currentState.window.compareTo(settings.timeWindow) < 0) {
         // it hasn't filled up the window yet
         Future.successful(0)
       } else {

--- a/projection/src/test/scala/akka/projection/r2dbc/R2dbcOffsetStoreStateSpec.scala
+++ b/projection/src/test/scala/akka/projection/r2dbc/R2dbcOffsetStoreStateSpec.scala
@@ -71,10 +71,19 @@ class R2dbcOffsetStoreStateSpec extends AnyWordSpec with TestSuite with Matchers
         "p4" -> 4L,
         "p5" -> 5L)
 
-      val state2 = state1.evict(t0.plusMillis(2))
+      val state2 = state1.evict(t0.plusMillis(2), keepNumberOfEntries = 1)
       state2.latestOffset.get.seen shouldBe Map("p5" -> 5L)
       state2.oldestTimestamp shouldBe t0.plusMillis(2)
       state2.byPid.map { case (pid, r) => pid -> r.seqNr } shouldBe Map("p3" -> 3L, "p4" -> 4L, "p5" -> 5L)
+
+      // keep all
+      state1.evict(t0.plusMillis(2), keepNumberOfEntries = 100) shouldBe state1
+
+      // keep 4
+      val state3 = state1.evict(t0.plusMillis(2), keepNumberOfEntries = 4)
+      state3.latestOffset.get.seen shouldBe Map("p5" -> 5L)
+      state3.oldestTimestamp shouldBe t0.plusMillis(1)
+      state3.byPid.map { case (pid, r) => pid -> r.seqNr } shouldBe Map("p2" -> 2L, "p3" -> 3L, "p4" -> 4L, "p5" -> 5L)
     }
 
     "find duplicate" in {

--- a/projection/src/test/scala/akka/projection/r2dbc/R2dbcTimestampOffsetStoreSpec.scala
+++ b/projection/src/test/scala/akka/projection/r2dbc/R2dbcTimestampOffsetStoreSpec.scala
@@ -27,6 +27,7 @@ import akka.projection.r2dbc.internal.R2dbcOffsetStore
 import akka.projection.r2dbc.internal.R2dbcOffsetStore.Pid
 import akka.projection.r2dbc.internal.R2dbcOffsetStore.Record
 import akka.projection.r2dbc.internal.R2dbcOffsetStore.SeqNr
+import com.typesafe.config.ConfigFactory
 import org.scalatest.wordspec.AnyWordSpecLike
 import org.slf4j.LoggerFactory
 
@@ -45,7 +46,12 @@ object R2dbcTimestampOffsetStoreSpec {
 }
 
 class R2dbcTimestampOffsetStoreSpec
-    extends ScalaTestWithActorTestKit(TestConfig.config)
+    extends ScalaTestWithActorTestKit(
+      ConfigFactory
+        .parseString("""
+    # to be able to test eviction
+    akka.projection.r2dbc.offset-store.keep-number-of-entries = 0
+    """).withFallback(TestConfig.config))
     with AnyWordSpecLike
     with TestDbLifecycle
     with TestData


### PR DESCRIPTION
* found this issue and also unique constraint violations when
  replaying projection from beginning and the events were stored
  with rather low frequency, i.e. many events but not that many per second
* what happended was that the events from backtracking were received after
  corresponding original event had been evicted from the store and then
  it was accepted (duplicate)
