### PR TITLE
Customizable entity type extraction in migration

### DIFF
--- a/migration/src/main/scala/akka/persistence/r2dbc/migration/MigrationTool.scala
+++ b/migration/src/main/scala/akka/persistence/r2dbc/migration/MigrationTool.scala
@@ -93,7 +93,7 @@ object MigrationTool {
  *
  * Note: tags are not migrated.
  */
-class MigrationTool(system: ActorSystem[_]) {
+class MigrationTool(system: ActorSystem[_], entityTypeExtractor: String => String = PersistenceId.extractEntityType) {
   import MigrationTool.Result
   import system.executionContext
   private implicit val sys: ActorSystem[_] = system
@@ -229,7 +229,7 @@ class MigrationTool(system: ActorSystem[_]) {
   }
 
   private def serializedJournalRow(env: ClassicEventEnvelope): SerializedJournalRow = {
-    val entityType = PersistenceId.extractEntityType(env.persistenceId)
+    val entityType = entityTypeExtractor(env.persistenceId)
     val slice = persistenceExt.sliceForPersistenceId(env.persistenceId)
 
     val event = env.event.asInstanceOf[AnyRef]


### PR DESCRIPTION
The migration tool uses `PersistenceId.extractEntityType` to derive an entity type from a persistence ID.  That method hardcodes the convention used in Lagom's Scala DSL, which isn't universal (Lagom's Java DSL doesn't follow it and non-Lagom users may have some other convention for encoding entity type in the persistence ID).

This change allows a custom entity-type extractor to be injected as a constructor parameter, defaulting to `PersistenceId.extractEntityType` for consistency with prior behavior.

Admittedly, I'm not entirely sure of the significance of the entity type in the journal schema, but I assume it's there for a reason (e.g. facilitating an `eventsByEntityTypeAndSlice` or similar query), so it's better to have it than not have it.