### PR TITLE
feat: Support for storing query representation for durable state from the write side

### DIFF
--- a/core/src/main/resources/reference.conf
+++ b/core/src/main/resources/reference.conf
@@ -79,6 +79,31 @@ akka.persistence.r2dbc {
     # previous revision. There might be a small performance gain if
     # this is disabled.
     assert-single-writer = on
+
+    # Extract a field from the state and store in an additional database column.
+    # Primary use case is for secondary indexes that can be queried.
+    # Each entity type can have several additional columns.
+    # The AdditionalColumn implementation may optionally define an ActorSystem
+    # constructor parameter.
+    additional-columns {
+      #"<entity-type-name>" = ["<fqcn of AdditionalColumn implementation>"]
+    }
+
+    # Use another table for the given entity types. Typically used together with
+    # additional-columns but can also be used without addition-columns.
+    custom-table {
+      #"<entity-type-name>" =  <other_durable_state_table>
+    }
+
+    # Additional processing in the same transaction as the Durable State upsert
+    # or delete. Primary use case is for storing a query or aggregate representation
+    # in a separate table.
+    # The ChangeHandler implementation may optionally define an ActorSystem
+    # constructor parameter.
+    change-handler {
+      #<entity-type-name>" = "<fqcn of ChangeHandler implementation>"
+    }
+
   }
 }
 // #durable-state-settings

--- a/core/src/main/scala/akka/persistence/r2dbc/internal/AdditionalColumnFactory.scala
+++ b/core/src/main/scala/akka/persistence/r2dbc/internal/AdditionalColumnFactory.scala
@@ -1,0 +1,85 @@
+/*
+ * Copyright (C) 2022 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.persistence.r2dbc.internal
+
+import scala.util.Try
+
+import akka.actor.{ ActorSystem => ClassicActorSystem }
+import akka.actor.ExtendedActorSystem
+import akka.actor.typed.ActorSystem
+import akka.annotation.InternalApi
+import akka.persistence.r2dbc.state.scaladsl.AdditionalColumn
+import akka.persistence.r2dbc.state.javadsl
+
+/**
+ * INTERNAL API
+ */
+@InternalApi private[akka] object AdditionalColumnFactory {
+
+  /**
+   * Adapter from javadsl.AdditionColumn to scaladsl.AdditionalColumn
+   */
+  final class AdditionColumnAdapter(delegate: javadsl.AdditionalColumn[Any, Any]) extends AdditionalColumn[Any, Any] {
+
+    override private[akka] val fieldClass: Class[_] =
+      delegate.fieldClass
+
+    override def columnName: String =
+      delegate.columnName
+
+    override def bind(upsert: AdditionalColumn.Upsert[Any]): AdditionalColumn.Binding[Any] = {
+      val javadslUpsert = new javadsl.AdditionalColumn.Upsert[Any](
+        upsert.persistenceId,
+        upsert.entityType,
+        upsert.slice,
+        upsert.revision,
+        upsert.value)
+      delegate.bind(javadslUpsert) match {
+        case bindValue: javadsl.AdditionalColumn.BindValue[_] => AdditionalColumn.BindValue(bindValue.value)
+        case javadsl.AdditionalColumn.BindNull                => AdditionalColumn.BindNull
+        case javadsl.AdditionalColumn.Skip                    => AdditionalColumn.Skip
+      }
+    }
+
+  }
+
+  def create(system: ActorSystem[_], fqcn: String): AdditionalColumn[Any, Any] = {
+    val dynamicAccess = system.classicSystem.asInstanceOf[ExtendedActorSystem].dynamicAccess
+
+    def tryCreateScaladslInstance(): Try[AdditionalColumn[Any, Any]] = {
+      dynamicAccess
+        .createInstanceFor[AdditionalColumn[Any, Any]](fqcn, Nil)
+        .orElse(
+          dynamicAccess
+            .createInstanceFor[AdditionalColumn[Any, Any]](fqcn, List(classOf[ActorSystem[_]] -> system))
+            .orElse(dynamicAccess.createInstanceFor[AdditionalColumn[Any, Any]](
+              fqcn,
+              List(classOf[ClassicActorSystem] -> system.classicSystem))))
+    }
+
+    def tryCreateJavadslInstance(): Try[javadsl.AdditionalColumn[Any, Any]] = {
+      dynamicAccess
+        .createInstanceFor[javadsl.AdditionalColumn[Any, Any]](fqcn, Nil)
+        .orElse(
+          dynamicAccess
+            .createInstanceFor[javadsl.AdditionalColumn[Any, Any]](fqcn, List(classOf[ActorSystem[_]] -> system))
+            .orElse(dynamicAccess.createInstanceFor[javadsl.AdditionalColumn[Any, Any]](
+              fqcn,
+              List(classOf[ClassicActorSystem] -> system.classicSystem))))
+    }
+
+    def adapt(javadslColumn: javadsl.AdditionalColumn[Any, Any]): AdditionalColumn[Any, Any] =
+      new AdditionColumnAdapter(javadslColumn)
+
+    tryCreateScaladslInstance()
+      .orElse(tryCreateJavadslInstance().map(adapt))
+      .getOrElse(
+        throw new IllegalArgumentException(
+          s"Additional column [$fqcn] must implement " +
+          s"[${classOf[AdditionalColumn[_, _]].getName}] or [${classOf[javadsl.AdditionalColumn[_, _]].getName}]. It " +
+          s"may have an ActorSystem constructor parameter."))
+  }
+
+}

--- a/core/src/main/scala/akka/persistence/r2dbc/internal/ChangeHandlerFactory.scala
+++ b/core/src/main/scala/akka/persistence/r2dbc/internal/ChangeHandlerFactory.scala
@@ -1,0 +1,78 @@
+/*
+ * Copyright (C) 2022 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.persistence.r2dbc.internal
+
+import scala.compat.java8.FutureConverters._
+import scala.concurrent.Future
+import scala.util.Try
+
+import akka.Done
+import akka.actor.ExtendedActorSystem
+import akka.actor.typed.ActorSystem
+import akka.annotation.InternalApi
+import akka.persistence.query.DurableStateChange
+import akka.persistence.r2dbc.session.scaladsl.R2dbcSession
+import akka.persistence.r2dbc.state.javadsl
+import akka.persistence.r2dbc.state.scaladsl.ChangeHandler
+
+/**
+ * INTERNAL API
+ */
+@InternalApi private[akka] object ChangeHandlerFactory {
+
+  /**
+   * Adapter from javadsl.ChangeHandler to scaladsl.ChangeHandler
+   */
+  final class ChangeHandlerAdapter(delegate: javadsl.ChangeHandler[Any]) extends ChangeHandler[Any] {
+    override def process(session: R2dbcSession, change: DurableStateChange[Any]): Future[Done] = {
+      val javadslSession =
+        new akka.persistence.r2dbc.session.javadsl.R2dbcSession(session.connection)(session.ec, session.system)
+      delegate.process(javadslSession, change).toScala
+    }
+  }
+
+  def create(system: ActorSystem[_], fqcn: String): ChangeHandler[Any] = {
+    val dynamicAccess = system.classicSystem.asInstanceOf[ExtendedActorSystem].dynamicAccess
+
+    def tryCreateScaladslInstance(): Try[ChangeHandler[Any]] = {
+      dynamicAccess
+        .createInstanceFor[ChangeHandler[Any]](fqcn, Nil)
+        .orElse(
+          dynamicAccess
+            .createInstanceFor[ChangeHandler[Any]](fqcn, List(classOf[ActorSystem[_]] -> system))
+            .orElse(
+              dynamicAccess
+                .createInstanceFor[ChangeHandler[Any]](
+                  fqcn,
+                  List(classOf[akka.actor.ActorSystem] -> system.classicSystem))))
+    }
+
+    def tryCreateJavadslInstance(): Try[javadsl.ChangeHandler[Any]] = {
+      dynamicAccess
+        .createInstanceFor[javadsl.ChangeHandler[Any]](fqcn, Nil)
+        .orElse(
+          dynamicAccess
+            .createInstanceFor[javadsl.ChangeHandler[Any]](fqcn, List(classOf[ActorSystem[_]] -> system))
+            .orElse(
+              dynamicAccess
+                .createInstanceFor[javadsl.ChangeHandler[Any]](
+                  fqcn,
+                  List(classOf[akka.actor.ActorSystem] -> system.classicSystem))))
+    }
+
+    def adapt(changeHandler: javadsl.ChangeHandler[Any]): ChangeHandler[Any] =
+      new ChangeHandlerAdapter(changeHandler)
+
+    tryCreateScaladslInstance()
+      .orElse(tryCreateJavadslInstance().map(adapt))
+      .getOrElse(
+        throw new IllegalArgumentException(
+          s"Additional column [$fqcn] must implement " +
+          s"[${classOf[ChangeHandler[_]].getName}] or [${classOf[javadsl.ChangeHandler[_]].getName}]. It " +
+          s"may have an ActorSystem constructor parameter."))
+
+  }
+
+}

