### PR TITLE
ci: check out full history for Fossa analyze

### DIFF
--- a/.github/workflows/fossa.yml
+++ b/.github/workflows/fossa.yml
@@ -16,6 +16,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3.1.0
+        with:
+          fetch-depth: 0
 
       - name: Cache Coursier cache
         uses: coursier/cache-action@v6.4.0


### PR DESCRIPTION
Fossa runs `sbt makePom` internally and needs more git history to make MiMa find the latest version.