### PR TITLE
chore: bump copyright header for 2023

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -40,7 +40,8 @@ def common: Seq[Setting[_]] =
     sonatypeProfileName := "com.lightbend",
     // Setting javac options in common allows IntelliJ IDEA to import them automatically
     Compile / javacOptions ++= Seq("-encoding", "UTF-8", "-source", "1.8", "-target", "1.8"),
-    headerLicense := Some(HeaderLicense.Custom("""Copyright (C) 2022 - 2023 Lightbend Inc. <https://www.lightbend.com>""")),
+    headerLicense := Some(
+      HeaderLicense.Custom("""Copyright (C) 2022 - 2023 Lightbend Inc. <https://www.lightbend.com>""")),
     Test / logBuffered := false,
     Test / parallelExecution := false,
     // show full stack traces and test case durations

--- a/build.sbt
+++ b/build.sbt
@@ -40,7 +40,7 @@ def common: Seq[Setting[_]] =
     sonatypeProfileName := "com.lightbend",
     // Setting javac options in common allows IntelliJ IDEA to import them automatically
     Compile / javacOptions ++= Seq("-encoding", "UTF-8", "-source", "1.8", "-target", "1.8"),
-    headerLicense := Some(HeaderLicense.Custom("""Copyright (C) 2022 Lightbend Inc. <https://www.lightbend.com>""")),
+    headerLicense := Some(HeaderLicense.Custom("""Copyright (C) 2022 - 2023 Lightbend Inc. <https://www.lightbend.com>""")),
     Test / logBuffered := false,
     Test / parallelExecution := false,
     // show full stack traces and test case durations

--- a/core/src/main/scala/akka/persistence/r2dbc/ConnectionFactoryProvider.scala
+++ b/core/src/main/scala/akka/persistence/r2dbc/ConnectionFactoryProvider.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2022 - 2023 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.persistence.r2dbc

--- a/core/src/main/scala/akka/persistence/r2dbc/R2dbcSettings.scala
+++ b/core/src/main/scala/akka/persistence/r2dbc/R2dbcSettings.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2022 - 2023 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.persistence.r2dbc

--- a/core/src/main/scala/akka/persistence/r2dbc/cleanup/javadsl/DurableStateCleanup.scala
+++ b/core/src/main/scala/akka/persistence/r2dbc/cleanup/javadsl/DurableStateCleanup.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2022 - 2023 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.persistence.r2dbc.cleanup.javadsl

--- a/core/src/main/scala/akka/persistence/r2dbc/cleanup/javadsl/EventSourcedCleanup.scala
+++ b/core/src/main/scala/akka/persistence/r2dbc/cleanup/javadsl/EventSourcedCleanup.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2022 - 2023 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.persistence.r2dbc.cleanup.javadsl

--- a/core/src/main/scala/akka/persistence/r2dbc/cleanup/scaladsl/DurableStateCleanup.scala
+++ b/core/src/main/scala/akka/persistence/r2dbc/cleanup/scaladsl/DurableStateCleanup.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2022 - 2023 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.persistence.r2dbc.cleanup.scaladsl

--- a/core/src/main/scala/akka/persistence/r2dbc/cleanup/scaladsl/EventSourcedCleanup.scala
+++ b/core/src/main/scala/akka/persistence/r2dbc/cleanup/scaladsl/EventSourcedCleanup.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2022 - 2023 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.persistence.r2dbc.cleanup.scaladsl

--- a/core/src/main/scala/akka/persistence/r2dbc/internal/AdditionalColumnFactory.scala
+++ b/core/src/main/scala/akka/persistence/r2dbc/internal/AdditionalColumnFactory.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2022 - 2023 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.persistence.r2dbc.internal

--- a/core/src/main/scala/akka/persistence/r2dbc/internal/BySliceQuery.scala
+++ b/core/src/main/scala/akka/persistence/r2dbc/internal/BySliceQuery.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2022 - 2023 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.persistence.r2dbc.internal

--- a/core/src/main/scala/akka/persistence/r2dbc/internal/ChangeHandlerFactory.scala
+++ b/core/src/main/scala/akka/persistence/r2dbc/internal/ChangeHandlerFactory.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2022 - 2023 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.persistence.r2dbc.internal