--- a/core/src/main/scala/akka/persistence/r2dbc/internal/R2dbcExecutor.scala
+++ b/core/src/main/scala/akka/persistence/r2dbc/internal/R2dbcExecutor.scala
@@ -246,8 +246,8 @@ class R2dbcExecutor(val connectionFactory: ConnectionFactory, log: Logger, logDb
   }
 
   /**
-   * Runs the passed function in using a Connection that's participating on a transaction Transaction is commit at the
-   * end or rolled back in case of failures.
+   * Runs the passed function in using a Connection with a new transaction. The connection is closed and the transaction
+   * is committed at the end or rolled back in case of failures.
    */
   def withConnection[A](logPrefix: String)(fun: Connection => Future[A]): Future[A] = {
     getConnection(logPrefix).flatMap { connection =>

--- a/core/src/main/scala/akka/persistence/r2dbc/session/javadsl/R2dbcSession.scala
+++ b/core/src/main/scala/akka/persistence/r2dbc/session/javadsl/R2dbcSession.scala
@@ -2,22 +2,48 @@
  * Copyright (C) 2022 Lightbend Inc. <https://www.lightbend.com>
  */
 
-package akka.projection.r2dbc.javadsl
+package akka.persistence.r2dbc.session.javadsl
 
 import java.util.Optional
 import java.util.concurrent.CompletionStage
+import java.util.function.{ Function => JFunction }
+
+import scala.collection.JavaConverters._
 import scala.compat.java8.FutureConverters._
 import scala.compat.java8.OptionConverters._
 import scala.concurrent.ExecutionContext
+
 import akka.actor.typed.ActorSystem
 import akka.annotation.ApiMayChange
 import akka.dispatch.ExecutionContexts
 import akka.persistence.r2dbc.internal.R2dbcExecutor
+import akka.persistence.r2dbc.session.scaladsl
 import io.r2dbc.spi.Connection
 import io.r2dbc.spi.Row
 import io.r2dbc.spi.Statement
 
-import scala.collection.JavaConverters._
+@ApiMayChange
+object R2dbcSession {
+
+  /**
+   * Runs the passed function in using a R2dbcSession with a new transaction. The connection is closed and the
+   * transaction is committed at the end or rolled back in case of failures.
+   */
+  def withSession[A](system: ActorSystem[_], fun: JFunction[R2dbcSession, CompletionStage[A]]): CompletionStage[A] = {
+    withSession(system, "akka.persistence.r2dbc.connection-factory", fun)
+  }
+
+  def withSession[A](
+      system: ActorSystem[_],
+      connectionFactoryConfigPath: String,
+      fun: JFunction[R2dbcSession, CompletionStage[A]]): CompletionStage[A] = {
+    scaladsl.R2dbcSession.withSession(system, connectionFactoryConfigPath) { scaladslSession =>
+      val javadslSession = new R2dbcSession(scaladslSession.connection)(system.executionContext, system)
+      fun(javadslSession).toScala
+    }
+  }.toJava
+
+}
 
 @ApiMayChange
 final class R2dbcSession(val connection: Connection)(implicit ec: ExecutionContext, system: ActorSystem[_]) {

--- a/core/src/main/scala/akka/persistence/r2dbc/session/scaladsl/R2dbcSession.scala
+++ b/core/src/main/scala/akka/persistence/r2dbc/session/scaladsl/R2dbcSession.scala
@@ -1,0 +1,64 @@
+/*
+ * Copyright (C) 2022 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.persistence.r2dbc.session.scaladsl
+
+import scala.collection.immutable
+import scala.concurrent.ExecutionContext
+import scala.concurrent.Future
+import scala.concurrent.duration._
+
+import akka.actor.typed.ActorSystem
+import akka.annotation.ApiMayChange
+import akka.persistence.r2dbc.ConnectionFactoryProvider
+import akka.persistence.r2dbc.internal.R2dbcExecutor
+import io.r2dbc.spi.Connection
+import io.r2dbc.spi.Row
+import io.r2dbc.spi.Statement
+import org.slf4j.LoggerFactory
+
+@ApiMayChange
+object R2dbcSession {
+  private val log = LoggerFactory.getLogger(classOf[R2dbcSession])
+
+  private val logDbCallsDisabled = -1.millis
+
+  /**
+   * Runs the passed function in using a R2dbcSession with a new transaction. The connection is closed and the
+   * transaction is committed at the end or rolled back in case of failures.
+   */
+  def withSession[A](system: ActorSystem[_])(fun: R2dbcSession => Future[A]): Future[A] = {
+    withSession(system, "akka.persistence.r2dbc.connection-factory")(fun)
+  }
+
+  def withSession[A](system: ActorSystem[_], connectionFactoryConfigPath: String)(
+      fun: R2dbcSession => Future[A]): Future[A] = {
+    val connectionFactory = ConnectionFactoryProvider(system).connectionFactoryFor(connectionFactoryConfigPath)
+    val r2dbcExecutor = new R2dbcExecutor(connectionFactory, log, logDbCallsDisabled)(system.executionContext, system)
+    r2dbcExecutor.withConnection("R2dbcSession") { connection =>
+      val session = new R2dbcSession(connection)(system.executionContext, system)
+      fun(session)
+    }
+  }
+}
+
+@ApiMayChange
+final class R2dbcSession(val connection: Connection)(implicit val ec: ExecutionContext, val system: ActorSystem[_]) {
+
+  def createStatement(sql: String): Statement =
+    connection.createStatement(sql)
+
+  def updateOne(statement: Statement): Future[Long] =
+    R2dbcExecutor.updateOneInTx(statement)
+
+  def update(statements: immutable.IndexedSeq[Statement]): Future[immutable.IndexedSeq[Long]] =
+    R2dbcExecutor.updateInTx(statements)
+
+  def selectOne[A](statement: Statement)(mapRow: Row => A): Future[Option[A]] =
+    R2dbcExecutor.selectOneInTx(statement, mapRow)
+
+  def select[A](statement: Statement)(mapRow: Row => A): Future[immutable.IndexedSeq[A]] =
+    R2dbcExecutor.selectInTx(statement, mapRow)
+
+}

--- a/core/src/main/scala/akka/persistence/r2dbc/state/ChangeHandlerException.scala
+++ b/core/src/main/scala/akka/persistence/r2dbc/state/ChangeHandlerException.scala
@@ -1,0 +1,10 @@
+/*
+ * Copyright (C) 2022 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.persistence.r2dbc.state
+
+import akka.annotation.ApiMayChange
+
+@ApiMayChange
+final class ChangeHandlerException(message: String, cause: Throwable) extends RuntimeException(message, cause)

--- a/core/src/main/scala/akka/persistence/r2dbc/state/javadsl/AdditionalColumn.scala
+++ b/core/src/main/scala/akka/persistence/r2dbc/state/javadsl/AdditionalColumn.scala
@@ -1,0 +1,54 @@
+/*
+ * Copyright (C) 2022 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.persistence.r2dbc.state.javadsl
+
+import akka.annotation.ApiMayChange
+import akka.annotation.InternalApi
+
+@ApiMayChange
+object AdditionalColumn {
+  final case class Upsert[A](persistenceId: String, entityType: String, slice: Int, revision: Long, value: A)
+
+  sealed trait Binding[+B]
+
+  def bindValue[B](value: B): Binding[B] = new BindValue(value)
+
+  def bindNull[B]: Binding[B] = BindNull
+
+  def skip[B]: Binding[B] = Skip
+
+  /**
+   * INTERNAL API
+   */
+  @InternalApi private[akka] final class BindValue[B](val value: B) extends Binding[B]
+
+  /**
+   * INTERNAL API
+   */
+  @InternalApi private[akka] case object BindNull extends Binding[Nothing]
+
+  /**
+   * INTERNAL API
+   */
+  @InternalApi private[akka] case object Skip extends Binding[Nothing]
+
+}
+
+/**
+ * @tparam A
+ *   The type of the durable state
+ * @tparam B
+ *   The type of the field stored in the additional column.
+ */
+@ApiMayChange
+abstract class AdditionalColumn[A, B] {
+
+  def fieldClass: Class[B]
+
+  def columnName: String
+
+  def bind(upsert: AdditionalColumn.Upsert[A]): AdditionalColumn.Binding[B]
+
+}

--- a/core/src/main/scala/akka/persistence/r2dbc/state/javadsl/ChangeHandler.scala
+++ b/core/src/main/scala/akka/persistence/r2dbc/state/javadsl/ChangeHandler.scala
@@ -1,0 +1,34 @@
+/*
+ * Copyright (C) 2022 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.persistence.r2dbc.state.javadsl
+
+import java.util.concurrent.CompletionStage
+
+import akka.Done
+import akka.annotation.ApiMayChange
+import akka.persistence.query.DurableStateChange
+import akka.persistence.r2dbc.session.javadsl.R2dbcSession
+
+@ApiMayChange
+trait ChangeHandler[A] {
+
+  /**
+   * Implement this method to perform additional processing in the same transaction as the Durable State upsert or
+   * delete.
+   *
+   * The `process` method is invoked for each `DurableStateChange`. Each time a new `Connection` is passed with a new
+   * open transaction. You can use `createStatement`, `update` and other methods provided by the [[R2dbcSession]]. The
+   * results of several statements can be combined with `CompletionStage` composition (e.g. `thenCompose`). The
+   * transaction will be automatically committed or rolled back when the returned `CompletionStage` is completed. Note
+   * that an exception here will abort the transaction and fail the upsert or delete.
+   *
+   * The `ChangeHandler` should be implemented as a stateless function without mutable state because the same
+   * `ChangeHandler` instance may be invoked concurrently for different entities. For a specific entity (persistenceId)
+   * one change is processed at a time and this `process` method will not be invoked with the next change for that
+   * entity until after the returned `CompletionStage` is completed.
+   */
+  def process(session: R2dbcSession, change: DurableStateChange[A]): CompletionStage[Done]
+
+}

