### PR TITLE
Allow escaping of literal `?` in SQL statements

### DIFF
--- a/core/src/main/scala/akka/persistence/r2dbc/internal/Sql.scala
+++ b/core/src/main/scala/akka/persistence/r2dbc/internal/Sql.scala
@@ -16,9 +16,9 @@ import akka.annotation.InternalStableApi
 object Sql {
 
   /**
-   * Scala string interpolation with `sql` prefix. Replaces `?` with numbered `\$1`, `\$2` for bind parameters. Use 
-   * `??` to include a literal `?`. Trims whitespace, including line breaks. Standard string interpolation arguments 
-   * `$` can be used.
+   * Scala string interpolation with `sql` prefix. Replaces `?` with numbered `\$1`, `\$2` for bind parameters. Use `??`
+   * to include a literal `?`. Trims whitespace, including line breaks. Standard string interpolation arguments `$` can
+   * be used.
    */
   implicit class Interpolation(val sc: StringContext) extends AnyVal {
     def sql(args: Any*): String =
@@ -26,7 +26,7 @@ object Sql {
   }
 
   /**
-   * Java API: Replaces `?` with numbered `\$1`, `\$2` for bind parameters. Use `??` to include a literal `?`. Trims 
+   * Java API: Replaces `?` with numbered `\$1`, `\$2` for bind parameters. Use `??` to include a literal `?`. Trims
    * whitespace, including line breaks. The arguments are used like in [[java.lang.String.format]].
    */
   @varargs
@@ -40,10 +40,10 @@ object Sql {
       val sb = new java.lang.StringBuilder(sql.length + 10)
       var n = 0
       var i = 0
+      def isNext(d: Char): Boolean = (i < sql.length - 1) && (sql.charAt(i + 1) == d)
       while (i < sql.length) {
         val c = sql.charAt(i)
-        val d = if (i < sql.length - 1) sql.charAt(i + 1) else 0
-        if (c == '?' && d == '?') {
+        if (c == '?' && isNext('?')) {
           sb.append('?')
           i += 1 // advance past extra '?'
         } else if (c == '?') {

--- a/core/src/main/scala/akka/persistence/r2dbc/internal/Sql.scala
+++ b/core/src/main/scala/akka/persistence/r2dbc/internal/Sql.scala
@@ -16,8 +16,9 @@ import akka.annotation.InternalStableApi
 object Sql {
 
   /**
-   * Scala string interpolation with `sql` prefix. Replaces `?` with numbered `\$1`, `\$2` for bind parameters. Trims
-   * whitespace, including line breaks. Standard string interpolation arguments `$` can be used.
+   * Scala string interpolation with `sql` prefix. Replaces `?` with numbered `\$1`, `\$2` for bind parameters. Use 
+   * `??` to include a literal `?`. Trims whitespace, including line breaks. Standard string interpolation arguments 
+   * `$` can be used.
    */
   implicit class Interpolation(val sc: StringContext) extends AnyVal {
     def sql(args: Any*): String =
@@ -25,8 +26,8 @@ object Sql {
   }
 
   /**
-   * Java API: Replaces `?` with numbered `\$1`, `\$2` for bind parameters. Trims whitespace, including line breaks. The
-   * arguments are used like in [[java.lang.String.format]].
+   * Java API: Replaces `?` with numbered `\$1`, `\$2` for bind parameters. Use `??` to include a literal `?`. Trims 
+   * whitespace, including line breaks. The arguments are used like in [[java.lang.String.format]].
    */
   @varargs
   def format(sql: String, args: AnyRef*): String =
@@ -41,7 +42,11 @@ object Sql {
       var i = 0
       while (i < sql.length) {
         val c = sql.charAt(i)
-        if (c == '?') {
+        val d = if (i < sql.length - 1) sql.charAt(i + 1) else 0
+        if (c == '?' && d == '?') {
+          sb.append('?')
+          i += 1 // advance past extra '?'
+        } else if (c == '?') {
           n += 1
           sb.append('$').append(n)
         } else {

--- a/core/src/test/scala/akka/persistence/r2dbc/internal/SqlSpec.scala
+++ b/core/src/test/scala/akka/persistence/r2dbc/internal/SqlSpec.scala
@@ -12,9 +12,9 @@ class SqlSpec extends AnyWordSpec with TestSuite with Matchers {
   import Sql.Interpolation
 
   "SQL string interpolation" should {
-    "replace ? bind parameters with numbered $" in {
-      sql"select * from bar where a = ?" shouldBe "select * from bar where a = $1"
-      sql"select * from bar where a = ? and b = ? and c = ?" shouldBe "select * from bar where a = $1 and b = $2 and c = $3"
+    "replace ? bind parameters with numbered $ (avoiding escaped ones)" in {
+      sql"select * from bar where a = ? and qa = 'Question?? Answer!'" shouldBe "select * from bar where a = $1 and qa = 'Question? Answer!'"
+      sql"select * from bar where a = ? and b = ? and jsonb ?? 'status' and c = ?" shouldBe "select * from bar where a = $1 and b = $2 and jsonb ? 'status' and c = $3"
       sql"select * from bar" shouldBe "select * from bar"
     }
 


### PR DESCRIPTION
A double question mark `??` is used to provide a single question mark `?` to the output statement.