--- a/core/src/main/scala/akka/persistence/r2dbc/internal/ContinuousQuery.scala
+++ b/core/src/main/scala/akka/persistence/r2dbc/internal/ContinuousQuery.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2022 - 2023 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.persistence.r2dbc.internal

--- a/core/src/main/scala/akka/persistence/r2dbc/internal/EWMA.scala
+++ b/core/src/main/scala/akka/persistence/r2dbc/internal/EWMA.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2022 - 2023 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.persistence.r2dbc.internal

--- a/core/src/main/scala/akka/persistence/r2dbc/internal/EnvelopeOrigin.scala
+++ b/core/src/main/scala/akka/persistence/r2dbc/internal/EnvelopeOrigin.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2022 - 2023 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.persistence.r2dbc.internal

--- a/core/src/main/scala/akka/persistence/r2dbc/internal/InstantFactory.scala
+++ b/core/src/main/scala/akka/persistence/r2dbc/internal/InstantFactory.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2022 - 2023 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.persistence.r2dbc.internal

--- a/core/src/main/scala/akka/persistence/r2dbc/internal/PubSub.scala
+++ b/core/src/main/scala/akka/persistence/r2dbc/internal/PubSub.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2022 - 2023 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.persistence.r2dbc.internal

--- a/core/src/main/scala/akka/persistence/r2dbc/internal/R2dbcExecutor.scala
+++ b/core/src/main/scala/akka/persistence/r2dbc/internal/R2dbcExecutor.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2022 - 2023 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.persistence.r2dbc.internal

--- a/core/src/main/scala/akka/persistence/r2dbc/internal/Sql.scala
+++ b/core/src/main/scala/akka/persistence/r2dbc/internal/Sql.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2022 - 2023 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.persistence.r2dbc.internal

--- a/core/src/main/scala/akka/persistence/r2dbc/journal/JournalDao.scala
+++ b/core/src/main/scala/akka/persistence/r2dbc/journal/JournalDao.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2022 - 2023 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.persistence.r2dbc.journal

--- a/core/src/main/scala/akka/persistence/r2dbc/journal/R2dbcJournal.scala
+++ b/core/src/main/scala/akka/persistence/r2dbc/journal/R2dbcJournal.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2022 - 2023 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.persistence.r2dbc.journal

--- a/core/src/main/scala/akka/persistence/r2dbc/query/R2dbcReadJournalProvider.scala
+++ b/core/src/main/scala/akka/persistence/r2dbc/query/R2dbcReadJournalProvider.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2022 - 2023 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.persistence.r2dbc.query

--- a/core/src/main/scala/akka/persistence/r2dbc/query/javadsl/R2dbcReadJournal.scala
+++ b/core/src/main/scala/akka/persistence/r2dbc/query/javadsl/R2dbcReadJournal.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2022 - 2023 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.persistence.r2dbc.query.javadsl

--- a/core/src/main/scala/akka/persistence/r2dbc/query/scaladsl/QueryDao.scala
+++ b/core/src/main/scala/akka/persistence/r2dbc/query/scaladsl/QueryDao.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2022 - 2023 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.persistence.r2dbc.query.scaladsl

--- a/core/src/main/scala/akka/persistence/r2dbc/query/scaladsl/R2dbcReadJournal.scala
+++ b/core/src/main/scala/akka/persistence/r2dbc/query/scaladsl/R2dbcReadJournal.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2022 - 2023 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.persistence.r2dbc.query.scaladsl

--- a/core/src/main/scala/akka/persistence/r2dbc/session/javadsl/R2dbcSession.scala
+++ b/core/src/main/scala/akka/persistence/r2dbc/session/javadsl/R2dbcSession.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2022 - 2023 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.persistence.r2dbc.session.javadsl

--- a/core/src/main/scala/akka/persistence/r2dbc/session/scaladsl/R2dbcSession.scala
+++ b/core/src/main/scala/akka/persistence/r2dbc/session/scaladsl/R2dbcSession.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2022 - 2023 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.persistence.r2dbc.session.scaladsl

