### PR TITLE
apidoc base_url

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -114,7 +114,7 @@ lazy val docs = project
     libraryDependencies ++= Dependencies.docs,
     makeSite := makeSite.dependsOn(LocalRootProject / ScalaUnidoc / doc).value,
     previewPath := (Paradox / siteSubdirName).value,
-    Preprocess / siteSubdirName := s"api/akka-projection/${projectInfoVersion.value}",
+    Preprocess / siteSubdirName := s"api/akka-persistence-r2dbc/${projectInfoVersion.value}",
     Preprocess / sourceDirectory := (LocalRootProject / ScalaUnidoc / unidoc / target).value,
     Paradox / siteSubdirName := s"docs/akka-persistence-r2dbc/${projectInfoVersion.value}",
     paradoxGroups := Map("Language" -> Seq("Java", "Scala")),
@@ -129,7 +129,14 @@ lazy val docs = project
       "extref.akka-projection.base_url" -> s"https://doc.akka.io/docs/akka-projection/${Dependencies.AkkaProjectionVersionInDocs}/%s",
       "extref.java-docs.base_url" -> "https://docs.oracle.com/en/java/javase/11/%s",
       "scaladoc.scala.base_url" -> s"https://www.scala-lang.org/api/current/",
-      "scaladoc.akka.base_url" -> s"https://doc.akka.io/api/akka/${Dependencies.AkkaVersion}",
+      "scaladoc.akka.persistence.r2dbc.base_url" -> s"/${(Preprocess / siteSubdirName).value}/",
+      "javadoc.akka.persistence.r2dbc.base_url" -> "", // no Javadoc is published
+      "scaladoc.akka.projection.r2dbc.base_url" -> s"/${(Preprocess / siteSubdirName).value}/",
+      "javadoc.akka.projection.r2dbc.base_url" -> "", // no Javadoc is published
+      "scaladoc.akka.projection.base_url" -> s"https://doc.akka.io/api/akka-projection/${Dependencies.AkkaProjectionVersionInDocs}/",
+      "javadoc.akka.projection.base_url" -> "", // no Javadoc is published
+      "scaladoc.akka.base_url" -> s"https://doc.akka.io/api/akka/${Dependencies.AkkaVersionInDocs}/",
+      "javadoc.akka.base_url" -> s"https://doc.akka.io/japi/akka/${Dependencies.AkkaVersionInDocs}/",
       "scaladoc.com.typesafe.config.base_url" -> s"https://lightbend.github.io/config/latest/api/"),
     ApidocPlugin.autoImport.apidocRootPackage := "akka",
     apidocRootPackage := "akka",


### PR DESCRIPTION
Wrong base_url

(cherry picked from commit fb794b0d1ba6950304c11b352094a348656934a0)

Note: api docs were missing when releasing 1.0.0, but I have published them now.
