### PR TITLE
feat: support client certificates in SSL connections

### DIFF
--- a/core/src/main/resources/reference.conf
+++ b/core/src/main/resources/reference.conf
@@ -207,8 +207,17 @@ akka.persistence.r2dbc {
       #  tunnel - use a SSL tunnel instead of following Postgres SSL handshake protocol
       mode = ""
 
-      # Can point to either a resource within the classpath or a file.
+      # Server root certificate. Can point to either a resource within the classpath or a file.
       root-cert = ""
+
+      # Client certificate. Can point to either a resource within the classpath or a file.
+      cert = ""
+
+      # Key for client certificate. Can point to either a resource within the classpath or a file.
+      key = ""
+
+      # Password for client key.
+      password = ""
     }
 
     # Initial pool size.

--- a/core/src/main/scala/akka/persistence/r2dbc/ConnectionFactoryProvider.scala
+++ b/core/src/main/scala/akka/persistence/r2dbc/ConnectionFactoryProvider.scala
@@ -90,6 +90,15 @@ class ConnectionFactoryProvider(system: ActorSystem[_]) extends Extension {
 
       if (settings.sslRootCert.nonEmpty)
         builder.option(PostgresqlConnectionFactoryProvider.SSL_ROOT_CERT, settings.sslRootCert)
+
+      if (settings.sslCert.nonEmpty)
+        builder.option(PostgresqlConnectionFactoryProvider.SSL_CERT, settings.sslCert)
+
+      if (settings.sslKey.nonEmpty)
+        builder.option(PostgresqlConnectionFactoryProvider.SSL_KEY, settings.sslKey)
+
+      if (settings.sslPassword.nonEmpty)
+        builder.option(PostgresqlConnectionFactoryProvider.SSL_PASSWORD, settings.sslPassword)
     }
 
     ConnectionFactories.get(builder.build())

--- a/core/src/main/scala/akka/persistence/r2dbc/R2dbcSettings.scala
+++ b/core/src/main/scala/akka/persistence/r2dbc/R2dbcSettings.scala
@@ -178,6 +178,9 @@ final class ConnectionFactorySettings(config: Config) {
   val sslEnabled: Boolean = config.getBoolean("ssl.enabled")
   val sslMode: String = config.getString("ssl.mode")
   val sslRootCert: String = config.getString("ssl.root-cert")
+  val sslCert: String = config.getString("ssl.cert")
+  val sslKey: String = config.getString("ssl.key")
+  val sslPassword: String = config.getString("ssl.password")
 
   val initialSize: Int = config.getInt("initial-size")
   val maxSize: Int = config.getInt("max-size")


### PR DESCRIPTION
Allow client certificates for SSL connections to be configured. Just passing more of the connection options.