--- a/core/src/main/scala/akka/persistence/r2dbc/state/scaladsl/AdditionalColumn.scala
+++ b/core/src/main/scala/akka/persistence/r2dbc/state/scaladsl/AdditionalColumn.scala
@@ -1,0 +1,57 @@
+/*
+ * Copyright (C) 2022 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.persistence.r2dbc.state.scaladsl
+
+import scala.reflect.ClassTag
+
+import akka.annotation.ApiMayChange
+import akka.annotation.InternalApi
+
+@ApiMayChange
+object AdditionalColumn {
+  final case class Upsert[A](persistenceId: String, entityType: String, slice: Int, revision: Long, value: A)
+
+  sealed trait Binding[+B]
+
+  final case class BindValue[B](value: B) extends Binding[B]
+
+  case object BindNull extends Binding[Nothing]
+
+  case object Skip extends Binding[Nothing]
+
+  private val scalaPrimitivesMapping: Map[Class[_], Class[_]] =
+    Map(
+      classOf[Int] -> classOf[java.lang.Integer],
+      classOf[Long] -> classOf[java.lang.Long],
+      classOf[Float] -> classOf[java.lang.Float],
+      classOf[Double] -> classOf[java.lang.Double],
+      classOf[Byte] -> classOf[java.lang.Byte],
+      classOf[Short] -> classOf[java.lang.Short],
+      classOf[Char] -> classOf[java.lang.Character])
+}
+
+/**
+ * @tparam A
+ *   The type of the durable state
+ * @tparam B
+ *   The type of the field stored in the additional column.
+ */
+@ApiMayChange
+abstract class AdditionalColumn[A, B: ClassTag] {
+  import AdditionalColumn.scalaPrimitivesMapping
+
+  /**
+   * INTERNAL API: used when binding null
+   */
+  @InternalApi private[akka] val fieldClass: Class[_] = {
+    val cls = implicitly[ClassTag[B]].runtimeClass
+    scalaPrimitivesMapping.getOrElse(cls, cls)
+  }
+
+  def columnName: String
+
+  def bind(upsert: AdditionalColumn.Upsert[A]): AdditionalColumn.Binding[B]
+
+}

--- a/core/src/main/scala/akka/persistence/r2dbc/state/scaladsl/ChangeHandler.scala
+++ b/core/src/main/scala/akka/persistence/r2dbc/state/scaladsl/ChangeHandler.scala
@@ -1,0 +1,34 @@
+/*
+ * Copyright (C) 2022 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.persistence.r2dbc.state.scaladsl
+
+import scala.concurrent.Future
+
+import akka.Done
+import akka.annotation.ApiMayChange
+import akka.persistence.query.DurableStateChange
+import akka.persistence.r2dbc.session.scaladsl.R2dbcSession
+
+@ApiMayChange
+trait ChangeHandler[A] {
+
+  /**
+   * Implement this method to perform additional processing in the same transaction as the Durable State upsert or
+   * delete.
+   *
+   * The `process` method is invoked for each `DurableStateChange`. Each time a new `Connection` is passed with a new
+   * open transaction. You can use `createStatement`, `update` and other methods provided by the [[R2dbcSession]]. The
+   * results of several statements can be combined with `CompletionStage` composition (e.g. `thenCompose`). The
+   * transaction will be automatically committed or rolled back when the returned `CompletionStage` is completed. Note
+   * that an exception here will abort the transaction and fail the upsert or delete.
+   *
+   * The `ChangeHandler` should be implemented as a stateless function without mutable state because the same
+   * `ChangeHandler` instance may be invoked concurrently for different entities. For a specific entity (persistenceId)
+   * one change is processed at a time and this `process` method will not be invoked with the next change for that
+   * entity until after the returned `Future` is completed.
+   */
+  def process(session: R2dbcSession, change: DurableStateChange[A]): Future[Done]
+
+}

--- a/core/src/test/java/akka/persistence/r2dbc/state/JavadslChangeHandler.java
+++ b/core/src/test/java/akka/persistence/r2dbc/state/JavadslChangeHandler.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (C) 2022 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.persistence.r2dbc.state;
+
+import akka.Done;
+import akka.persistence.query.DurableStateChange;
+import akka.persistence.query.UpdatedDurableState;
+import akka.persistence.r2dbc.session.javadsl.R2dbcSession;
+import akka.persistence.r2dbc.state.javadsl.ChangeHandler;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+
+public class JavadslChangeHandler implements ChangeHandler<String> {
+  @Override
+  public CompletionStage<Done> process(R2dbcSession session, DurableStateChange<String> change) {
+    if (change instanceof UpdatedDurableState) {
+      UpdatedDurableState<String> upd = (UpdatedDurableState<String>) change;
+      return session
+          .updateOne(
+              session
+                  .createStatement("insert into changes_test (pid, rev, value) values ($1, $2, $3)")
+                  .bind(0, upd.persistenceId())
+                  .bind(1, upd.revision())
+                  .bind(2, upd.value()))
+          .thenApply(n -> Done.getInstance());
+    } else {
+      return CompletableFuture.completedFuture(Done.getInstance());
+    }
+  }
+}

--- a/core/src/test/java/akka/persistence/r2dbc/state/JavadslColumn.java
+++ b/core/src/test/java/akka/persistence/r2dbc/state/JavadslColumn.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright (C) 2022 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.persistence.r2dbc.state;
+
+import akka.persistence.r2dbc.state.javadsl.AdditionalColumn;
+
+public class JavadslColumn extends AdditionalColumn<String, Integer> {
+  @Override
+  public Class<Integer> fieldClass() {
+    return Integer.class;
+  }
+
+  @Override
+  public String columnName() {
+    return "col3";
+  }
+
+  @Override
+  public Binding<Integer> bind(Upsert<String> upsert) {
+    if (upsert.value().isEmpty())
+      return AdditionalColumn.bindNull();
+    else if (upsert.value().equals("SKIP"))
+      return AdditionalColumn.skip();
+    else
+      return new AdditionalColumn.BindValue(upsert.value().length());
+  }
+}

