### PR TITLE
fix: PubSub events shouldn't be too far ahead

### DIFF
--- a/core/src/main/scala/akka/persistence/r2dbc/internal/BySliceQuery.scala
+++ b/core/src/main/scala/akka/persistence/r2dbc/internal/BySliceQuery.scala
@@ -333,8 +333,7 @@ import org.slf4j.Logger
     }
 
     def switchFromBacktracking(state: QueryState): Boolean = {
-      // backtrackingCount is for fairness, to not run too many backtracking queries in a row
-      state.backtracking && (state.backtrackingCount >= 3 || state.rowCount < settings.querySettings.bufferSize - 1)
+      state.backtracking && state.rowCount < settings.querySettings.bufferSize - 1
     }
 
     def nextQuery(state: QueryState): (QueryState, Option[Source[Envelope, NotUsed]]) = {
@@ -345,6 +344,9 @@ import org.slf4j.Logger
             .between(state.latestBacktracking.timestamp, state.latest.timestamp)
             .compareTo(halfBacktrackingWindow) > 0)) {
           // FIXME config for newIdleCount >= 5 and maybe something like `newIdleCount % 5 == 0`
+
+          // Note that when starting the query with offset = NoOffset it will switch to backtracking immediately after
+          // the first normal query because between(latestBacktracking.timestamp, latest.timestamp) > halfBacktrackingWindow
 
           // switching to backtracking
           val fromOffset =


### PR DESCRIPTION
* because if consumer stores offset from PubSub event that is further ahead than than the backtracking window a subsequent restart of the consumer will not read the possibly missing events from backtracking

* [x] More test coverage