### PR TITLE
Allow envelope from backtracking as duplicate when in-flight, #245

### DIFF
--- a/projection/src/test/scala/akka/projection/r2dbc/R2dbcTimestampOffsetProjectionSpec.scala
+++ b/projection/src/test/scala/akka/projection/r2dbc/R2dbcTimestampOffsetProjectionSpec.scala
@@ -260,6 +260,17 @@ class R2dbcTimestampOffsetProjectionSpec
       slice)
   }
 
+  def backtrackingEnvelope(env: EventEnvelope[String]): EventEnvelope[String] =
+    new EventEnvelope[String](
+      env.offset,
+      env.persistenceId,
+      env.sequenceNr,
+      eventOption = None,
+      env.timestamp,
+      env.eventMetadata,
+      env.entityType,
+      env.slice)
+
   def createEnvelopes(pid: Pid, numberOfEvents: Int): immutable.IndexedSeq[EventEnvelope[String]] = {
     (1 to numberOfEvents).map { n =>
       createEnvelope(pid, n, tick().instant(), s"e$n")
@@ -268,6 +279,7 @@ class R2dbcTimestampOffsetProjectionSpec
 
   def createEnvelopesWithDuplicates(pid1: Pid, pid2: Pid): Vector[EventEnvelope[String]] = {
     val startTime = Instant.now()
+
     Vector(
       createEnvelope(pid1, 1, startTime, s"e1-1"),
       createEnvelope(pid1, 2, startTime.plusMillis(1), s"e1-2"),
@@ -1246,6 +1258,8 @@ class R2dbcTimestampOffsetProjectionSpec
       val envelopes = createEnvelopesWithDuplicates(pid1, pid2)
       val sourceProvider = createSourceProvider(envelopes)
       implicit val offsetStore = createOffsetStore(projectionId, sourceProvider)
+
+      info(s"pid1 [$pid1], pid2 [$pid2]")
 
       val flowHandler =
         FlowWithContext[EventEnvelope[String], ProjectionContext]

--- a/projection/src/test/scala/akka/projection/r2dbc/R2dbcTimestampOffsetStoreSpec.scala
+++ b/projection/src/test/scala/akka/projection/r2dbc/R2dbcTimestampOffsetStoreSpec.scala
@@ -91,6 +91,17 @@ class R2dbcTimestampOffsetStoreSpec
       slice)
   }
 
+  def backtrackingEnvelope(env: EventEnvelope[String]): EventEnvelope[String] =
+    new EventEnvelope[String](
+      env.offset,
+      env.persistenceId,
+      env.sequenceNr,
+      eventOption = None,
+      env.timestamp,
+      env.eventMetadata,
+      env.entityType,
+      env.slice)
+
   def createUpdatedDurableState(
       pid: Pid,
       revision: SeqNr,
@@ -346,12 +357,16 @@ class R2dbcTimestampOffsetStoreSpec
       // seqNr 1 is always accepted
       val env1 = createEnvelope("p4", 1L, startTime.plusMillis(1), "e4-1")
       offsetStore.isAccepted(env1).futureValue shouldBe true
+      offsetStore.isAccepted(backtrackingEnvelope(env1)).futureValue shouldBe true
       // but not if already inflight, seqNr 1 was accepted
       offsetStore.addInflight(env1)
-      offsetStore.isAccepted(createEnvelope("p4", 1L, startTime.plusMillis(1), "e4-1")).futureValue shouldBe false
+      val env1Later = createEnvelope("p4", 1L, startTime.plusMillis(1), "e4-1")
+      offsetStore.isAccepted(env1Later).futureValue shouldBe false
+      offsetStore.isAccepted(backtrackingEnvelope(env1Later)).futureValue shouldBe false
       // subsequent seqNr is accepted
       val env2 = createEnvelope("p4", 2L, startTime.plusMillis(2), "e4-2")
       offsetStore.isAccepted(env2).futureValue shouldBe true
+      offsetStore.isAccepted(backtrackingEnvelope(env2)).futureValue shouldBe true
       offsetStore.addInflight(env2)
       // but not when gap
       offsetStore.isAccepted(createEnvelope("p4", 4L, startTime.plusMillis(3), "e4-4")).futureValue shouldBe false
@@ -370,6 +385,10 @@ class R2dbcTimestampOffsetStoreSpec
       offsetStore.addInflight(env3)
       // and then it's not accepted again
       offsetStore.isAccepted(env3).futureValue shouldBe false
+      offsetStore.isAccepted(backtrackingEnvelope(env3)).futureValue shouldBe false
+      // and not when later seqNr is inflight
+      offsetStore.isAccepted(env2).futureValue shouldBe false
+      offsetStore.isAccepted(backtrackingEnvelope(env2)).futureValue shouldBe false
 
       // +1 to known, and then also subsequent are accepted (needed for grouped)
       val env4 = createEnvelope("p3", 6L, startTime.plusMillis(5), "e3-6")


### PR DESCRIPTION
This was noticed as a problem with atLeastOnceFlow but could probably happen with other async projections as well.

The scenario to trigger this was that events were added to in-flight but offset not stored yet. Then a backtracking query emitted previous events that were rejected (throw exception) because seqNr wasn't the expected previous+1. Solution is to accept such events as duplicates when they are in-flight.

Fixes #245
