### PR TITLE
Tagged pubsub

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ target/
 ext-lib-src/
 .classpath_nb
 .bsp
+metals.sbt

--- a/core/src/main/scala/akka/persistence/r2dbc/journal/R2dbcJournal.scala
+++ b/core/src/main/scala/akka/persistence/r2dbc/journal/R2dbcJournal.scala
@@ -187,7 +187,29 @@ private[r2dbc] final class R2dbcJournal(config: Config, cfgPath: String) extends
     if (pubSub.isDefined) {
       dbTimestamp.map { timestamp =>
         pubSub.foreach { p =>
-          messages.iterator.flatMap(_.payload.iterator).foreach(pr => p.publish(pr, timestamp))
+          messages.iterator
+            .flatMap(_.payload.iterator)
+            .foreach { pr =>
+              val untagged: PersistentRepr =
+                pr.payload match {
+                  case Tagged(tPayload, tags) =>
+                    // eventsByTag not implemented yet (see issue #82), so for now there's no need
+                    // to propagate the tags to subscribers.  When there is, having pubsub topics per tag
+                    // seems to be the way to go?
+                    PersistentRepr(
+                      payload = tPayload,
+                      sequenceNr = pr.sequenceNr,
+                      persistenceId = pr.persistenceId,
+                      manifest = pr.manifest,
+                      deleted = pr.deleted,
+                      sender = pr.sender,
+                      writerUuid = pr.writerUuid)
+
+                  case _ => pr
+                }
+
+              p.publish(untagged, timestamp)
+            }
         }
         Done
       }

--- a/core/src/main/scala/akka/persistence/r2dbc/journal/R2dbcJournal.scala
+++ b/core/src/main/scala/akka/persistence/r2dbc/journal/R2dbcJournal.scala
@@ -189,27 +189,7 @@ private[r2dbc] final class R2dbcJournal(config: Config, cfgPath: String) extends
         pubSub.foreach { p =>
           messages.iterator
             .flatMap(_.payload.iterator)
-            .foreach { pr =>
-              val untagged: PersistentRepr =
-                pr.payload match {
-                  case Tagged(tPayload, tags) =>
-                    // eventsByTag not implemented yet (see issue #82), so for now there's no need
-                    // to propagate the tags to subscribers.  When there is, having pubsub topics per tag
-                    // seems to be the way to go?
-                    PersistentRepr(
-                      payload = tPayload,
-                      sequenceNr = pr.sequenceNr,
-                      persistenceId = pr.persistenceId,
-                      manifest = pr.manifest,
-                      deleted = pr.deleted,
-                      sender = pr.sender,
-                      writerUuid = pr.writerUuid)
-
-                  case _ => pr
-                }
-
-              p.publish(untagged, timestamp)
-            }
+            .foreach(pr => p.publish(pr, timestamp))
         }
         Done
       }


### PR DESCRIPTION
#206 partially implements support for tagging events by persisting them (without adding query support see #82).

When tagged events are persisted, the `Tagged` wrapper is unwrapped, but this does not occur when the events are broadcast via pubsub.  The result is that queries will not see the `Tagged` wrapper when polling the DB but will when they receive events via pubsub.

This change unwraps the tagged events in pubsub.  This approach can be changed in the future, e.g. if a hypothetical `eventsByTagAndSlice` query is introduced.