--- a/core/src/main/scala/akka/persistence/r2dbc/snapshot/R2dbcSnapshotStore.scala
+++ b/core/src/main/scala/akka/persistence/r2dbc/snapshot/R2dbcSnapshotStore.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2022 - 2023 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.persistence.r2dbc.snapshot

--- a/core/src/main/scala/akka/persistence/r2dbc/snapshot/SnapshotDao.scala
+++ b/core/src/main/scala/akka/persistence/r2dbc/snapshot/SnapshotDao.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2022 - 2023 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.persistence.r2dbc.snapshot

--- a/core/src/main/scala/akka/persistence/r2dbc/state/ChangeHandlerException.scala
+++ b/core/src/main/scala/akka/persistence/r2dbc/state/ChangeHandlerException.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2022 - 2023 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.persistence.r2dbc.state

--- a/core/src/main/scala/akka/persistence/r2dbc/state/R2dbcDurableStateStoreProvider.scala
+++ b/core/src/main/scala/akka/persistence/r2dbc/state/R2dbcDurableStateStoreProvider.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2022 - 2023 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.persistence.r2dbc.state

--- a/core/src/main/scala/akka/persistence/r2dbc/state/javadsl/AdditionalColumn.scala
+++ b/core/src/main/scala/akka/persistence/r2dbc/state/javadsl/AdditionalColumn.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2022 - 2023 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.persistence.r2dbc.state.javadsl

--- a/core/src/main/scala/akka/persistence/r2dbc/state/javadsl/ChangeHandler.scala
+++ b/core/src/main/scala/akka/persistence/r2dbc/state/javadsl/ChangeHandler.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2022 - 2023 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.persistence.r2dbc.state.javadsl

--- a/core/src/main/scala/akka/persistence/r2dbc/state/javadsl/R2dbcDurableStateStore.scala
+++ b/core/src/main/scala/akka/persistence/r2dbc/state/javadsl/R2dbcDurableStateStore.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2022 - 2023 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.persistence.r2dbc.state.javadsl

--- a/core/src/main/scala/akka/persistence/r2dbc/state/scaladsl/AdditionalColumn.scala
+++ b/core/src/main/scala/akka/persistence/r2dbc/state/scaladsl/AdditionalColumn.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2022 - 2023 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.persistence.r2dbc.state.scaladsl

--- a/core/src/main/scala/akka/persistence/r2dbc/state/scaladsl/ChangeHandler.scala
+++ b/core/src/main/scala/akka/persistence/r2dbc/state/scaladsl/ChangeHandler.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2022 - 2023 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.persistence.r2dbc.state.scaladsl

--- a/core/src/main/scala/akka/persistence/r2dbc/state/scaladsl/DurableStateDao.scala
+++ b/core/src/main/scala/akka/persistence/r2dbc/state/scaladsl/DurableStateDao.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2022 - 2023 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.persistence.r2dbc.state.scaladsl

--- a/core/src/main/scala/akka/persistence/r2dbc/state/scaladsl/R2dbcDurableStateStore.scala
+++ b/core/src/main/scala/akka/persistence/r2dbc/state/scaladsl/R2dbcDurableStateStore.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2022 - 2023 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.persistence.r2dbc.state.scaladsl

--- a/core/src/test/java/akka/persistence/r2dbc/state/JavadslChangeHandler.java
+++ b/core/src/test/java/akka/persistence/r2dbc/state/JavadslChangeHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2022 - 2023 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.persistence.r2dbc.state;

--- a/core/src/test/java/akka/persistence/r2dbc/state/JavadslColumn.java
+++ b/core/src/test/java/akka/persistence/r2dbc/state/JavadslColumn.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2022 - 2023 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.persistence.r2dbc.state;

--- a/core/src/test/scala/akka/persistence/r2dbc/CborSerializable.scala
+++ b/core/src/test/scala/akka/persistence/r2dbc/CborSerializable.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2022 - 2023 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.persistence.r2dbc

--- a/core/src/test/scala/akka/persistence/r2dbc/R2dbcSettingsSpec.scala
+++ b/core/src/test/scala/akka/persistence/r2dbc/R2dbcSettingsSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2022 - 2023 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.persistence.r2dbc