--- a/core/src/test/scala/akka/persistence/r2dbc/state/DurableStateStoreAdditionalColumnSpec.scala
+++ b/core/src/test/scala/akka/persistence/r2dbc/state/DurableStateStoreAdditionalColumnSpec.scala
@@ -1,0 +1,211 @@
+/*
+ * Copyright (C) 2022 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.persistence.r2dbc.state
+
+import java.lang
+
+import scala.concurrent.Await
+import scala.concurrent.duration._
+
+import akka.actor.testkit.typed.scaladsl.LogCapturing
+import akka.actor.testkit.typed.scaladsl.ScalaTestWithActorTestKit
+import akka.actor.typed.ActorSystem
+import akka.persistence.r2dbc.TestConfig
+import akka.persistence.r2dbc.TestData
+import akka.persistence.r2dbc.TestDbLifecycle
+import akka.persistence.r2dbc.state.scaladsl.AdditionalColumn
+import akka.persistence.r2dbc.state.scaladsl.AdditionalColumn.BindNull
+import akka.persistence.r2dbc.state.scaladsl.AdditionalColumn.BindValue
+import akka.persistence.r2dbc.state.scaladsl.AdditionalColumn.Skip
+import akka.persistence.r2dbc.state.scaladsl.R2dbcDurableStateStore
+import akka.persistence.state.DurableStateStoreRegistry
+import akka.persistence.state.scaladsl.GetObjectResult
+import com.typesafe.config.Config
+import com.typesafe.config.ConfigFactory
+import org.scalatest.wordspec.AnyWordSpecLike
+
+object DurableStateStoreAdditionalColumnSpec {
+  val config: Config = ConfigFactory
+    .parseString(s"""
+    akka.persistence.r2dbc.state {
+      custom-table {
+        "CustomEntity" = durable_state_test
+      }
+      additional-columns {
+        "CustomEntity" = ["${classOf[Column1].getName}", "${classOf[Column2].getName}", "${classOf[JavadslColumn].getName}"]
+      }
+    }
+    """)
+    .withFallback(TestConfig.config)
+
+  class Column1 extends AdditionalColumn[String, String] {
+    override def columnName: String = "col1"
+
+    override def bind(upsert: AdditionalColumn.Upsert[String]): AdditionalColumn.Binding[String] =
+      if (upsert.value.isEmpty) BindNull
+      else if (upsert.value == "SKIP") Skip
+      else BindValue(upsert.value)
+  }
+
+  class Column2 extends AdditionalColumn[String, Int] {
+    override def columnName: String = "col2"
+
+    override def bind(upsert: AdditionalColumn.Upsert[String]): AdditionalColumn.Binding[Int] =
+      if (upsert.value.isEmpty) BindNull
+      else if (upsert.value == "SKIP") Skip
+      else BindValue(upsert.value.length)
+  }
+}
+
+class DurableStateStoreAdditionalColumnSpec
+    extends ScalaTestWithActorTestKit(DurableStateStoreAdditionalColumnSpec.config)
+    with AnyWordSpecLike
+    with TestDbLifecycle
+    with TestData
+    with LogCapturing {
+
+  private val customTable = r2dbcSettings.getDurableStateTableWithSchema("CustomEntity")
+
+  override def typedSystem: ActorSystem[_] = system
+
+  override def beforeAll(): Unit = {
+    super.beforeAll()
+    Await.result(
+      r2dbcExecutor.executeDdl("beforeAll create durable_state_test")(
+        _.createStatement(
+          s"create table if not exists $customTable as select * from durable_state where persistence_id = ''")),
+      20.seconds)
+    Await.result(
+      r2dbcExecutor.executeDdl("beforeAll alter durable_state_test")(
+        _.createStatement(s"alter table $customTable add if not exists col1 varchar(256)")),
+      20.seconds)
+    Await.result(
+      r2dbcExecutor.executeDdl("beforeAll alter durable_state_test")(
+        _.createStatement(s"alter table $customTable add if not exists col2 int")),
+      20.seconds)
+    Await.result(
+      r2dbcExecutor.executeDdl("beforeAll alter durable_state_test")(
+        _.createStatement(s"alter table $customTable add if not exists col3 int")),
+      20.seconds)
+    Await.result(
+      r2dbcExecutor.updateOne("beforeAll delete")(_.createStatement(s"delete from $customTable")),
+      10.seconds)
+  }
+
+  private val store = DurableStateStoreRegistry(testKit.system)
+    .durableStateStoreFor[R2dbcDurableStateStore[String]](R2dbcDurableStateStore.Identifier)
+
+  private val unusedTag = "n/a"
+
+  private def exists(whereCondition: String): Boolean =
+    r2dbcExecutor
+      .selectOne("count")(
+        _.createStatement(s"select count(*) from $customTable where $whereCondition"),
+        row => row.get(0, classOf[lang.Long]).longValue())
+      .futureValue
+      .contains(1)
+
+  private def existsInCustomTable(persistenceId: String): Boolean =
+    exists(s"persistence_id = '$persistenceId'")
+
+  private def existsMatchingCol1(persistenceId: String, columnValue: String): Boolean =
+    exists(s"persistence_id = '$persistenceId' and col1 = '$columnValue'")
+
+  private def existsMatchingCol2(persistenceId: String, columnValue: Int): Boolean =
+    exists(s"persistence_id = '$persistenceId' and col2 = $columnValue")
+
+  private def existsMatchingCol3(persistenceId: String, columnValue: Int): Boolean =
+    exists(s"persistence_id = '$persistenceId' and col3 = $columnValue")
+
+  private def existsCol1IsNull(persistenceId: String): Boolean =
+    exists(s"persistence_id = '$persistenceId' and col1 is null")
+
+  private def existsCol2IsNull(persistenceId: String): Boolean =
+    exists(s"persistence_id = '$persistenceId' and col2 is null")
+
+  private def existsCol3IsNull(persistenceId: String): Boolean =
+    exists(s"persistence_id = '$persistenceId' and col3 is null")
+
+  "The R2DBC durable state store" should {
+    "save and retrieve a value in custom table with additional columns" in {
+      val entityType = "CustomEntity"
+      val persistenceId = nextPid(entityType)
+      val value = "Genuinely Collaborative"
+
+      store.upsertObject(persistenceId, 1L, value, unusedTag).futureValue
+      store.getObject(persistenceId).futureValue should be(GetObjectResult(Some(value), 1L))
+
+      existsInCustomTable(persistenceId) should be(true)
+      existsMatchingCol1(persistenceId, value) should be(true)
+      existsMatchingCol2(persistenceId, value.length) should be(true)
+      existsMatchingCol3(persistenceId, value.length) should be(true)
+    }
+
+    "update a value in custom table with additional columns" in {
+      val entityType = "CustomEntity"
+      val persistenceId = nextPid(entityType)
+      val value = "Genuinely Collaborative"
+      store.upsertObject(persistenceId, 1L, value, unusedTag).futureValue
+      store.getObject(persistenceId).futureValue should be(GetObjectResult(Some(value), 1L))
+
+      val updatedValue = "Open to Feedback"
+      store.upsertObject(persistenceId, 2L, updatedValue, unusedTag).futureValue
+      store.getObject(persistenceId).futureValue should be(GetObjectResult(Some(updatedValue), 2L))
+
+      existsInCustomTable(persistenceId) should be(true)
+      existsMatchingCol1(persistenceId, value) should be(false)
+      existsMatchingCol1(persistenceId, updatedValue) should be(true)
+      existsMatchingCol2(persistenceId, value.length) should be(false)
+      existsMatchingCol2(persistenceId, updatedValue.length) should be(true)
+      existsMatchingCol3(persistenceId, value.length) should be(false)
+      existsMatchingCol3(persistenceId, updatedValue.length) should be(true)
+    }
+
+    "support null binding of additional columns" in {
+      val entityType = "CustomEntity"
+      val persistenceId = nextPid(entityType)
+      val emptyValue = ""
+      store.upsertObject(persistenceId, 1L, emptyValue, unusedTag).futureValue
+      store.getObject(persistenceId).futureValue should be(GetObjectResult(Some(emptyValue), 1L))
+      existsCol1IsNull(persistenceId) should be(true)
+      existsCol2IsNull(persistenceId) should be(true)
+      existsCol3IsNull(persistenceId) should be(true)
+
+      val updatedValue = "Open to Feedback"
+      store.upsertObject(persistenceId, 2L, updatedValue, unusedTag).futureValue
+      store.getObject(persistenceId).futureValue should be(GetObjectResult(Some(updatedValue), 2L))
+      existsCol1IsNull(persistenceId) should be(false)
+      existsCol2IsNull(persistenceId) should be(false)
+      existsCol3IsNull(persistenceId) should be(false)
+
+      store.upsertObject(persistenceId, 3L, emptyValue, unusedTag).futureValue
+      store.getObject(persistenceId).futureValue should be(GetObjectResult(Some(emptyValue), 3L))
+      existsCol1IsNull(persistenceId) should be(true)
+      existsCol2IsNull(persistenceId) should be(true)
+      existsCol3IsNull(persistenceId) should be(true)
+    }
+
+    "support skip binding of additional columns" in {
+      val entityType = "CustomEntity"
+      val persistenceId = nextPid(entityType)
+      val value = "Genuinely Collaborative"
+      store.upsertObject(persistenceId, 1L, value, unusedTag).futureValue
+      store.getObject(persistenceId).futureValue should be(GetObjectResult(Some(value), 1L))
+      existsMatchingCol1(persistenceId, value) should be(true)
+      existsMatchingCol2(persistenceId, value.length) should be(true)
+      existsMatchingCol3(persistenceId, value.length) should be(true)
+
+      val updatedValue = "SKIP"
+      store.upsertObject(persistenceId, 2L, updatedValue, unusedTag).futureValue
+      store.getObject(persistenceId).futureValue should be(GetObjectResult(Some(updatedValue), 2L))
+      // still same column values
+      existsMatchingCol1(persistenceId, value) should be(true)
+      existsMatchingCol2(persistenceId, value.length) should be(true)
+      existsMatchingCol3(persistenceId, value.length) should be(true)
+    }
+
+  }
+
+}

--- a/core/src/test/scala/akka/persistence/r2dbc/state/DurableStateStoreChangeHandlerSpec.scala
+++ b/core/src/test/scala/akka/persistence/r2dbc/state/DurableStateStoreChangeHandlerSpec.scala
@@ -1,0 +1,195 @@
+/*
+ * Copyright (C) 2022 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.persistence.r2dbc.state
+
+import scala.concurrent.Await
+import scala.concurrent.ExecutionContext
+import scala.concurrent.Future
+import scala.concurrent.duration._
+
+import akka.Done
+import akka.actor.testkit.typed.scaladsl.LogCapturing
+import akka.actor.testkit.typed.scaladsl.ScalaTestWithActorTestKit
+import akka.actor.typed.ActorSystem
+import akka.persistence.query.DeletedDurableState
+import akka.persistence.query.DurableStateChange
+import akka.persistence.query.UpdatedDurableState
+import akka.persistence.r2dbc.TestConfig
+import akka.persistence.r2dbc.TestData
+import akka.persistence.r2dbc.TestDbLifecycle
+import akka.persistence.r2dbc.internal.Sql.Interpolation
+import akka.persistence.r2dbc.session.scaladsl.R2dbcSession
+import akka.persistence.r2dbc.state.scaladsl.ChangeHandler
+import akka.persistence.r2dbc.state.scaladsl.R2dbcDurableStateStore
+import akka.persistence.state.DurableStateStoreRegistry
+import akka.persistence.state.scaladsl.GetObjectResult
+import com.typesafe.config.Config
+import com.typesafe.config.ConfigFactory
+import org.scalatest.wordspec.AnyWordSpecLike
+
+object DurableStateStoreChangeHandlerSpec {
+  val config: Config = ConfigFactory
+    .parseString(s"""
+    akka.persistence.r2dbc.state {
+      change-handler {
+        "CustomEntity" = "${classOf[Handler].getName}"
+        "JavadslCustomEntity" = "${classOf[JavadslChangeHandler].getName}"
+      }
+    }
+    """)
+    .withFallback(TestConfig.config)
+
+  class Handler(system: ActorSystem[_]) extends ChangeHandler[String] {
+    private implicit val ec: ExecutionContext = system.executionContext
+
+    override def process(session: R2dbcSession, change: DurableStateChange[String]): Future[Done] = {
+      change match {
+        case upd: UpdatedDurableState[String] =>
+          if (upd.value == "BOOM")
+            Future.failed(new RuntimeException("BOOM"))
+          else
+            session
+              .updateOne(
+                session
+                  .createStatement(sql"insert into changes_test (pid, rev, value) values (?, ?, ?)")
+                  .bind(0, upd.persistenceId)
+                  .bind(1, upd.revision)
+                  .bind(2, upd.value))
+              .map(_ => Done)
+
+        case del: DeletedDurableState[String] =>
+          session
+            .updateOne(
+              session
+                .createStatement(sql"insert into changes_test (pid, rev, value) values (?, ?, ?)")
+                .bind(0, del.persistenceId)
+                .bind(1, del.revision)
+                .bindNull(2, classOf[String]))
+            .map(_ => Done)
+      }
+    }
+  }
+
+}
+
+class DurableStateStoreChangeHandlerSpec
+    extends ScalaTestWithActorTestKit(DurableStateStoreChangeHandlerSpec.config)
+    with AnyWordSpecLike
+    with TestDbLifecycle
+    with TestData
+    with LogCapturing {
+
+  private val anotherTable = "changes_test"
+
+  override def typedSystem: ActorSystem[_] = system
+
+  override def beforeAll(): Unit = {
+    super.beforeAll()
+    Await.result(
+      r2dbcExecutor.executeDdl("beforeAll create durable_state_test")(
+        _.createStatement(
+          s"create table if not exists $anotherTable (pid varchar(256), rev bigint, value varchar(256))")),
+      20.seconds)
+    Await.result(
+      r2dbcExecutor.updateOne("beforeAll delete")(_.createStatement(s"delete from $anotherTable")),
+      10.seconds)
+  }
+
+  private val store = DurableStateStoreRegistry(testKit.system)
+    .durableStateStoreFor[R2dbcDurableStateStore[String]](R2dbcDurableStateStore.Identifier)
+
+  private val unusedTag = "n/a"
+
+  private def exists(whereCondition: String): Boolean =
+    r2dbcExecutor
+      .selectOne("count")(
+        _.createStatement(s"select count(*) from $anotherTable where $whereCondition"),
+        row => row.get(0, classOf[java.lang.Long]).longValue())
+      .futureValue
+      .contains(1)
+
+  "The R2DBC durable state store change handler" should {
+    "be invoked for first revision" in {
+      val entityType = "CustomEntity"
+      val persistenceId = nextPid(entityType)
+      val value = "Genuinely Collaborative"
+
+      store.upsertObject(persistenceId, 1L, value, unusedTag).futureValue
+      store.getObject(persistenceId).futureValue should be(GetObjectResult(Some(value), 1L))
+
+      exists(s"pid = '$persistenceId' and rev = 1 and value = '$value'") should be(true)
+    }
+
+    "be invoked for updates" in {
+      val entityType = "CustomEntity"
+      val persistenceId = nextPid(entityType)
+      val value = "Genuinely Collaborative"
+      store.upsertObject(persistenceId, 1L, value, unusedTag).futureValue
+      store.getObject(persistenceId).futureValue should be(GetObjectResult(Some(value), 1L))
+
+      val updatedValue = "Open to Feedback"
+      store.upsertObject(persistenceId, 2L, updatedValue, unusedTag).futureValue
+      store.getObject(persistenceId).futureValue should be(GetObjectResult(Some(updatedValue), 2L))
+
+      exists(s"pid = '$persistenceId' and rev = 2 and value = '$updatedValue'") should be(true)
+    }
+
+    "be invoked for deletes" in {
+      val entityType = "CustomEntity"
+      val persistenceId = nextPid(entityType)
+      val value = "Genuinely Collaborative"
+      store.upsertObject(persistenceId, 1L, value, unusedTag).futureValue
+      store.getObject(persistenceId).futureValue should be(GetObjectResult(Some(value), 1L))
+
+      store.deleteObject(persistenceId, 2L).futureValue
+      store.getObject(persistenceId).futureValue should be(GetObjectResult(None, 2L))
+
+      exists(s"pid = '$persistenceId' and rev = 2 and value is null") should be(true)
+    }
+
+    "be invoked for hard deletes" in {
+      val entityType = "CustomEntity"
+      val persistenceId = nextPid(entityType)
+      val value = "Genuinely Collaborative"
+      store.upsertObject(persistenceId, 1L, value, unusedTag).futureValue
+      store.getObject(persistenceId).futureValue should be(GetObjectResult(Some(value), 1L))
+
+      // revision 0 is for hard delete
+      store.deleteObject(persistenceId, 0L).futureValue
+      store.getObject(persistenceId).futureValue should be(GetObjectResult(None, 0L))
+
+      exists(s"pid = '$persistenceId' and rev = 0 and value is null") should be(true)
+    }
+
+    "use same transaction" in {
+      val entityType = "CustomEntity"
+      val persistenceId = nextPid(entityType)
+      val value = "Genuinely Collaborative"
+      store.upsertObject(persistenceId, 1L, value, unusedTag).futureValue
+      store.getObject(persistenceId).futureValue should be(GetObjectResult(Some(value), 1L))
+
+      val updatedValue = "BOOM"
+      store.upsertObject(persistenceId, 2L, updatedValue, unusedTag).failed.futureValue.getMessage should be(
+        s"Change handler update failed for [$persistenceId] revision [2], due to BOOM")
+      // still old value
+      store.getObject(persistenceId).futureValue should be(GetObjectResult(Some(value), 1L))
+
+      exists(s"pid = '$persistenceId' and rev = 2") should be(false)
+    }
+
+    "support javadsl.ChangeHandler" in {
+      val entityType = "JavadslCustomEntity"
+      val persistenceId = nextPid(entityType)
+      val value = "Run anywhere"
+
+      store.upsertObject(persistenceId, 1L, value, unusedTag).futureValue
+      store.getObject(persistenceId).futureValue should be(GetObjectResult(Some(value), 1L))
+
+      exists(s"pid = '$persistenceId' and rev = 1 and value = '$value'") should be(true)
+    }
+
+  }
+
+}

--- a/docs/src/main/paradox/durable-state-store.md
+++ b/docs/src/main/paradox/durable-state-store.md
@@ -41,3 +41,101 @@ don't reuse the same revision numbers that have been deleted.
 
 See the @ref[DurableStateCleanup tool](cleanup.md#durable-state-cleanup-tool) for more information about how to delete
 state tombstone records.
+
+## Storing query representation
+
+@extref:[Durable state actors](akka:typed/durable-state/persistence.html) can only be looked up by their entity id.
+Additional indexed data can be stored as a query representation. You can either store the query representation from
+an asynchronous @ref:[Projection](projection.md) or you can store it in the same transaction as the Durable State
+upsert or delete.
+
+Advantages of storing the query representation in the same transaction as the Durable State change:
+
+* exactly-once processing and atomic update with the Durable State change
+* no eventual consistency delay from asynchronous Projection processing
+* no need for Projection offset storage
+
+That said, for write heavy Durable State, a Projection can have the advantage of not impacting write latency of
+the Durable State updates. Note that updating the secondary index also has an impact on the write latency.
+
+### Additional columns
+
+In many cases you just want a secondary index on one or a few fields other than the entity id. For that purpose
+you can configure one or more @apidoc[AdditionalColumn] classes for an entity type. The `AdditionalColumn` will
+extract the field from the Durable State value and define how to bind it to a database column.
+
+The configuration:
+
+@@snip [application.conf](/docs/src/test/scala/docs/home/state/BlogPostTitleColumn.scala) { #additional-column-config }
+
+For each entity type you can define a list of fully qualified class names of `AdditionalColumn` implementations.
+The `AdditionalColumn` implementation may optionally define an ActorSystem constructor parameter.
+
+`AdditionalColumn` for a secondary index on the title of @extref:[blog posts (example in the Akka documentation)](akka:typed/durable-state/persistence.html#changing-behavior):
+
+Scala
+:  @@snip [BlogPostTitleColumn.scala](/docs/src/test/scala/docs/home/state/BlogPostTitleColumn.scala) { #additional-column }
+
+Java
+:  @@snip [BlogPostTitleColumn.java](/docs/src/test/java/jdocs/home/state/BlogPostTitleColumn.java) { #additional-column }
+
+From the `bind` method you can return one of:
+
+* @scala[`AdditionalColumn.BindValue`]@java[`AdditionalColumn.bindValue`] - bind a value such as a `String` or `Long` to the database column
+* @scala[`AdditionalColumn.BindNull`]@java[`AdditionalColumn.bindNull`] - store `null` in the database column
+* @scala[`AdditionalColumn.Skip`]@java[`AdditionalColumn.skip`] - don't update the database column for this change, keep existing value
+
+You would have to add the additional columns to the `durable_state` table definition, and create secondary database index.
+Unless you only have one entity type it's best to define a separate table with the `custom-table` configuration, see
+example above. The full serialized state and the additional columns are stored in the custom table instead of the
+default `durable_state` table. The custom table should have the same table definition as the default 
+`durable_state` table but with the extra columns added.
+
+The state can be found by the additional column and deserialized like this:
+
+Scala
+:  @@snip [BlogPostQuery.scala](/docs/src/test/scala/docs/home/state/BlogPostQuery.scala) { #query }
+
+Java
+:  @@snip [BlogPostQuery.java](/docs/src/test/java/jdocs/home/state/BlogPostQuery.java) { #query }
+
+### Change handler
+
+For more advanced cases where the query representation would not fit in @ref:[additional columns](#additional-columns)
+you can configure a @apidoc[ChangeHandler] for an entity type. The `ChangeHandler` will be invoked for each
+Durable State change. From the `ChangeHandler` you can run database operations in the same transaction
+as the Durable State upsert or delete.
+
+The configuration:
+
+@@snip [application.conf](/docs/src/test/scala/docs/home/state/BlogPostCounts.scala) { #change-handler-config }
+
+For each entity type you can define the fully qualified class name of a `ChangeHandler` implementation.
+The `ChangeHandler` implementation may optionally define an ActorSystem constructor parameter.
+
+`ChangeHandler` for a keeping track of number of published @extref:[blog posts (example in the Akka documentation)](akka:typed/durable-state/persistence.html#changing-behavior):
+
+Scala
+:  @@snip [BlogPostCounts.scala](/docs/src/test/scala/docs/home/state/BlogPostCounts.scala) { #change-handler }
+
+Java
+:  @@snip [BlogPostCounts.java](/docs/src/test/java/jdocs/home/state/BlogPostCounts.java) { #change-handler }
+
+The @apidoc[DurableStateChange] parameter is an @apidoc[UpdatedDurableState] when the Durable State is created or updated.
+It is a @apidoc[DeletedDurableState] when the Durable State is deleted.
+
+The @apidoc[akka.persistence.r2dbc.session.*.R2dbcSession] provides the means to access an open R2DBC connection
+that can be used to process the change. The target database operations run in the same transaction as the storage
+of the Durable State change.
+
+One change is processed at a time. It will not be invoked with the next change until after the `process` method returns
+and the returned @scala[`Future`]@java[`CompletionStage`] is completed.
+
+@@@ note { title="Concurrency semantics" }
+
+The `ChangeHandler` should be implemented as a stateless function without mutable state because the same
+`ChangeHandler` instance may be invoked concurrently for different entities.
+For a specific entity (persistenceId) one change is processed at a time and the `process` method will not be
+invoked with the next change for that entity until after the returned @scala[`Future`]@java[`CompletionStage`] is completed.
+
+@@@

--- a/docs/src/main/paradox/projection.md
+++ b/docs/src/main/paradox/projection.md
@@ -8,7 +8,7 @@ The source of the envelopes is from a `SourceProvider`, which can be:
 * state changes for Durable State entities via the @extref:[SourceProvider for changesBySlices](akka-projection:durable-state.html#sourceprovider-for-changesbyslices) with the @ref:[changesBySlices query](query.md#changesbyslices)
 * any other `SourceProvider` with supported @ref:[offset types](#offset-types)
 
-A @apidoc[R2dbcHandler] receives a @apidoc[R2dbcSession] instance and an envelope. The
+A @apidoc[R2dbcHandler] receives a @apidoc[akka.projection.*.R2dbcSession] instance and an envelope. The
 `R2dbcSession` provides the means to access an open R2DBC connection that can be used to process the envelope.
 The target database operations can be run in the same transaction as the storage of the offset, which means
 that @ref:[exactly-once](#exactly-once) processing semantics is supported. It also offers

--- a/docs/src/test/java/jdocs/home/state/BlogPost.java
+++ b/docs/src/test/java/jdocs/home/state/BlogPost.java
@@ -1,0 +1,202 @@
+/*
+ * Copyright (C) 2018-2022 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package jdocs.home.state;
+
+import akka.Done;
+import akka.actor.typed.ActorRef;
+import akka.actor.typed.Behavior;
+import akka.actor.typed.javadsl.Behaviors;
+import akka.persistence.typed.PersistenceId;
+import akka.persistence.typed.state.javadsl.CommandHandler;
+import akka.persistence.typed.state.javadsl.CommandHandlerBuilder;
+import akka.persistence.typed.state.javadsl.DurableStateBehavior;
+import akka.persistence.typed.state.javadsl.Effect;
+
+public class BlogPost
+    extends DurableStateBehavior<
+        BlogPost.Command, BlogPost.State> {
+  // commands and state as in above snippets
+
+  interface State {}
+
+  enum BlankState implements State {
+    INSTANCE
+  }
+
+  static class DraftState implements State {
+    final PostContent content;
+
+    DraftState(PostContent content) {
+      this.content = content;
+    }
+
+    DraftState withContent(PostContent newContent) {
+      return new DraftState(newContent);
+    }
+
+    DraftState withBody(String newBody) {
+      return withContent(new PostContent(postId(), content.title, newBody));
+    }
+
+    String postId() {
+      return content.postId;
+    }
+  }
+
+  static class PublishedState implements State {
+    final PostContent content;
+
+    PublishedState(PostContent content) {
+      this.content = content;
+    }
+
+    PublishedState withContent(PostContent newContent) {
+      return new PublishedState(newContent);
+    }
+
+    PublishedState withBody(String newBody) {
+      return withContent(new PostContent(postId(), content.title, newBody));
+    }
+
+    String postId() {
+      return content.postId;
+    }
+  }
+
+  public interface Command {}
+  public static class AddPost implements Command {
+    final PostContent content;
+    final ActorRef<AddPostDone> replyTo;
+
+    public AddPost(PostContent content, ActorRef<AddPostDone> replyTo) {
+      this.content = content;
+      this.replyTo = replyTo;
+    }
+  }
+
+  public static class AddPostDone implements Command {
+    final String postId;
+
+    public AddPostDone(String postId) {
+      this.postId = postId;
+    }
+  }
+  public static class GetPost implements Command {
+    final ActorRef<PostContent> replyTo;
+
+    public GetPost(ActorRef<PostContent> replyTo) {
+      this.replyTo = replyTo;
+    }
+  }
+
+  public static class ChangeBody implements Command {
+    final String newBody;
+    final ActorRef<Done> replyTo;
+
+    public ChangeBody(String newBody, ActorRef<Done> replyTo) {
+      this.newBody = newBody;
+      this.replyTo = replyTo;
+    }
+  }
+
+  public static class Publish implements Command {
+    final ActorRef<Done> replyTo;
+
+    public Publish(ActorRef<Done> replyTo) {
+      this.replyTo = replyTo;
+    }
+  }
+
+  public static class PostContent implements Command {
+    final String postId;
+    final String title;
+    final String body;
+
+    public PostContent(String postId, String title, String body) {
+      this.postId = postId;
+      this.title = title;
+      this.body = body;
+    }
+  }
+
+  public static Behavior<Command> create(String entityId, PersistenceId persistenceId) {
+    return Behaviors.setup(
+        context -> {
+          context.getLog().info("Starting BlogPostEntityDurableState {}", entityId);
+          return new BlogPost(persistenceId);
+        });
+  }
+
+  private BlogPost(PersistenceId persistenceId) {
+    super(persistenceId);
+  }
+
+  @Override
+  public State emptyState() {
+    return BlankState.INSTANCE;
+  }
+
+  @Override
+  public CommandHandler<Command, State> commandHandler() {
+    CommandHandlerBuilder<Command, State> builder = newCommandHandlerBuilder();
+
+    builder.forStateType(BlankState.class).onCommand(AddPost.class, this::onAddPost);
+
+    builder
+        .forStateType(DraftState.class)
+        .onCommand(ChangeBody.class, this::onChangeBody)
+        .onCommand(Publish.class, this::onPublish)
+        .onCommand(GetPost.class, this::onGetPost);
+
+    builder
+        .forStateType(PublishedState.class)
+        .onCommand(ChangeBody.class, this::onChangeBody)
+        .onCommand(GetPost.class, this::onGetPost);
+
+    builder.forAnyState().onCommand(AddPost.class, (state, cmd) -> Effect().unhandled());
+
+    return builder.build();
+  }
+
+  private Effect<State> onAddPost(AddPost cmd) {
+    return Effect()
+        .persist(new DraftState(cmd.content))
+        .thenRun(() -> cmd.replyTo.tell(new AddPostDone(cmd.content.postId)));
+  }
+
+  private Effect<State> onChangeBody(DraftState state, ChangeBody cmd) {
+    return Effect()
+        .persist(state.withBody(cmd.newBody))
+        .thenRun(() -> cmd.replyTo.tell(Done.getInstance()));
+  }
+
+  private Effect<State> onChangeBody(PublishedState state, ChangeBody cmd) {
+    return Effect()
+        .persist(state.withBody(cmd.newBody))
+        .thenRun(() -> cmd.replyTo.tell(Done.getInstance()));
+  }
+
+  private Effect<State> onPublish(DraftState state, Publish cmd) {
+    return Effect()
+        .persist(new PublishedState(state.content))
+        .thenRun(
+            () -> {
+              System.out.println("Blog post published: " + state.postId());
+              cmd.replyTo.tell(Done.getInstance());
+            });
+  }
+
+  private Effect<State> onGetPost(DraftState state, GetPost cmd) {
+    cmd.replyTo.tell(state.content);
+    return Effect().none();
+  }
+
+  private Effect<State> onGetPost(PublishedState state, GetPost cmd) {
+    cmd.replyTo.tell(state.content);
+    return Effect().none();
+  }
+
+  // commandHandler, eventHandler as in above snippets
+}

--- a/docs/src/test/java/jdocs/home/state/BlogPostCounts.java
+++ b/docs/src/test/java/jdocs/home/state/BlogPostCounts.java
@@ -1,0 +1,74 @@
+/**
+ * Copyright (C) 2022 Lightbend Inc. <https://www.lightbend.com>
+ */
+package jdocs.home.state;
+
+// #change-handler
+import akka.Done;
+import akka.actor.typed.ActorSystem;
+import akka.persistence.Persistence;
+import akka.persistence.query.DeletedDurableState;
+import akka.persistence.query.DurableStateChange;
+import akka.persistence.query.UpdatedDurableState;
+import akka.persistence.r2dbc.session.javadsl.R2dbcSession;
+import akka.persistence.r2dbc.state.javadsl.ChangeHandler;
+import io.r2dbc.spi.Statement;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+
+/**
+ * Keep track of number of published blog posts. Count per slice.
+ *
+ * <pre>
+ * CREATE TABLE post_count (slice INT NOT NULL, cnt BIGINT NOT NULL, PRIMARY KEY(slice));
+ * </pre>
+ */
+public class BlogPostCounts implements ChangeHandler<BlogPost.State> {
+
+  private final ActorSystem<?> system;
+
+  private final String incrementSql =
+      "INSERT INTO post_count (slice, cnt) VALUES ($1, 1) " +
+          "ON CONFLICT (slice) DO UPDATE SET cnt = excluded.cnt + 1";
+
+  private final String decrementSql =
+      "UPDATE post_count SET cnt = cnt - 1 WHERE slice = $1";
+
+  public BlogPostCounts(ActorSystem<?> system) {
+    this.system = system;
+  }
+
+  @Override
+  public CompletionStage<Done> process(R2dbcSession session, DurableStateChange<BlogPost.State> change) {
+    if (change instanceof UpdatedDurableState) {
+      return processUpdate(session, (UpdatedDurableState<BlogPost.State>) change);
+    } else if (change instanceof DeletedDurableState) {
+      return processDelete(session, (DeletedDurableState<BlogPost.State>) change);
+    } else {
+      throw new IllegalArgumentException("Unexpected change " + change.getClass().getName());
+    }
+  }
+
+  private CompletionStage<Done> processUpdate(R2dbcSession session, UpdatedDurableState<BlogPost.State> upd) {
+    if (upd.value() instanceof BlogPost.PublishedState) {
+      int slice = Persistence.get(system).sliceForPersistenceId(upd.persistenceId());
+      Statement stmt = session
+          .createStatement(incrementSql)
+          .bind(0, slice);
+      return session.updateOne(stmt).thenApply(count -> Done.getInstance());
+    } else {
+      return CompletableFuture.completedFuture(Done.getInstance());
+    }
+  }
+
+  private CompletionStage<Done> processDelete(R2dbcSession session, DeletedDurableState<BlogPost.State> del) {
+    int slice = Persistence.get(system).sliceForPersistenceId(del.persistenceId());
+    Statement stmt = session
+        .createStatement(decrementSql)
+        .bind(0, slice);
+    return session.updateOne(stmt).thenApply(count -> Done.getInstance());
+  }
+
+}
+// #change-handler

