### PR TITLE
Disable deduplication for publish-events by default

### DIFF
--- a/core/src/main/resources/reference.conf
+++ b/core/src/main/resources/reference.conf
@@ -85,9 +85,13 @@ akka.persistence.r2dbc {
       buffer-size = 1000
     }
 
-    # When journal publish-events is enabled there is a best effort deduplication
-    # filter in the `eventsBySlices` query. It keeps track of this number of entries.
-    deduplicate-capacity = 5000
+    # When journal publish-events is enabled a best effort deduplication can be enabled by setting
+    # this property to the size of the deduplication buffer in the `eventsBySlices` query.
+    # It keeps track of this number of entries and 5000 is recommended capacity. The drawback
+    # of enabling this is that when the sequence numbers received via publish-events are out of sync
+    # after some error scenarios it will take longer to receive those events, since it will rely on
+    # the backtracking queries.
+    deduplicate-capacity = 0
 
   }
 }


### PR DESCRIPTION
* Noticed that EventSourcedPubSubSpec was flaky

Dedup was added in https://github.com/akka/akka-persistence-r2dbc/pull/248