--- a/core/src/test/scala/akka/persistence/r2dbc/TestActors.scala
+++ b/core/src/test/scala/akka/persistence/r2dbc/TestActors.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2022 - 2023 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.persistence.r2dbc

--- a/core/src/test/scala/akka/persistence/r2dbc/TestConfig.scala
+++ b/core/src/test/scala/akka/persistence/r2dbc/TestConfig.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2022 - 2023 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.persistence.r2dbc

--- a/core/src/test/scala/akka/persistence/r2dbc/TestData.scala
+++ b/core/src/test/scala/akka/persistence/r2dbc/TestData.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2022 - 2023 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.persistence.r2dbc

--- a/core/src/test/scala/akka/persistence/r2dbc/TestDbLifecycle.scala
+++ b/core/src/test/scala/akka/persistence/r2dbc/TestDbLifecycle.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2022 - 2023 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.persistence.r2dbc

--- a/core/src/test/scala/akka/persistence/r2dbc/cleanup/scaladsl/DurableStateCleanupSpec.scala
+++ b/core/src/test/scala/akka/persistence/r2dbc/cleanup/scaladsl/DurableStateCleanupSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2022 - 2023 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.persistence.r2dbc.cleanup.scaladsl

--- a/core/src/test/scala/akka/persistence/r2dbc/cleanup/scaladsl/EventSourcedCleanupSpec.scala
+++ b/core/src/test/scala/akka/persistence/r2dbc/cleanup/scaladsl/EventSourcedCleanupSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2022 - 2023 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.persistence.r2dbc.cleanup.scaladsl

--- a/core/src/test/scala/akka/persistence/r2dbc/internal/BySliceQueryBucketsSpec.scala
+++ b/core/src/test/scala/akka/persistence/r2dbc/internal/BySliceQueryBucketsSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2022 - 2023 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.persistence.r2dbc.internal

--- a/core/src/test/scala/akka/persistence/r2dbc/internal/ContinuousQuerySpec.scala
+++ b/core/src/test/scala/akka/persistence/r2dbc/internal/ContinuousQuerySpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2022 - 2023 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.persistence.r2dbc.internal

--- a/core/src/test/scala/akka/persistence/r2dbc/internal/EWMASpec.scala
+++ b/core/src/test/scala/akka/persistence/r2dbc/internal/EWMASpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2022 - 2023 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.persistence.r2dbc.internal

--- a/core/src/test/scala/akka/persistence/r2dbc/internal/SqlSpec.scala
+++ b/core/src/test/scala/akka/persistence/r2dbc/internal/SqlSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2022 - 2023 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.persistence.r2dbc.internal

--- a/core/src/test/scala/akka/persistence/r2dbc/journal/MultiPluginSpec.scala
+++ b/core/src/test/scala/akka/persistence/r2dbc/journal/MultiPluginSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2022 - 2023 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.persistence.r2dbc.journal

--- a/core/src/test/scala/akka/persistence/r2dbc/journal/PersistTagsSpec.scala
+++ b/core/src/test/scala/akka/persistence/r2dbc/journal/PersistTagsSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2022 - 2023 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.persistence.r2dbc.journal

--- a/core/src/test/scala/akka/persistence/r2dbc/journal/PersistTimestampSpec.scala
+++ b/core/src/test/scala/akka/persistence/r2dbc/journal/PersistTimestampSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2022 - 2023 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.persistence.r2dbc.journal

--- a/core/src/test/scala/akka/persistence/r2dbc/journal/R2dbcJournalPerfManyActorsSpec.scala
+++ b/core/src/test/scala/akka/persistence/r2dbc/journal/R2dbcJournalPerfManyActorsSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2022 - 2023 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.persistence.r2dbc.journal

--- a/core/src/test/scala/akka/persistence/r2dbc/journal/R2dbcJournalPerfSpec.scala
+++ b/core/src/test/scala/akka/persistence/r2dbc/journal/R2dbcJournalPerfSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2022 - 2023 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.persistence.r2dbc.journal

