### PR TITLE
chore: Un-lazy the read journal providers

### DIFF
--- a/core/src/main/scala/akka/persistence/r2dbc/query/R2dbcReadJournalProvider.scala
+++ b/core/src/main/scala/akka/persistence/r2dbc/query/R2dbcReadJournalProvider.scala
@@ -12,12 +12,12 @@ import com.typesafe.config.Config
 final class R2dbcReadJournalProvider(system: ExtendedActorSystem, config: Config, cfgPath: String)
     extends ReadJournalProvider {
 
-  private lazy val scaladslReadJournalInstance =
+  private val scaladslReadJournalInstance =
     new scaladsl.R2dbcReadJournal(system, config, cfgPath)
 
   override def scaladslReadJournal(): ReadJournal = scaladslReadJournalInstance
 
-  private lazy val javadslReadJournalInstance =
+  private val javadslReadJournalInstance =
     new javadsl.R2dbcReadJournal(scaladslReadJournalInstance)
 
   override def javadslReadJournal(): javadsl.R2dbcReadJournal = javadslReadJournalInstance


### PR DESCRIPTION
Not a huge thing, but the Scala 3 work made these lazy while they were previously eagerly constructed with the provider, so changing it back so it works exactly like before.
