### PR TITLE
ci: restore scala 3 postgres nightly only running core/test

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -24,7 +24,7 @@ jobs:
           # { scalaVersion: "2.13", jdkVersion: "1.8.0",  jvmName: "temurin:1.8.0", extraOpts: '', testCmd: "test"}
           # { scalaVersion: "2.13", jdkVersion: "1.11.0", jvmName: "temurin:1.11.0", extraOpts: '-J-XX:+UnlockExperimentalVMOptions -J-XX:+UseJVMCICompiler', testCmd: "test"}
           - { scalaVersion: "2.13", jdkVersion: "1.17.0", jvmName: "temurin:1.17.0", extraOpts: '', testCmd: "test"}
-          - { scalaVersion: "3.1",  jdkVersion: "1.17.0", jvmName: "temurin:1.17.0", extraOpts: '', testCmd: "core/test"}
+          - { scalaVersion: "3.1",  jdkVersion: "1.17.0", jvmName: "temurin:1.17.0", extraOpts: '', testCmd: "core/test projection/test"}
     steps:
       - name: Checkout
         uses: actions/checkout@v3.1.0

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -24,7 +24,7 @@ jobs:
           # { scalaVersion: "2.13", jdkVersion: "1.8.0",  jvmName: "temurin:1.8.0", extraOpts: '', testCmd: "test"}
           # { scalaVersion: "2.13", jdkVersion: "1.11.0", jvmName: "temurin:1.11.0", extraOpts: '-J-XX:+UnlockExperimentalVMOptions -J-XX:+UseJVMCICompiler', testCmd: "test"}
           - { scalaVersion: "2.13", jdkVersion: "1.17.0", jvmName: "temurin:1.17.0", extraOpts: '', testCmd: "test"}
-          - { scalaVersion: "3.1",  jdkVersion: "1.17.0", jvmName: "temurin:1.17.0", extraOpts: '', testCmd: "test"}
+          - { scalaVersion: "3.1",  jdkVersion: "1.17.0", jvmName: "temurin:1.17.0", extraOpts: '', testCmd: "core/test"}
     steps:
       - name: Checkout
         uses: actions/checkout@v3.1.0


### PR DESCRIPTION
Refs #368

#367 changed the scala 3 postgres nightly from `core/test` to `test`, which fails to compile. Change this back again.