--- a/core/src/test/scala/akka/persistence/r2dbc/journal/R2dbcJournalSpec.scala
+++ b/core/src/test/scala/akka/persistence/r2dbc/journal/R2dbcJournalSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2022 - 2023 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.persistence.r2dbc.journal

--- a/core/src/test/scala/akka/persistence/r2dbc/journal/TestDataGenerator.scala
+++ b/core/src/test/scala/akka/persistence/r2dbc/journal/TestDataGenerator.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2022 - 2023 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.persistence.r2dbc.journal

--- a/core/src/test/scala/akka/persistence/r2dbc/query/CurrentPersistenceIdsQuerySpec.scala
+++ b/core/src/test/scala/akka/persistence/r2dbc/query/CurrentPersistenceIdsQuerySpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2022 - 2023 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.persistence.r2dbc.query

--- a/core/src/test/scala/akka/persistence/r2dbc/query/EventsByPersistenceIdSpec.scala
+++ b/core/src/test/scala/akka/persistence/r2dbc/query/EventsByPersistenceIdSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2022 - 2023 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.persistence.r2dbc.query

--- a/core/src/test/scala/akka/persistence/r2dbc/query/EventsBySliceBacktrackingSpec.scala
+++ b/core/src/test/scala/akka/persistence/r2dbc/query/EventsBySliceBacktrackingSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2022 - 2023 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.persistence.r2dbc.query

--- a/core/src/test/scala/akka/persistence/r2dbc/query/EventsBySlicePerfSpec.scala
+++ b/core/src/test/scala/akka/persistence/r2dbc/query/EventsBySlicePerfSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2022 - 2023 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.persistence.r2dbc.query

--- a/core/src/test/scala/akka/persistence/r2dbc/query/EventsBySlicePubSubSpec.scala
+++ b/core/src/test/scala/akka/persistence/r2dbc/query/EventsBySlicePubSubSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2022 - 2023 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.persistence.r2dbc.query

--- a/core/src/test/scala/akka/persistence/r2dbc/query/EventsBySliceSpec.scala
+++ b/core/src/test/scala/akka/persistence/r2dbc/query/EventsBySliceSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2022 - 2023 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.persistence.r2dbc.query

--- a/core/src/test/scala/akka/persistence/r2dbc/snapshot/R2dbcSnapshotStoreSpec.scala
+++ b/core/src/test/scala/akka/persistence/r2dbc/snapshot/R2dbcSnapshotStoreSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2022 - 2023 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.persistence.r2dbc.snapshot

--- a/core/src/test/scala/akka/persistence/r2dbc/state/CurrentPersistenceIdsQuerySpec.scala
+++ b/core/src/test/scala/akka/persistence/r2dbc/state/CurrentPersistenceIdsQuerySpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2022 - 2023 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.persistence.r2dbc.state

--- a/core/src/test/scala/akka/persistence/r2dbc/state/DurableStateBySliceSpec.scala
+++ b/core/src/test/scala/akka/persistence/r2dbc/state/DurableStateBySliceSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2022 - 2023 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.persistence.r2dbc.state

--- a/core/src/test/scala/akka/persistence/r2dbc/state/DurableStateStoreAdditionalColumnSpec.scala
+++ b/core/src/test/scala/akka/persistence/r2dbc/state/DurableStateStoreAdditionalColumnSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2022 - 2023 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.persistence.r2dbc.state

--- a/core/src/test/scala/akka/persistence/r2dbc/state/DurableStateStoreChangeHandlerSpec.scala
+++ b/core/src/test/scala/akka/persistence/r2dbc/state/DurableStateStoreChangeHandlerSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2022 - 2023 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.persistence.r2dbc.state

--- a/core/src/test/scala/akka/persistence/r2dbc/state/DurableStateStoreSpec.scala
+++ b/core/src/test/scala/akka/persistence/r2dbc/state/DurableStateStoreSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2022 - 2023 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.persistence.r2dbc.state

--- a/core/src/test/scala/akka/persistence/r2dbc/state/TestDataGenerator.scala
+++ b/core/src/test/scala/akka/persistence/r2dbc/state/TestDataGenerator.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2022 - 2023 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.persistence.r2dbc.state