--- a/docs/src/test/java/jdocs/home/state/BlogPostQuery.java
+++ b/docs/src/test/java/jdocs/home/state/BlogPostQuery.java
@@ -1,0 +1,42 @@
+/**
+ * Copyright (C) 2022 Lightbend Inc. <https://www.lightbend.com>
+ */
+package jdocs.home.state;
+
+// #query
+import akka.actor.typed.ActorSystem;
+import akka.persistence.r2dbc.session.javadsl.R2dbcSession;
+import akka.serialization.SerializationExtension;
+import io.r2dbc.spi.Statement;
+
+import java.util.List;
+import java.util.concurrent.CompletionStage;
+
+public class BlogPostQuery {
+  private final ActorSystem<?> system;
+
+  public BlogPostQuery(ActorSystem<?> system) {
+    this.system = system;
+  }
+
+  private final String findByTitleSql =
+      "SELECT state_ser_id, state_ser_manifest, state_payload " +
+      "FROM durable_state_blog_post " +
+      "WHERE title = $1";
+
+  public CompletionStage<List<BlogPost.State>> findByTitle(String title) {
+    return R2dbcSession.withSession(system, session -> {
+      Statement stmt = session.createStatement(findByTitleSql).bind(0, title);
+      return session.select(stmt, row -> {
+        int serializerId = row.get("state_ser_id", Integer.class);
+        String serializerManifest = row.get("state_ser_manifest", String.class);
+        byte[] payload = row.get("state_payload", byte[].class);
+        BlogPost.State state = (BlogPost.State) SerializationExtension.get(system)
+            .deserialize(payload, serializerId, serializerManifest).get();
+        return state;
+      });
+    });
+  }
+
+}
+// #query

