### PR TITLE
build: don't copy jvmopts in publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches:
       - main
-    tags: ["*"]
+    tags: [ "*" ]
 
 permissions:
   contents: read
@@ -31,7 +31,6 @@ jobs:
 
       - name: Publish
         run: |-
-          cp .jvmopts-ci .jvmopts
           sbt ci-release
         env:
           PGP_PASSPHRASE: ${{ secrets.PGP_PASSPHRASE }}
@@ -64,7 +63,6 @@ jobs:
           echo $SCP_SECRET | base64 -d > /tmp/id_rsa
           chmod 600 /tmp/id_rsa
           ssh-add /tmp/id_rsa
-          cp .jvmopts-ci .jvmopts
           sbt docs/publishRsync
         env:
           SCP_SECRET: ${{ secrets.SCP_SECRET }}


### PR DESCRIPTION
* because then it will bump the version and not match the tag

@ennru This can be a problem in all repositories where this was changed.