--- a/migration-tests/src/test/scala/akka/persistence/r2dbc/migration/MigrationToolSpec.scala
+++ b/migration-tests/src/test/scala/akka/persistence/r2dbc/migration/MigrationToolSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2022 - 2023 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.persistence.r2dbc.migration

--- a/migration/src/main/scala/akka/persistence/r2dbc/migration/MigrationTool.scala
+++ b/migration/src/main/scala/akka/persistence/r2dbc/migration/MigrationTool.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2022 - 2023 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.persistence.r2dbc.migration

--- a/migration/src/main/scala/akka/persistence/r2dbc/migration/MigrationToolDao.scala
+++ b/migration/src/main/scala/akka/persistence/r2dbc/migration/MigrationToolDao.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2022 - 2023 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.persistence.r2dbc.migration

--- a/projection/src/main/scala/akka/projection/r2dbc/R2dbcProjectionSettings.scala
+++ b/projection/src/main/scala/akka/projection/r2dbc/R2dbcProjectionSettings.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2022 - 2023 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.projection.r2dbc

--- a/projection/src/main/scala/akka/projection/r2dbc/internal/BySliceSourceProviderAdapter.scala
+++ b/projection/src/main/scala/akka/projection/r2dbc/internal/BySliceSourceProviderAdapter.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2022 - 2023 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.projection.r2dbc.internal

--- a/projection/src/main/scala/akka/projection/r2dbc/internal/R2dbcHandlerAdapter.scala
+++ b/projection/src/main/scala/akka/projection/r2dbc/internal/R2dbcHandlerAdapter.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2022 - 2023 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.projection.r2dbc.internal

--- a/projection/src/main/scala/akka/projection/r2dbc/internal/R2dbcOffsetStore.scala
+++ b/projection/src/main/scala/akka/projection/r2dbc/internal/R2dbcOffsetStore.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2022 - 2023 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.projection.r2dbc.internal

--- a/projection/src/main/scala/akka/projection/r2dbc/internal/R2dbcProjectionImpl.scala
+++ b/projection/src/main/scala/akka/projection/r2dbc/internal/R2dbcProjectionImpl.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2022 - 2023 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.projection.r2dbc.internal

--- a/projection/src/main/scala/akka/projection/r2dbc/javadsl/R2dbcHandler.scala
+++ b/projection/src/main/scala/akka/projection/r2dbc/javadsl/R2dbcHandler.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2022 - 2023 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.projection.r2dbc.javadsl

--- a/projection/src/main/scala/akka/projection/r2dbc/javadsl/R2dbcProjection.scala
+++ b/projection/src/main/scala/akka/projection/r2dbc/javadsl/R2dbcProjection.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2022 - 2023 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.projection.r2dbc.javadsl

--- a/projection/src/main/scala/akka/projection/r2dbc/javadsl/R2dbcReplication.scala
+++ b/projection/src/main/scala/akka/projection/r2dbc/javadsl/R2dbcReplication.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2022 - 2023 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.projection.r2dbc.javadsl

--- a/projection/src/main/scala/akka/projection/r2dbc/javadsl/R2dbcSession.scala
+++ b/projection/src/main/scala/akka/projection/r2dbc/javadsl/R2dbcSession.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2022 - 2023 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.projection.r2dbc.javadsl

--- a/projection/src/main/scala/akka/projection/r2dbc/scaladsl/R2dbcHandler.scala
+++ b/projection/src/main/scala/akka/projection/r2dbc/scaladsl/R2dbcHandler.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2022 - 2023 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.projection.r2dbc.scaladsl

--- a/projection/src/main/scala/akka/projection/r2dbc/scaladsl/R2dbcProjection.scala
+++ b/projection/src/main/scala/akka/projection/r2dbc/scaladsl/R2dbcProjection.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2022 - 2023 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.projection.r2dbc.scaladsl

--- a/projection/src/main/scala/akka/projection/r2dbc/scaladsl/R2dbcReplication.scala
+++ b/projection/src/main/scala/akka/projection/r2dbc/scaladsl/R2dbcReplication.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2022 - 2023 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.projection.r2dbc.scaladsl