--- a/docs/src/test/java/jdocs/home/state/BlogPostTitleColumn.java
+++ b/docs/src/test/java/jdocs/home/state/BlogPostTitleColumn.java
@@ -1,0 +1,33 @@
+/**
+ * Copyright (C) 2022 Lightbend Inc. <https://www.lightbend.com>
+ */
+package jdocs.home.state;
+
+// #additional-column
+import akka.persistence.r2dbc.state.javadsl.AdditionalColumn;
+
+public class BlogPostTitleColumn extends AdditionalColumn<BlogPost.State, String> {
+  @Override
+  public Class<String> fieldClass() {
+    return String.class;
+  }
+
+  @Override
+  public String columnName() {
+    return "title";
+  }
+
+  @Override
+  public Binding<String> bind(Upsert<BlogPost.State> upsert) {
+    BlogPost.State state = upsert.value();
+    if (state.equals(BlogPost.BlankState.INSTANCE)) {
+      return AdditionalColumn.bindNull();
+    } else if (state instanceof BlogPost.DraftState) {
+      BlogPost.DraftState draft = (BlogPost.DraftState) state;
+      return AdditionalColumn.bindValue(draft.content.title);
+    } else {
+      return AdditionalColumn.skip();
+    }
+  }
+}
+// #additional-column

