### PR TITLE
perf: Avoid too large bursts of backtracking events

### DIFF
--- a/core/src/main/scala/akka/persistence/r2dbc/internal/EnvelopeOrigin.scala
+++ b/core/src/main/scala/akka/persistence/r2dbc/internal/EnvelopeOrigin.scala
@@ -16,6 +16,9 @@ import akka.persistence.query.typed.EventEnvelope
   val SourceBacktracking = "BT"
   val SourcePubSub = "PS"
 
+  def fromQuery(env: EventEnvelope[_]): Boolean =
+    env.source == SourceQuery
+
   def fromBacktracking(env: EventEnvelope[_]): Boolean =
     env.source == SourceBacktracking
 

--- a/core/src/main/scala/akka/persistence/r2dbc/query/scaladsl/R2dbcReadJournal.scala
+++ b/core/src/main/scala/akka/persistence/r2dbc/query/scaladsl/R2dbcReadJournal.scala
@@ -82,6 +82,7 @@ final class R2dbcReadJournal(system: ExtendedActorSystem, config: Config, cfgPat
       val event = row.payload.map(payload => serialization.deserialize(payload, row.serId, row.serManifest).get)
       val metadata = row.metadata.map(meta => serialization.deserialize(meta.payload, meta.serId, meta.serManifest).get)
       val source = if (event.isDefined) EnvelopeOrigin.SourceQuery else EnvelopeOrigin.SourceBacktracking
+
       new EventEnvelope(
         offset,
         row.persistenceId,


### PR DESCRIPTION
https://github.com/akka/akka-persistence-r2dbc/pull/300 added some fairness to switch from backtracking earlier.
That is reverted in https://github.com/akka/akka-persistence-r2dbc/pull/345

This PR solves the original issue in a better way. Instead of only having a time based switch (half backtracking window) it is now also switching to backtracking if many events have been received by the ordinary queries.