--- a/projection/src/main/scala/akka/projection/r2dbc/scaladsl/R2dbcSession.scala
+++ b/projection/src/main/scala/akka/projection/r2dbc/scaladsl/R2dbcSession.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2022 - 2023 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.projection.r2dbc.scaladsl

--- a/projection/src/test/scala/akka/projection/TestStatusObserver.scala
+++ b/projection/src/test/scala/akka/projection/TestStatusObserver.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2022 - 2023 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.projection

--- a/projection/src/test/scala/akka/projection/r2dbc/DurableStateEndToEndSpec.scala
+++ b/projection/src/test/scala/akka/projection/r2dbc/DurableStateEndToEndSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2022 - 2023 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.projection.r2dbc

--- a/projection/src/test/scala/akka/projection/r2dbc/EventSourcedChaosSpec.scala
+++ b/projection/src/test/scala/akka/projection/r2dbc/EventSourcedChaosSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2022 - 2023 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.projection.r2dbc

--- a/projection/src/test/scala/akka/projection/r2dbc/EventSourcedEndToEndSpec.scala
+++ b/projection/src/test/scala/akka/projection/r2dbc/EventSourcedEndToEndSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2022 - 2023 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.projection.r2dbc

--- a/projection/src/test/scala/akka/projection/r2dbc/EventSourcedPubSubSpec.scala
+++ b/projection/src/test/scala/akka/projection/r2dbc/EventSourcedPubSubSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2022 - 2023 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.projection.r2dbc

--- a/projection/src/test/scala/akka/projection/r2dbc/R2dbcOffsetStoreSpec.scala
+++ b/projection/src/test/scala/akka/projection/r2dbc/R2dbcOffsetStoreSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2022 - 2023 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.projection.r2dbc

--- a/projection/src/test/scala/akka/projection/r2dbc/R2dbcOffsetStoreStateSpec.scala
+++ b/projection/src/test/scala/akka/projection/r2dbc/R2dbcOffsetStoreStateSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2022 - 2023 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.projection.r2dbc

--- a/projection/src/test/scala/akka/projection/r2dbc/R2dbcProjectionSpec.scala
+++ b/projection/src/test/scala/akka/projection/r2dbc/R2dbcProjectionSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2022 - 2023 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.projection.r2dbc

--- a/projection/src/test/scala/akka/projection/r2dbc/R2dbcTimestampOffsetProjectionSpec.scala
+++ b/projection/src/test/scala/akka/projection/r2dbc/R2dbcTimestampOffsetProjectionSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2022 - 2023 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.projection.r2dbc

--- a/projection/src/test/scala/akka/projection/r2dbc/R2dbcTimestampOffsetStoreSpec.scala
+++ b/projection/src/test/scala/akka/projection/r2dbc/R2dbcTimestampOffsetStoreSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2022 - 2023 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.projection.r2dbc

--- a/projection/src/test/scala/akka/projection/r2dbc/TestClock.scala
+++ b/projection/src/test/scala/akka/projection/r2dbc/TestClock.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2022 - 2023 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.projection.r2dbc

--- a/projection/src/test/scala/akka/projection/r2dbc/TestConfig.scala
+++ b/projection/src/test/scala/akka/projection/r2dbc/TestConfig.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2022 - 2023 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.projection.r2dbc

--- a/projection/src/test/scala/akka/projection/r2dbc/TestData.scala
+++ b/projection/src/test/scala/akka/projection/r2dbc/TestData.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2022 - 2023 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.projection.r2dbc

--- a/projection/src/test/scala/akka/projection/r2dbc/TestDbLifecycle.scala
+++ b/projection/src/test/scala/akka/projection/r2dbc/TestDbLifecycle.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2022 - 2023 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.projection.r2dbc

--- a/projection/src/test/scala/akka/projection/r2dbc/TestSourceProviderWithInput.scala
+++ b/projection/src/test/scala/akka/projection/r2dbc/TestSourceProviderWithInput.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2022 - 2023 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.projection.r2dbc


### PR DESCRIPTION
Does what it says on the tin.

Not sure if preference is `(C) 2022 - 2023` or `(C) 2023`.  Can redo and force push if guessed wrong.