--- a/docs/src/test/scala/docs/home/state/BlogPost.scala
+++ b/docs/src/test/scala/docs/home/state/BlogPost.scala
@@ -1,0 +1,106 @@
+/*
+ * Copyright (C) 2022 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package docs.home.state
+
+import akka.Done
+import akka.actor.typed.ActorRef
+import akka.actor.typed.Behavior
+import akka.actor.typed.scaladsl.Behaviors
+import akka.pattern.StatusReply
+import akka.persistence.typed.PersistenceId
+import akka.persistence.typed.state.scaladsl.DurableStateBehavior
+import akka.persistence.typed.state.scaladsl.Effect
+
+object BlogPost {
+  val EntityTypeName = "BlogPost"
+
+  sealed trait State
+
+  case object BlankState extends State
+
+  final case class DraftState(content: PostContent) extends State {
+    def withBody(newBody: String): DraftState =
+      copy(content = content.copy(body = newBody))
+
+    def postId: String = content.postId
+  }
+
+  final case class PublishedState(content: PostContent) extends State {
+    def postId: String = content.postId
+  }
+
+  sealed trait Command
+  final case class AddPost(content: PostContent, replyTo: ActorRef[StatusReply[AddPostDone]]) extends Command
+  final case class AddPostDone(postId: String)
+  final case class GetPost(replyTo: ActorRef[PostContent]) extends Command
+  final case class ChangeBody(newBody: String, replyTo: ActorRef[Done]) extends Command
+  final case class Publish(replyTo: ActorRef[Done]) extends Command
+  final case class PostContent(postId: String, title: String, body: String)
+
+  def apply(entityId: String, persistenceId: PersistenceId): Behavior[Command] = {
+    Behaviors.setup { context =>
+      context.log.info("Starting BlogPostEntityDurableState {}", entityId)
+      DurableStateBehavior[Command, State](persistenceId, emptyState = BlankState, commandHandler)
+    }
+  }
+
+  private val commandHandler: (State, Command) => Effect[State] = { (state, command) =>
+    state match {
+
+      case BlankState =>
+        command match {
+          case cmd: AddPost => addPost(cmd)
+          case _            => Effect.unhandled
+        }
+
+      case draftState: DraftState =>
+        command match {
+          case cmd: ChangeBody  => changeBody(draftState, cmd)
+          case Publish(replyTo) => publish(draftState, replyTo)
+          case GetPost(replyTo) => getPost(draftState, replyTo)
+          case AddPost(_, replyTo) =>
+            Effect.unhandled[State].thenRun(_ => replyTo ! StatusReply.Error("Cannot add post while in draft state"))
+        }
+
+      case publishedState: PublishedState =>
+        command match {
+          case GetPost(replyTo) => getPost(publishedState, replyTo)
+          case AddPost(_, replyTo) =>
+            Effect.unhandled[State].thenRun(_ => replyTo ! StatusReply.Error("Cannot add post, already published"))
+          case _ => Effect.unhandled
+        }
+    }
+  }
+
+  private def addPost(cmd: AddPost): Effect[State] = {
+    Effect.persist(DraftState(cmd.content)).thenRun { _ =>
+      cmd.replyTo ! StatusReply.Success(AddPostDone(cmd.content.postId))
+    }
+  }
+
+  private def changeBody(state: DraftState, cmd: ChangeBody): Effect[State] = {
+    Effect.persist(state.withBody(cmd.newBody)).thenRun { _ =>
+      cmd.replyTo ! Done
+    }
+  }
+
+  private def publish(state: DraftState, replyTo: ActorRef[Done]): Effect[State] = {
+    Effect.persist(PublishedState(state.content)).thenRun { _ =>
+      println(s"Blog post ${state.postId} was published")
+      replyTo ! Done
+    }
+  }
+
+  private def getPost(state: DraftState, replyTo: ActorRef[PostContent]): Effect[State] = {
+    replyTo ! state.content
+    Effect.none
+  }
+
+  private def getPost(state: PublishedState, replyTo: ActorRef[PostContent]): Effect[State] = {
+    replyTo ! state.content
+    Effect.none
+  }
+
+}

--- a/docs/src/test/scala/docs/home/state/BlogPostCounts.scala
+++ b/docs/src/test/scala/docs/home/state/BlogPostCounts.scala
@@ -1,0 +1,74 @@
+/*
+ * Copyright (C) 2022 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package docs.home.state
+
+// #change-handler
+import scala.concurrent.ExecutionContext
+import scala.concurrent.Future
+
+import akka.Done
+import akka.actor.typed.ActorSystem
+import akka.persistence.Persistence
+import akka.persistence.query.DeletedDurableState
+import akka.persistence.query.DurableStateChange
+import akka.persistence.query.UpdatedDurableState
+import akka.persistence.r2dbc.session.scaladsl.R2dbcSession
+import akka.persistence.r2dbc.state.scaladsl.ChangeHandler
+
+// #change-handler
+
+/* config:
+// #change-handler-config
+akka.persistence.r2dbc.state {
+  change-handler {
+    "BlogPost" = "docs.BlogPostCounts"
+  }
+}
+// #change-handler-config
+ */
+
+// #change-handler
+/**
+ * Keep track of number of published blog posts. Count per slice.
+ *
+ * {{{
+ * CREATE TABLE post_count (slice INT NOT NULL, cnt BIGINT NOT NULL, PRIMARY KEY(slice));
+ * }}}
+ */
+class BlogPostCounts(system: ActorSystem[_]) extends ChangeHandler[BlogPost.State] {
+
+  private val incrementSql =
+    "INSERT INTO post_count (slice, cnt) VALUES ($1, 1) " +
+    "ON CONFLICT (slice) DO UPDATE SET cnt = excluded.cnt + 1"
+
+  private val decrementSql =
+    "UPDATE post_count SET cnt = cnt - 1 WHERE slice = $1"
+
+  private implicit val ec: ExecutionContext = system.executionContext
+
+  override def process(session: R2dbcSession, change: DurableStateChange[BlogPost.State]): Future[Done] = {
+    change match {
+      case upd: UpdatedDurableState[BlogPost.State] =>
+        upd.value match {
+          case _: BlogPost.PublishedState =>
+            val slice = Persistence(system).sliceForPersistenceId(upd.persistenceId)
+            val stmt = session
+              .createStatement(incrementSql)
+              .bind(0, slice)
+            session.updateOne(stmt).map(_ => Done)
+          case _ =>
+            Future.successful(Done)
+        }
+
+      case del: DeletedDurableState[BlogPost.State] =>
+        val slice = Persistence(system).sliceForPersistenceId(del.persistenceId)
+        val stmt = session
+          .createStatement(decrementSql)
+          .bind(0, slice)
+        session.updateOne(stmt).map(_ => Done)
+    }
+  }
+}
+// #change-handler

