### PR TITLE
Reduce periodic latency spikes

### DIFF
--- a/core/src/main/scala/akka/persistence/r2dbc/query/scaladsl/R2dbcReadJournal.scala
+++ b/core/src/main/scala/akka/persistence/r2dbc/query/scaladsl/R2dbcReadJournal.scala
@@ -167,7 +167,9 @@ final class R2dbcReadJournal(system: ExtendedActorSystem, config: Config, cfgPat
               pubSub.eventTopic(entityType, slice) ! Topic.Subscribe(ref.toTyped[EventEnvelope[Event]])
             }
           }
-      dbSource.merge(pubSubSource).via(deduplicate(settings.querySettings.deduplicateCapacity))
+      dbSource
+        .mergePrioritized(pubSubSource, leftPriority = 1, rightPriority = 10)
+        .via(deduplicate(settings.querySettings.deduplicateCapacity))
     } else
       dbSource
   }


### PR DESCRIPTION
* With pub-sub enabled there are latency spikes when the db queries are running, especially the backtracking queries.
* Seems to help with mergePrioritized
* Also limited number of backtracking queries that will be run before mixing with ordinary query, for better fairness
