### PR TITLE
fix: Filtered event looks like backtracking event, #343

### DIFF
--- a/core/src/main/scala/akka/persistence/r2dbc/internal/EnvelopeOrigin.scala
+++ b/core/src/main/scala/akka/persistence/r2dbc/internal/EnvelopeOrigin.scala
@@ -1,0 +1,34 @@
+/*
+ * Copyright (C) 2022 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.persistence.r2dbc.internal
+
+import akka.annotation.InternalStableApi
+import akka.persistence.query.UpdatedDurableState
+import akka.persistence.query.typed.EventEnvelope
+
+/**
+ * INTERNAL API
+ */
+@InternalStableApi private[akka] object EnvelopeOrigin {
+  val SourceQuery = ""
+  val SourceBacktracking = "BT"
+  val SourcePubSub = "PS"
+
+  def fromBacktracking(env: EventEnvelope[_]): Boolean =
+    env.source == SourceBacktracking
+
+  def fromBacktracking(change: UpdatedDurableState[_]): Boolean =
+    change.value == null
+
+  def fromPubSub(env: EventEnvelope[_]): Boolean =
+    env.source == SourcePubSub
+
+  def isFilteredEvent(env: Any): Boolean =
+    env match {
+      case e: EventEnvelope[_] => e.filtered
+      case _                   => false
+    }
+
+}

--- a/core/src/main/scala/akka/persistence/r2dbc/internal/PubSub.scala
+++ b/core/src/main/scala/akka/persistence/r2dbc/internal/PubSub.scala
@@ -137,7 +137,9 @@ import org.slf4j.LoggerFactory
         timestamp.toEpochMilli,
         pr.metadata,
         entityType,
-        slice)
+        slice,
+        filtered = false,
+        source = EnvelopeOrigin.SourcePubSub)
       eventTopic(entityType, slice) ! Topic.Publish(envelope)
     }
   }

--- a/core/src/test/scala/akka/persistence/r2dbc/query/EventsBySliceBacktrackingSpec.scala
+++ b/core/src/test/scala/akka/persistence/r2dbc/query/EventsBySliceBacktrackingSpec.scala
@@ -20,6 +20,7 @@ import akka.persistence.r2dbc.internal.Sql.Interpolation
 import akka.persistence.r2dbc.TestConfig
 import akka.persistence.r2dbc.TestData
 import akka.persistence.r2dbc.TestDbLifecycle
+import akka.persistence.r2dbc.internal.EnvelopeOrigin
 import akka.persistence.r2dbc.internal.InstantFactory
 import akka.persistence.r2dbc.query.scaladsl.R2dbcReadJournal
 import akka.persistence.typed.PersistenceId
@@ -103,17 +104,20 @@ class EventsBySliceBacktrackingSpec
       env1.persistenceId shouldBe pid1
       env1.sequenceNr shouldBe 1L
       env1.eventOption shouldBe Some("e1-1")
+      env1.source shouldBe EnvelopeOrigin.SourceQuery
 
       val env2 = result.expectNext()
       env2.persistenceId shouldBe pid1
       env2.sequenceNr shouldBe 2L
       env2.eventOption shouldBe Some("e1-2")
+      env2.source shouldBe EnvelopeOrigin.SourceQuery
 
       // first backtracking query kicks in immediately after the first normal query has finished
       // and it also emits duplicates (by design)
       val env3 = result.expectNext()
       env3.persistenceId shouldBe pid1
       env3.sequenceNr shouldBe 1L
+      env3.source shouldBe EnvelopeOrigin.SourceBacktracking
       // event payload isn't included in backtracking results
       env3.eventOption shouldBe None
       // but it can be lazy loaded

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -7,7 +7,7 @@ import sbt._
 object Dependencies {
   val Scala212 = "2.12.17"
   val Scala213 = "2.13.10"
-  val AkkaVersion = System.getProperty("override.akka.version", "2.8.0-M3+11-f194d030-SNAPSHOT") // FIXME
+  val AkkaVersion = System.getProperty("override.akka.version", "2.8.0-M4")
   val AkkaVersionInDocs = AkkaVersion.take(3)
   val AkkaProjectionVersion = "1.3.0"
   val AkkaPersistenceJdbcVersion = "5.2.0" // only in migration tool tests

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -7,7 +7,7 @@ import sbt._
 object Dependencies {
   val Scala212 = "2.12.17"
   val Scala213 = "2.13.10"
-  val AkkaVersion = System.getProperty("override.akka.version", "2.7.0")
+  val AkkaVersion = System.getProperty("override.akka.version", "2.8.0-M3+11-f194d030-SNAPSHOT") // FIXME
   val AkkaVersionInDocs = AkkaVersion.take(3)
   val AkkaProjectionVersion = "1.3.0"
   val AkkaPersistenceJdbcVersion = "5.2.0" // only in migration tool tests


### PR DESCRIPTION
`R2dbcOffsetStore` is supposed to throw exception if a backtracking even is out of sync, but for events from the tail query and pubsub it should return false so that they are tried again when backtracking event arrives. The problem is for filtered events. We can't see if the filtered event is from backtracking or not. Looks like they are always from backtracking.

Filtered events are represented with `eventOption = None, eventMetadata = Some(NotUsed)`.

We need a way to see if the filtered event is from backtracking. That should still result in a hard error.

References #343

TODO:
- [x] actual fix
- [x] add test of filtered event in the tests of isAccepted