--- a/docs/src/test/scala/docs/home/state/BlogPostQuery.scala
+++ b/docs/src/test/scala/docs/home/state/BlogPostQuery.scala
@@ -1,0 +1,36 @@
+/**
+ * Copyright (C) 2022 Lightbend Inc. <https://www.lightbend.com>
+ */
+package docs.home.state
+
+// #query
+import scala.concurrent.Future
+
+import akka.actor.typed.ActorSystem
+import akka.persistence.r2dbc.session.scaladsl.R2dbcSession
+import akka.serialization.SerializationExtension
+
+class BlogPostQuery(system: ActorSystem[_]) {
+
+  private val findByTitleSql =
+    "SELECT state_ser_id, state_ser_manifest, state_payload " +
+    "FROM durable_state_blog_post " +
+    "WHERE title = $1"
+
+  def findByTitle(title: String): Future[IndexedSeq[BlogPost.State]] = {
+    R2dbcSession.withSession(system) { session =>
+      session.select(session.createStatement(findByTitleSql).bind(0, title)) { row =>
+        val serializerId = row.get("state_ser_id", classOf[java.lang.Integer])
+        val serializerManifest = row.get("state_ser_manifest", classOf[String])
+        val payload = row.get("state_payload", classOf[Array[Byte]])
+        val state = SerializationExtension(system)
+          .deserialize(payload, serializerId, serializerManifest)
+          .get
+          .asInstanceOf[BlogPost.State]
+        state
+      }
+    }
+  }
+
+}
+// #query

--- a/docs/src/test/scala/docs/home/state/BlogPostTitleColumn.scala
+++ b/docs/src/test/scala/docs/home/state/BlogPostTitleColumn.scala
@@ -1,0 +1,40 @@
+/*
+ * Copyright (C) 2022 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package docs.home.state
+
+// #additional-column
+import akka.persistence.r2dbc.state.scaladsl.AdditionalColumn
+
+// #additional-column
+
+/* config:
+// #additional-column-config
+akka.persistence.r2dbc.state {
+  additional-columns {
+    "BlogPost" = ["docs.BlogPostTitleColumn"]
+  }
+  custom-table {
+    "BlogPost" =  durable_state_blog_post
+  }
+}
+// #additional-column-config
+ */
+
+// #additional-column
+class BlogPostTitleColumn extends AdditionalColumn[BlogPost.State, String] {
+
+  override val columnName: String = "title"
+
+  override def bind(upsert: AdditionalColumn.Upsert[BlogPost.State]): AdditionalColumn.Binding[String] =
+    upsert.value match {
+      case BlogPost.BlankState =>
+        AdditionalColumn.BindNull
+      case s: BlogPost.DraftState =>
+        AdditionalColumn.BindValue(s.content.title)
+      case _: BlogPost.PublishedState =>
+        AdditionalColumn.Skip
+    }
+}
+// #additional-column


### PR DESCRIPTION
* for storing query representation from the write side in same transaction as the upsert
* support for additional columns in the durable_state table, for secondary indexes
* support for any additional processing for storing more complex
  representations, such as in a secondary table, still in same transaction
  
When reviewing it might be easier to look at the individual commits, which adds one feature at a time.

References #90

TODO:
- [x] javadsl
- [x] reference documentation
