### PR TITLE
feat: Compaction events as starting point for eventsBySlices

### DIFF
--- a/core/src/main/scala/akka/persistence/r2dbc/internal/QueryDao.scala
+++ b/core/src/main/scala/akka/persistence/r2dbc/internal/QueryDao.scala
@@ -23,6 +23,12 @@ private[r2dbc] trait QueryDao extends BySliceQuery.Dao[SerializedJournalRow] {
    */
   override def countBucketsMayChange: Boolean = false
 
+  def compactionOffsets(
+      entityType: String,
+      minSlice: Int,
+      maxSlice: Int,
+      fromTimestamp: Instant): Future[Map[String, (Long, Instant)]]
+
   def timestampOfEvent(persistenceId: String, seqNr: Long): Future[Option[Instant]]
   def loadEvent(persistenceId: String, seqNr: Long): Future[Option[SerializedJournalRow]]
 

--- a/core/src/main/scala/akka/persistence/r2dbc/journal/R2dbcJournal.scala
+++ b/core/src/main/scala/akka/persistence/r2dbc/journal/R2dbcJournal.scala
@@ -134,6 +134,9 @@ private[r2dbc] final class R2dbcJournal(config: Config, cfgPath: String) extends
             SerializedEventMetadata(id, metaManifest, serializedMeta)
           }
 
+          // FIXME set the compaction column. One easy way to define that an event is an compaction event
+          // would be to use a special tag. We don't have to store that tag.
+
           SerializedJournalRow(
             slice,
             entityType,

--- a/core/src/main/scala/akka/persistence/r2dbc/state/scaladsl/R2dbcDurableStateStore.scala
+++ b/core/src/main/scala/akka/persistence/r2dbc/state/scaladsl/R2dbcDurableStateStore.scala
@@ -164,7 +164,7 @@ class R2dbcDurableStateStore[A](system: ExtendedActorSystem, config: Config, cfg
       minSlice: Int,
       maxSlice: Int,
       offset: Offset): Source[DurableStateChange[A], NotUsed] =
-    bySlice.liveBySlices("changesBySlices", entityType, minSlice, maxSlice, offset)
+    bySlice.liveBySlices("changesBySlices", entityType, minSlice, maxSlice, offset, Map.empty)
 
   /**
    * Note: If you have configured `custom-table` this query will look in both the default table and the custom tables.

--- a/ddl-scripts/create_tables_postgres.sql
+++ b/ddl-scripts/create_tables_postgres.sql
@@ -13,10 +13,19 @@ CREATE TABLE IF NOT EXISTS event_journal(
   writer VARCHAR(255) NOT NULL,
   adapter_manifest VARCHAR(255),
   tags TEXT ARRAY,
+  compaction BOOLEAN DEFAULT FALSE,
 
   meta_ser_id INTEGER,
   meta_ser_manifest VARCHAR(255),
   meta_payload BYTEA,
+
+  PRIMARY KEY(persistence_id, seq_nr)
+);
+
+CREATE TABLE IF NOT EXISTS events(
+  persistence_id VARCHAR(255) NOT NULL,
+  seq_nr BIGINT NOT NULL,
+  db_timestamp timestamp with time zone NOT NULL,
 
   PRIMARY KEY(persistence_id, seq_nr)
 );


### PR DESCRIPTION
Very early draft to explore the idea...

* When consumer is far behind or starting from zero it would be good to not have to replay all events but start from some kind of snapshot, here called compaction event.
* First it loads the highest seqNr of all compaction events.
* Then it's running the ordinary eventsBySlices with an adjusted start offset. Filtering out events for each persistenceId before the known compaction event seqNr.
* It would be an application concern to emit these specially tagged compaction events from the EventSourcedBehavior.
