### PR TITLE
fix: Use explicit microsecond timestamp resolution, #321

### DIFF
--- a/core/src/main/scala/akka/persistence/r2dbc/internal/BySliceQuery.scala
+++ b/core/src/main/scala/akka/persistence/r2dbc/internal/BySliceQuery.scala
@@ -91,7 +91,7 @@ import org.slf4j.Logger
   class Buckets(countByBucket: immutable.SortedMap[Buckets.EpochSeconds, Buckets.Count]) {
     import Buckets.{ Bucket, BucketDurationSeconds, Count, EpochSeconds }
 
-    val createdAt: Instant = Instant.now()
+    val createdAt: Instant = InstantFactory.now()
 
     def findTimeForLimit(from: Instant, atLeastCounts: Int): Option[Instant] = {
       val fromEpochSeconds = from.toEpochMilli / 1000
@@ -423,7 +423,7 @@ import org.slf4j.Logger
       state: QueryState): Option[Future[QueryState]] = {
     // Don't run this too frequently
     if ((state.buckets.isEmpty || JDuration
-        .between(state.buckets.createdAt, Instant.now())
+        .between(state.buckets.createdAt, InstantFactory.now())
         .compareTo(eventBucketCountInterval) > 0) &&
       // For Durable State we always refresh the bucket counts at the interval. For Event Sourced we know
       // that they don't change because events are append only.

--- a/core/src/main/scala/akka/persistence/r2dbc/internal/InstantFactory.scala
+++ b/core/src/main/scala/akka/persistence/r2dbc/internal/InstantFactory.scala
@@ -1,0 +1,24 @@
+/*
+ * Copyright (C) 2022 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.persistence.r2dbc.internal
+
+import java.time.Instant
+import java.time.temporal.ChronoUnit
+
+import akka.annotation.InternalApi
+
+/**
+ * INTERNAL API
+ */
+@InternalApi private[akka] object InstantFactory {
+
+  /**
+   * Current time truncated to microseconds. The reason for using microseconds is that Postgres timestamps has the
+   * resolution of microseconds but some OS/JDK (Linux/JDK17) has Instant resolution of nanoseconds.
+   */
+  def now(): Instant =
+    Instant.now().truncatedTo(ChronoUnit.MICROS)
+
+}

--- a/core/src/main/scala/akka/persistence/r2dbc/journal/R2dbcJournal.scala
+++ b/core/src/main/scala/akka/persistence/r2dbc/journal/R2dbcJournal.scala
@@ -28,6 +28,7 @@ import akka.persistence.journal.Tagged
 import akka.persistence.query.PersistenceQuery
 import akka.persistence.r2dbc.ConnectionFactoryProvider
 import akka.persistence.r2dbc.R2dbcSettings
+import akka.persistence.r2dbc.internal.InstantFactory
 import akka.persistence.r2dbc.internal.PubSub
 import akka.persistence.r2dbc.journal.JournalDao.SerializedEventMetadata
 import akka.persistence.r2dbc.journal.JournalDao.SerializedJournalRow
@@ -109,7 +110,7 @@ private[r2dbc] final class R2dbcJournal(config: Config, cfgPath: String) extends
 
   override def asyncWriteMessages(messages: immutable.Seq[AtomicWrite]): Future[immutable.Seq[Try[Unit]]] = {
     def atomicWrite(atomicWrite: AtomicWrite): Future[Instant] = {
-      val timestamp = if (journalSettings.useAppTimestamp) Instant.now() else JournalDao.EmptyDbTimestamp
+      val timestamp = if (journalSettings.useAppTimestamp) InstantFactory.now() else JournalDao.EmptyDbTimestamp
       val serialized: Try[Seq[SerializedJournalRow]] = Try {
         atomicWrite.payload.map { pr =>
           val (event, tags) = pr.payload match {

--- a/core/src/main/scala/akka/persistence/r2dbc/query/scaladsl/QueryDao.scala
+++ b/core/src/main/scala/akka/persistence/r2dbc/query/scaladsl/QueryDao.scala
@@ -5,10 +5,12 @@
 package akka.persistence.r2dbc.query.scaladsl
 
 import java.time.Instant
+
 import scala.concurrent.ExecutionContext
 import scala.concurrent.Future
 import scala.concurrent.duration.Duration
 import scala.concurrent.duration.FiniteDuration
+
 import akka.NotUsed
 import akka.actor.typed.ActorSystem
 import akka.actor.typed.scaladsl.LoggerOps
@@ -20,6 +22,7 @@ import akka.persistence.r2dbc.internal.Sql.Interpolation
 import akka.persistence.r2dbc.internal.BySliceQuery
 import akka.persistence.r2dbc.internal.BySliceQuery.Buckets
 import akka.persistence.r2dbc.internal.BySliceQuery.Buckets.Bucket
+import akka.persistence.r2dbc.internal.InstantFactory
 import akka.persistence.r2dbc.internal.R2dbcExecutor
 import akka.persistence.r2dbc.journal.JournalDao
 import akka.persistence.r2dbc.journal.JournalDao.SerializedJournalRow
@@ -209,7 +212,7 @@ private[r2dbc] class QueryDao(settings: R2dbcSettings, connectionFactory: Connec
       limit: Int): Future[Seq[Bucket]] = {
 
     val toTimestamp = {
-      val now = Instant.now() // not important to use database time
+      val now = InstantFactory.now() // not important to use database time
       if (fromTimestamp == Instant.EPOCH)
         now
       else {

--- a/core/src/main/scala/akka/persistence/r2dbc/state/scaladsl/DurableStateDao.scala
+++ b/core/src/main/scala/akka/persistence/r2dbc/state/scaladsl/DurableStateDao.scala
@@ -26,12 +26,14 @@ import io.r2dbc.spi.Row
 import io.r2dbc.spi.Statement
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
-
 import java.time.Instant
+
 import scala.concurrent.ExecutionContext
 import scala.concurrent.Future
 import scala.concurrent.duration.Duration
 import scala.concurrent.duration.FiniteDuration
+
+import akka.persistence.r2dbc.internal.InstantFactory
 
 /**
  * INTERNAL API
@@ -470,7 +472,7 @@ private[r2dbc] class DurableStateDao(settings: R2dbcSettings, connectionFactory:
       limit: Int): Future[Seq[Bucket]] = {
 
     val toTimestamp = {
-      val now = Instant.now() // not important to use database time
+      val now = InstantFactory.now() // not important to use database time
       if (fromTimestamp == Instant.EPOCH)
         now
       else {

--- a/core/src/test/scala/akka/persistence/r2dbc/internal/BySliceQueryBucketsSpec.scala
+++ b/core/src/test/scala/akka/persistence/r2dbc/internal/BySliceQueryBucketsSpec.scala
@@ -15,7 +15,7 @@ import org.scalatest.wordspec.AnyWordSpec
 
 class BySliceQueryBucketsSpec extends AnyWordSpec with TestSuite with Matchers {
 
-  private val startTime = Instant.now()
+  private val startTime = InstantFactory.now()
   private val firstBucketStartTime = startTime.plusSeconds(60)
   private val firstBucketStartEpochSeconds = firstBucketStartTime.toEpochMilli / 1000
 

--- a/core/src/test/scala/akka/persistence/r2dbc/query/EventsBySliceBacktrackingSpec.scala
+++ b/core/src/test/scala/akka/persistence/r2dbc/query/EventsBySliceBacktrackingSpec.scala
@@ -20,6 +20,7 @@ import akka.persistence.r2dbc.internal.Sql.Interpolation
 import akka.persistence.r2dbc.TestConfig
 import akka.persistence.r2dbc.TestData
 import akka.persistence.r2dbc.TestDbLifecycle
+import akka.persistence.r2dbc.internal.InstantFactory
 import akka.persistence.r2dbc.query.scaladsl.R2dbcReadJournal
 import akka.persistence.typed.PersistenceId
 import akka.serialization.SerializationExtension
@@ -87,7 +88,7 @@ class EventsBySliceBacktrackingSpec
       val sinkProbe = TestSink.probe[EventEnvelope[String]](system.classicSystem)
 
       // don't let behind-current-time be a reason for not finding events
-      val startTime = Instant.now().minusSeconds(10 * 60)
+      val startTime = InstantFactory.now().minusSeconds(10 * 60)
 
       writeEvent(slice1, pid1, 1L, startTime, "e1-1")
       writeEvent(slice1, pid1, 2L, startTime.plusMillis(1), "e1-2")

--- a/core/src/test/scala/akka/persistence/r2dbc/query/EventsBySlicePubSubSpec.scala
+++ b/core/src/test/scala/akka/persistence/r2dbc/query/EventsBySlicePubSubSpec.scala
@@ -26,6 +26,7 @@ import akka.persistence.r2dbc.TestActors.Persister.PersistWithAck
 import akka.persistence.r2dbc.TestConfig
 import akka.persistence.r2dbc.TestData
 import akka.persistence.r2dbc.TestDbLifecycle
+import akka.persistence.r2dbc.internal.InstantFactory
 import akka.persistence.r2dbc.internal.PubSub
 import akka.persistence.r2dbc.query.scaladsl.R2dbcReadJournal
 import akka.persistence.typed.PersistenceId
@@ -77,7 +78,7 @@ class EventsBySlicePubSubSpec
   }
 
   private def createEnvelope(pid: PersistenceId, seqNr: Long, evt: String): EventEnvelope[String] = {
-    val now = Instant.now()
+    val now = InstantFactory.now()
     EventEnvelope(
       TimestampOffset(Instant.now, Map(pid.id -> seqNr)),
       pid.id,

--- a/projection/src/test/resources/logback-test.xml
+++ b/projection/src/test/resources/logback-test.xml
@@ -12,8 +12,8 @@
         <appender-ref ref="STDOUT"/>
     </logger>
 
-    <logger name="akka.projection.r2dbc" level="TRACE" />
-    <logger name="akka.persistence.r2dbc" level="TRACE" />
+    <logger name="akka.projection.r2dbc" level="DEBUG" />
+    <logger name="akka.persistence.r2dbc" level="DEBUG" />
 <!--    <logger name="io.r2dbc.postgresql.QUERY" level="DEBUG" />-->
 <!--    <logger name="io.r2dbc.pool" level="DEBUG" />-->
 

--- a/projection/src/test/scala/akka/projection/r2dbc/EventSourcedEndToEndSpec.scala
+++ b/projection/src/test/scala/akka/projection/r2dbc/EventSourcedEndToEndSpec.scala
@@ -286,7 +286,7 @@ class EventSourcedEndToEndSpec
       val pid2 = nextPid(entityType)
       val pid3 = nextPid(entityType)
 
-      val startTime = Instant.now()
+      val startTime = TestClock.nowMicros().instant()
       val oldTime = startTime.minus(projectionSettings.timeWindow).minusSeconds(60)
       writeEvent(pid1, 1L, startTime, "e1-1")
 

--- a/projection/src/test/scala/akka/projection/r2dbc/R2dbcOffsetStoreSpec.scala
+++ b/projection/src/test/scala/akka/projection/r2dbc/R2dbcOffsetStoreSpec.scala
@@ -31,7 +31,7 @@ class R2dbcOffsetStoreSpec
   override def typedSystem: ActorSystem[_] = system
 
   // test clock for testing of the `last_updated` Instant
-  private val clock = new TestClock
+  private val clock = TestClock.nowMillis()
 
   private val settings = R2dbcProjectionSettings(testKit.system)
 

--- a/projection/src/test/scala/akka/projection/r2dbc/R2dbcOffsetStoreStateSpec.scala
+++ b/projection/src/test/scala/akka/projection/r2dbc/R2dbcOffsetStoreStateSpec.scala
@@ -16,7 +16,7 @@ class R2dbcOffsetStoreStateSpec extends AnyWordSpec with TestSuite with Matchers
 
   "R2dbcOffsetStore.State" should {
     "add records and keep track of pids and latest offset" in {
-      val t0 = Instant.now()
+      val t0 = TestClock.nowMillis().instant()
       val state1 = State.empty
         .add(Vector(Record("p1", 1, t0), Record("p1", 2, t0.plusMillis(1)), Record("p1", 3, t0.plusMillis(2))))
       state1.byPid("p1").seqNr shouldBe 3L
@@ -43,7 +43,7 @@ class R2dbcOffsetStoreStateSpec extends AnyWordSpec with TestSuite with Matchers
 
     // reproducer of issue #173
     "include highest seqNr in seen of latestOffset" in {
-      val t0 = Instant.now()
+      val t0 = TestClock.nowMillis().instant()
       val records =
         Vector(Record("p4", 9, t0), Record("p2", 2, t0), Record("p3", 5, t0), Record("p2", 1, t0), Record("p1", 3, t0))
       val state = State(records)
@@ -53,7 +53,7 @@ class R2dbcOffsetStoreStateSpec extends AnyWordSpec with TestSuite with Matchers
     }
 
     "evict old" in {
-      val t0 = Instant.now()
+      val t0 = TestClock.nowMillis().instant()
       val state1 = State.empty
         .add(
           Vector(
@@ -87,7 +87,7 @@ class R2dbcOffsetStoreStateSpec extends AnyWordSpec with TestSuite with Matchers
     }
 
     "find duplicate" in {
-      val t0 = Instant.now()
+      val t0 = TestClock.nowMillis().instant()
       val state =
         State(Vector(Record("p1", 1, t0), Record("p2", 2, t0.plusMillis(1)), Record("p3", 3, t0.plusMillis(2))))
       state.isDuplicate(Record("p1", 1, t0)) shouldBe true

--- a/projection/src/test/scala/akka/projection/r2dbc/R2dbcTimestampOffsetProjectionSpec.scala
+++ b/projection/src/test/scala/akka/projection/r2dbc/R2dbcTimestampOffsetProjectionSpec.scala
@@ -241,7 +241,7 @@ class R2dbcTimestampOffsetProjectionSpec
 
   }
 
-  private val clock = new TestClock
+  private val clock = TestClock.nowMicros()
   def tick(): TestClock = {
     clock.tick(JDuration.ofMillis(1))
     clock
@@ -278,7 +278,7 @@ class R2dbcTimestampOffsetProjectionSpec
   }
 
   def createEnvelopesWithDuplicates(pid1: Pid, pid2: Pid): Vector[EventEnvelope[String]] = {
-    val startTime = Instant.now()
+    val startTime = TestClock.nowMicros().instant()
 
     Vector(
       createEnvelope(pid1, 1, startTime, s"e1-1"),
@@ -542,7 +542,7 @@ class R2dbcTimestampOffsetProjectionSpec
       val pid2 = UUID.randomUUID().toString
       val projectionId = genRandomProjectionId()
 
-      val startTime = Instant.now()
+      val startTime = TestClock.nowMicros().instant()
       val envelopes1 = createEnvelopesUnknownSequenceNumbers(startTime, pid1, pid2)
       val sourceProvider1 = createSourceProvider(envelopes1)
       implicit val offsetStore = createOffsetStore(projectionId, sourceProvider1)
@@ -654,7 +654,7 @@ class R2dbcTimestampOffsetProjectionSpec
       val pid2 = UUID.randomUUID().toString
       val projectionId = genRandomProjectionId()
 
-      val startTime = Instant.now()
+      val startTime = TestClock.nowMicros().instant()
       val envelopes1 = createEnvelopesUnknownSequenceNumbers(startTime, pid1, pid2)
       val sourceProvider1 = createBacktrackingSourceProvider(envelopes1)
       implicit val offsetStore = createOffsetStore(projectionId, sourceProvider1)
@@ -803,7 +803,7 @@ class R2dbcTimestampOffsetProjectionSpec
       val pid2 = UUID.randomUUID().toString
       val projectionId = genRandomProjectionId()
 
-      val startTime = Instant.now()
+      val startTime = TestClock.nowMicros().instant()
       val sourceProvider = new TestSourceProviderWithInput()
       implicit val offsetStore =
         new R2dbcOffsetStore(projectionId, Some(sourceProvider), system, settings, r2dbcExecutor)
@@ -940,7 +940,7 @@ class R2dbcTimestampOffsetProjectionSpec
       val pid2 = UUID.randomUUID().toString
       val projectionId = genRandomProjectionId()
 
-      val startTime = Instant.now()
+      val startTime = TestClock.nowMicros().instant()
       val sourceProvider = new TestSourceProviderWithInput()
       implicit val offsetStore =
         new R2dbcOffsetStore(projectionId, Some(sourceProvider), system, settings, r2dbcExecutor)
@@ -1144,7 +1144,7 @@ class R2dbcTimestampOffsetProjectionSpec
       val pid1 = UUID.randomUUID().toString
       val pid2 = UUID.randomUUID().toString
       val projectionId = genRandomProjectionId()
-      val startTime = Instant.now()
+      val startTime = TestClock.nowMicros().instant()
       val sourceProvider = new TestSourceProviderWithInput()
       implicit val offsetStore =
         new R2dbcOffsetStore(projectionId, Some(sourceProvider), system, settings, r2dbcExecutor)
@@ -1286,7 +1286,7 @@ class R2dbcTimestampOffsetProjectionSpec
       val pid2 = UUID.randomUUID().toString
       val projectionId = genRandomProjectionId()
 
-      val startTime = Instant.now()
+      val startTime = TestClock.nowMicros().instant()
       val sourceProvider = new TestSourceProviderWithInput()
       implicit val offsetStore =
         new R2dbcOffsetStore(projectionId, Some(sourceProvider), system, settings, r2dbcExecutor)

--- a/projection/src/test/scala/akka/projection/r2dbc/R2dbcTimestampOffsetStoreSpec.scala
+++ b/projection/src/test/scala/akka/projection/r2dbc/R2dbcTimestampOffsetStoreSpec.scala
@@ -60,7 +60,7 @@ class R2dbcTimestampOffsetStoreSpec
 
   override def typedSystem: ActorSystem[_] = system
 
-  private val clock = new TestClock
+  private val clock = TestClock.nowMicros()
   def tick(): Unit = clock.tick(JDuration.ofMillis(1))
 
   private val log = LoggerFactory.getLogger(getClass)
@@ -347,10 +347,10 @@ class R2dbcTimestampOffsetStoreSpec
 
     "accept known sequence numbers and reject unknown" in {
       val projectionId = genRandomProjectionId()
-      val eventTimestampQueryClock = new TestClock
+      val eventTimestampQueryClock = TestClock.nowMicros()
       val offsetStore = createOffsetStore(projectionId, eventTimestampQueryClock = eventTimestampQueryClock)
 
-      val startTime = Instant.now()
+      val startTime = TestClock.nowMicros().instant()
       val offset1 = TimestampOffset(startTime, Map("p1" -> 3L, "p2" -> 1L, "p3" -> 5L))
       offsetStore.saveOffset(offset1).futureValue
 
@@ -427,7 +427,7 @@ class R2dbcTimestampOffsetStoreSpec
       val projectionId = genRandomProjectionId()
       val offsetStore = createOffsetStore(projectionId)
 
-      val startTime = Instant.now()
+      val startTime = TestClock.nowMicros().instant()
 
       val envelope1 = createEnvelope("p1", 1L, startTime.plusMillis(1), "e1-1")
       val envelope2 = createEnvelope("p1", 2L, startTime.plusMillis(2), "e1-2")
@@ -464,7 +464,7 @@ class R2dbcTimestampOffsetStoreSpec
 
     "filter accepted" in {
       val projectionId = genRandomProjectionId()
-      val startTime = Instant.now()
+      val startTime = TestClock.nowMicros().instant()
       val offsetStore = createOffsetStore(projectionId)
 
       val offset1 = TimestampOffset(startTime, Map("p1" -> 3L, "p2" -> 1L, "p3" -> 5L))
@@ -489,7 +489,7 @@ class R2dbcTimestampOffsetStoreSpec
       val projectionId = genRandomProjectionId()
       val offsetStore = createOffsetStore(projectionId)
 
-      val startTime = Instant.now()
+      val startTime = TestClock.nowMicros().instant()
       val offset1 = TimestampOffset(startTime, Map("p1" -> 3L, "p2" -> 1L, "p3" -> 5L))
       offsetStore.saveOffset(offset1).futureValue
 
@@ -555,7 +555,7 @@ class R2dbcTimestampOffsetStoreSpec
       import evictSettings._
       val offsetStore = createOffsetStore(projectionId, evictSettings)
 
-      val startTime = Instant.now()
+      val startTime = TestClock.nowMicros().instant()
       log.debug("Start time [{}]", startTime)
 
       offsetStore.saveOffset(TimestampOffset(startTime, Map("p1" -> 1L))).futureValue
@@ -598,7 +598,7 @@ class R2dbcTimestampOffsetStoreSpec
       import deleteSettings._
       val offsetStore = createOffsetStore(projectionId, deleteSettings)
 
-      val startTime = Instant.now()
+      val startTime = TestClock.nowMicros().instant()
       log.debug("Start time [{}]", startTime)
 
       offsetStore.saveOffset(TimestampOffset(startTime, Map("p1" -> 1L))).futureValue
@@ -630,7 +630,7 @@ class R2dbcTimestampOffsetStoreSpec
       import deleteSettings._
       val offsetStore = createOffsetStore(projectionId, deleteSettings)
 
-      val startTime = Instant.now()
+      val startTime = TestClock.nowMicros().instant()
       log.debug("Start time [{}]", startTime)
 
       offsetStore.saveOffset(TimestampOffset(startTime, Map("p1" -> 1L))).futureValue

--- a/projection/src/test/scala/akka/projection/r2dbc/TestClock.scala
+++ b/projection/src/test/scala/akka/projection/r2dbc/TestClock.scala
@@ -9,15 +9,25 @@ import java.time.Duration
 import java.time.Instant
 import java.time.ZoneId
 import java.time.ZoneOffset
+import java.time.temporal.ChronoUnit
+import java.time.temporal.TemporalUnit
 
 import akka.annotation.InternalApi
 
-/**
- * INTERNAL API
- */
-@InternalApi private[projection] class TestClock extends Clock {
+object TestClock {
+  def nowMillis(): TestClock = new TestClock(ChronoUnit.MILLIS)
+  def nowMicros(): TestClock = new TestClock(ChronoUnit.MICROS)
+}
 
-  @volatile private var _instant = roundToMillis(Instant.now())
+/**
+ * Clock for testing purpose, which is truncated to a resolution (milliseconds or microseconds).
+ *
+ * The reason for truncating to the resolution is that Postgres timestamps has the resolution of microseconds but some
+ * OS/JDK (Linux/JDK17) has Instant resolution of nanoseconds.
+ */
+@InternalApi private[projection] class TestClock(resolution: TemporalUnit) extends Clock {
+
+  @volatile private var _instant = Instant.now().truncatedTo(resolution)
 
   override def getZone: ZoneId = ZoneOffset.UTC
 
@@ -28,18 +38,15 @@ import akka.annotation.InternalApi
     _instant
 
   def setInstant(newInstant: Instant): Unit =
-    _instant = roundToMillis(newInstant)
+    _instant = newInstant.truncatedTo(resolution)
 
+  /**
+   * Increase the clock with this duration (truncated to the resolution)
+   */
   def tick(duration: Duration): Instant = {
-    val newInstant = roundToMillis(_instant.plus(duration))
+    val newInstant = _instant.plus(duration.truncatedTo(resolution))
     _instant = newInstant
     newInstant
-  }
-
-  private def roundToMillis(i: Instant): Instant = {
-    // algo taken from java.time.Clock.tick
-    val epochMilli = i.toEpochMilli
-    Instant.ofEpochMilli(epochMilli - Math.floorMod(epochMilli, 1L))
   }
 
 }

--- a/projection/src/test/scala/akka/projection/r2dbc/TestClock.scala
+++ b/projection/src/test/scala/akka/projection/r2dbc/TestClock.scala
@@ -44,7 +44,7 @@ object TestClock {
    * Increase the clock with this duration (truncated to the resolution)
    */
   def tick(duration: Duration): Instant = {
-    val newInstant = _instant.plus(duration.truncatedTo(resolution))
+    val newInstant = _instant.plus(duration).truncatedTo(resolution)
     _instant = newInstant
     newInstant
   }


### PR DESCRIPTION
* Truncate timestamps to microseconds because Postgres timestamps has the resolution of microseconds but some OS/JDK (Linux/JDK17) has Instant resolution of nanoseconds.
* This could have been a problem when sending the events directly vs reading through the db.
* Change TestClock to use microseconds or milliseconds and use it from tests instead of Instant.now().
* Some tests that are not using the timestamp offset must still use millisecond resolution.

<!--
  Are there any relevant issues / PRs / mailing lists discussions?
  Please reference them here - but don't use `fixes` notation.
-->
References #321
