### PR TITLE
Implement Delete effect for DurableState, #276

### DIFF
--- a/core/src/test/scala/akka/persistence/r2dbc/TestActors.scala
+++ b/core/src/test/scala/akka/persistence/r2dbc/TestActors.scala
@@ -108,6 +108,7 @@ object TestActors {
     sealed trait Command
     final case class Persist(payload: Any) extends Command
     final case class PersistWithAck(payload: Any, replyTo: ActorRef[Done]) extends Command
+    final case class DeleteWithAck(replyTo: ActorRef[Done]) extends Command
     final case class Ping(replyTo: ActorRef[Done]) extends Command
     final case class Stop(replyTo: ActorRef[Done]) extends Command
 
@@ -135,6 +136,10 @@ object TestActors {
                   pid.id,
                   DurableStateBehavior.lastSequenceNumber(context) + 1)
                 Effect.persist(command.payload).thenRun(_ => command.replyTo ! Done)
+              case command: DeleteWithAck =>
+                context.log
+                  .debug("Delete pid [{}], seqNr [{}]", pid.id, DurableStateBehavior.lastSequenceNumber(context) + 1)
+                Effect.delete[Any]().thenRun(_ => command.replyTo ! Done)
               case Ping(replyTo) =>
                 replyTo ! Done
                 Effect.none

--- a/core/src/test/scala/akka/persistence/r2dbc/state/DurableStateStoreSpec.scala
+++ b/core/src/test/scala/akka/persistence/r2dbc/state/DurableStateStoreSpec.scala
@@ -94,14 +94,82 @@ class DurableStateStoreSpec
         s"Update failed: durable state for persistence id [${persistenceId.id}] could not be updated to revision [2]")
     }
 
-    "support deletions" in {
+    "hard delete when revision=0" in {
       val entityType = nextEntityType()
       val persistenceId = PersistenceId(entityType, "to-be-added-and-removed").id
       val value = "Genuinely Collaborative"
       store.upsertObject(persistenceId, 1L, value, unusedTag).futureValue
       store.getObject(persistenceId).futureValue should be(GetObjectResult(Some(value), 1L))
-      store.deleteObject(persistenceId).futureValue
+      store.deleteObject(persistenceId, revision = 0).futureValue
       store.getObject(persistenceId).futureValue should be(GetObjectResult(None, 0L))
+    }
+
+    "delete payload but keep revision" in {
+      val entityType = nextEntityType()
+      val persistenceId = PersistenceId(entityType, "to-be-added-and-removed").id
+      val value1 = "value1"
+      store.upsertObject(persistenceId, 1L, value1, unusedTag).futureValue
+      store.getObject(persistenceId).futureValue should be(GetObjectResult(Some(value1), 1L))
+      store.deleteObject(persistenceId, revision = 2L).futureValue
+      store.getObject(persistenceId).futureValue should be(GetObjectResult(None, 2L))
+
+      val value2 = "value2"
+      store.upsertObject(persistenceId, 3L, value2, unusedTag).futureValue
+      store.getObject(persistenceId).futureValue should be(GetObjectResult(Some(value2), 3L))
+    }
+
+    "update revision when deleting" in {
+      val entityType = nextEntityType()
+      val persistenceId = PersistenceId(entityType, "to-be-removed").id
+
+      store.deleteObject(persistenceId, revision = 1L).futureValue
+      store.getObject(persistenceId).futureValue should be(GetObjectResult(None, 1L))
+      store.deleteObject(persistenceId, revision = 2L).futureValue
+      store.getObject(persistenceId).futureValue should be(GetObjectResult(None, 2L))
+
+      val value1 = "value1"
+      store.upsertObject(persistenceId, 3L, value1, unusedTag).futureValue
+      store.getObject(persistenceId).futureValue should be(GetObjectResult(Some(value1), 3L))
+
+      store.deleteObject(persistenceId, revision = 4L).futureValue
+      store.getObject(persistenceId).futureValue should be(GetObjectResult(None, 4L))
+      store.deleteObject(persistenceId, revision = 5L).futureValue
+      store.getObject(persistenceId).futureValue should be(GetObjectResult(None, 5L))
+    }
+
+    "detect and reject concurrent delete of revision 1" in {
+      val entityType = nextEntityType()
+      val persistenceId = PersistenceId(entityType, "id-to-be-deleted-concurrently")
+      val value = "Genuinely Collaborative"
+      store.upsertObject(persistenceId.id, revision = 1L, value, entityType).futureValue
+      store.getObject(persistenceId.id).futureValue should be(GetObjectResult(Some(value), 1L))
+
+      val failure =
+        store.deleteObject(persistenceId.id, revision = 1L).failed.futureValue
+      failure.getMessage should include(
+        s"Insert delete marker with revision 1 failed: durable state for persistence id [${persistenceId.id}] already exists")
+    }
+
+    "detect and reject concurrent deletes" in {
+      if (!r2dbcSettings.durableStateAssertSingleWriter)
+        pending
+
+      val entityType = nextEntityType()
+      val persistenceId = PersistenceId(entityType, "id-to-be-updated-concurrently")
+      val value = "Genuinely Collaborative"
+      store.upsertObject(persistenceId.id, revision = 1L, value, entityType).futureValue
+      store.getObject(persistenceId.id).futureValue should be(GetObjectResult(Some(value), 1L))
+
+      val updatedValue = "Open to Feedback"
+      store.upsertObject(persistenceId.id, revision = 2L, updatedValue, entityType).futureValue
+      store.getObject(persistenceId.id).futureValue should be(GetObjectResult(Some(updatedValue), 2L))
+
+      // simulate a delete by a different node that didn't see the first one:
+      val updatedValue2 = "Genuine and Sincere in all Communications"
+      val failure =
+        store.deleteObject(persistenceId.id, revision = 2L).failed.futureValue
+      failure.getMessage should include(
+        s"Delete failed: durable state for persistence id [${persistenceId.id}] could not be updated to revision [2]")
     }
 
   }

--- a/docs/src/main/paradox/query.md
+++ b/docs/src/main/paradox/query.md
@@ -135,12 +135,16 @@ Java
 Scala
 :  @@snip [create](/docs/src/test/scala/docs/home/query/QueryDocCompileOnly.scala) { #currentChangesBySlices }
 
-The emitted `DurableStateChange` can be a `UpdatedDurableState` or `DeletedDurableState`, but `DeletedDurableState` is not implemented yet.
+The emitted `DurableStateChange` can be a `UpdatedDurableState` or `DeletedDurableState`.
 
 It will emit an `UpdatedDurableState` when the durable state is updated. When the state is updated again another
 `UpdatedDurableState` is emitted. It will always emit an `UpdatedDurableState` for the latest revision of the state,
 but there is no guarantee that all intermediate changes are emitted if the state is updated several times. Note that
 `UpdatedDurableState` contains the full current state, and it is not a delta from previous revision of state.
+
+It will emit an `DeletedDurableState` when the durable state is deleted. When the state is updated again a new
+`UpdatedDurableState` is emitted. There is no guarantee that all intermediate changes are emitted if the state is
+updated or deleted several times.
 
 `changesBySlices` should be used via @ref:[R2dbcProjection](projection.md), which will automatically handle the similar difficulties
 with duplicates as described for @ref[eventsBySlices](#eventsbyslices). When using `R2dbcProjection` the changes


### PR DESCRIPTION
* When deleting it will keep the record in the db, to keep track of latest revision number.
* Kept hard delete for revision=0 parameter.
* Emits DeletedDurableState in eventsBySlices query.

Fixes #276
