### PR TITLE
feat: Snapshots as starting point for eventsBySlices

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -137,7 +137,7 @@ lazy val docs = project
     Preprocess / siteSubdirName := s"api/akka-persistence-r2dbc/${projectInfoVersion.value}",
     Preprocess / sourceDirectory := (LocalRootProject / ScalaUnidoc / unidoc / target).value,
     Paradox / siteSubdirName := s"docs/akka-persistence-r2dbc/${projectInfoVersion.value}",
-    paradoxGroups := Map("Language" -> Seq("Java", "Scala")),
+    paradoxGroups := Map("Language" -> Seq("Java", "Scala"), "Dialect" -> Seq("Postgres", "Yugabyte", "H2")),
     Compile / paradoxProperties ++= Map(
       "project.url" -> "https://doc.akka.io/docs/akka-persistence-r2dbc/current/",
       "canonical.base_url" -> "https://doc.akka.io/docs/akka-persistence-r2dbc/current",

--- a/core/src/main/mima-filters/1.2.0-M1.backwards.excludes/SerializedJournalRow.excludes
+++ b/core/src/main/mima-filters/1.2.0-M1.backwards.excludes/SerializedJournalRow.excludes
@@ -6,3 +6,4 @@ ProblemFilters.exclude[MissingClassProblem]("akka.persistence.r2dbc.internal.pos
 # internals
 ProblemFilters.exclude[Problem]("akka.persistence.r2dbc.internal.SnapshotDao#SerializedSnapshotRow*")
 ProblemFilters.exclude[MissingTypesProblem]("akka.persistence.r2dbc.internal.SnapshotDao$SerializedSnapshotRow$")
+ProblemFilters.exclude[ReversedMissingMethodProblem]("akka.persistence.r2dbc.internal.BySliceQuery#SerializedRow.isPayloadDefined")

--- a/core/src/main/mima-filters/1.2.0-M1.backwards.excludes/SerializedJournalRow.excludes
+++ b/core/src/main/mima-filters/1.2.0-M1.backwards.excludes/SerializedJournalRow.excludes
@@ -1,0 +1,8 @@
+# Unused internal class, leftover from refactoring
+ProblemFilters.exclude[IncompatibleSignatureProblem]("akka.persistence.r2dbc.internal.SnapshotDao#SerializedSnapshotRow.unapply")
+ProblemFilters.exclude[MissingClassProblem]("akka.persistence.r2dbc.internal.postgres.PostgresJournalDao$SerializedJournalRow")
+ProblemFilters.exclude[MissingClassProblem]("akka.persistence.r2dbc.internal.postgres.PostgresJournalDao$SerializedJournalRow$")
+
+# internals
+ProblemFilters.exclude[Problem]("akka.persistence.r2dbc.internal.SnapshotDao#SerializedSnapshotRow*")
+ProblemFilters.exclude[MissingTypesProblem]("akka.persistence.r2dbc.internal.SnapshotDao$SerializedSnapshotRow$")

--- a/core/src/main/resources/reference.conf
+++ b/core/src/main/resources/reference.conf
@@ -157,6 +157,15 @@ akka.persistence.r2dbc {
     # the backtracking queries.
     deduplicate-capacity = 0
 
+    # Settings for eventsBySlicesStartingFromSnapshots and currentEventsBySlicesStartingFromSnapshots
+    start-from-snapshot {
+      # Set this to on true if eventsBySlicesStartingFromSnapshots or
+      # currentEventsBySlicesStartingFromSnapshots are used. That has a small overhead when storing
+      # snapshots because the timestamp and tags of the corresponding event is retrieved when storing
+      # a snapshot.
+      # See also https://doc.akka.io/docs/akka-persistence-r2dbc/current/migration.html#eventsBySlicesStartingFromSnapshots
+      enabled = false
+    }
   }
 }
 // #query-settings

--- a/core/src/main/resources/reference.conf
+++ b/core/src/main/resources/reference.conf
@@ -163,7 +163,7 @@ akka.persistence.r2dbc {
       # currentEventsBySlicesStartingFromSnapshots are used. That has a small overhead when storing
       # snapshots because the timestamp and tags of the corresponding event is retrieved when storing
       # a snapshot.
-      # See also https://doc.akka.io/docs/akka-persistence-r2dbc/current/migration.html#eventsBySlicesStartingFromSnapshots
+      # See also https://doc.akka.io/docs/akka-persistence-r2dbc/current/migration-guide.html#eventsBySlicesStartingFromSnapshots
       enabled = false
     }
   }

--- a/core/src/main/scala/akka/persistence/r2dbc/R2dbcSettings.scala
+++ b/core/src/main/scala/akka/persistence/r2dbc/R2dbcSettings.scala
@@ -266,6 +266,7 @@ final class QuerySettings(config: Config) {
   val bufferSize: Int = config.getInt("buffer-size")
   val persistenceIdsBufferSize: Int = config.getInt("persistence-ids.buffer-size")
   val deduplicateCapacity: Int = config.getInt("deduplicate-capacity")
+  val startFromSnapshotEnabled: Boolean = config.getBoolean("start-from-snapshot.enabled")
 }
 
 /**

--- a/core/src/main/scala/akka/persistence/r2dbc/internal/DurableStateDao.scala
+++ b/core/src/main/scala/akka/persistence/r2dbc/internal/DurableStateDao.scala
@@ -30,6 +30,7 @@ import scala.concurrent.Future
       tags: Set[String])
       extends BySliceQuery.SerializedRow {
     override def seqNr: Long = revision
+    override def isPayloadDefined: Boolean = payload.isDefined
   }
 
 }

--- a/core/src/main/scala/akka/persistence/r2dbc/internal/JournalDao.scala
+++ b/core/src/main/scala/akka/persistence/r2dbc/internal/JournalDao.scala
@@ -30,7 +30,9 @@ private[r2dbc] object JournalDao {
       writerUuid: String,
       tags: Set[String],
       metadata: Option[SerializedEventMetadata])
-      extends BySliceQuery.SerializedRow
+      extends BySliceQuery.SerializedRow {
+    override def isPayloadDefined: Boolean = payload.isDefined
+  }
 
 }
 

--- a/core/src/main/scala/akka/persistence/r2dbc/internal/QueryDao.scala
+++ b/core/src/main/scala/akka/persistence/r2dbc/internal/QueryDao.scala
@@ -24,7 +24,7 @@ private[r2dbc] trait QueryDao extends BySliceQuery.Dao[SerializedJournalRow] {
   override def countBucketsMayChange: Boolean = false
 
   def timestampOfEvent(persistenceId: String, seqNr: Long): Future[Option[Instant]]
-  def loadEvent(persistenceId: String, seqNr: Long): Future[Option[SerializedJournalRow]]
+  def loadEvent(persistenceId: String, seqNr: Long, includePayload: Boolean): Future[Option[SerializedJournalRow]]
 
   def eventsByPersistenceId(
       persistenceId: String,

--- a/core/src/main/scala/akka/persistence/r2dbc/internal/SnapshotDao.scala
+++ b/core/src/main/scala/akka/persistence/r2dbc/internal/SnapshotDao.scala
@@ -31,6 +31,7 @@ private[r2dbc] object SnapshotDao {
       metadata: Option[SerializedSnapshotMetadata])
       extends BySliceQuery.SerializedRow {
     override def readDbTimestamp: Instant = dbTimestamp
+    def isPayloadDefined: Boolean = true
   }
 
   final case class SerializedSnapshotMetadata(payload: Array[Byte], serializerId: Int, serializerManifest: String)

--- a/core/src/main/scala/akka/persistence/r2dbc/internal/SnapshotDao.scala
+++ b/core/src/main/scala/akka/persistence/r2dbc/internal/SnapshotDao.scala
@@ -27,6 +27,7 @@ private[r2dbc] object SnapshotDao {
       snapshot: Array[Byte],
       serializerId: Int,
       serializerManifest: String,
+      tags: Set[String],
       metadata: Option[SerializedSnapshotMetadata])
       extends BySliceQuery.SerializedRow {
     override def readDbTimestamp: Instant = dbTimestamp

--- a/core/src/main/scala/akka/persistence/r2dbc/internal/SnapshotDao.scala
+++ b/core/src/main/scala/akka/persistence/r2dbc/internal/SnapshotDao.scala
@@ -4,24 +4,33 @@
 
 package akka.persistence.r2dbc.internal
 
-import akka.annotation.InternalApi
-import akka.persistence.SnapshotSelectionCriteria
+import java.time.Instant
 
 import scala.concurrent.Future
+
+import akka.annotation.InternalApi
+import akka.persistence.SnapshotSelectionCriteria
 
 /**
  * INTERNAL API
  */
 private[r2dbc] object SnapshotDao {
+  val EmptyDbTimestamp: Instant = Instant.EPOCH
 
   final case class SerializedSnapshotRow(
+      slice: Int,
+      entityType: String,
       persistenceId: String,
       seqNr: Long,
+      dbTimestamp: Instant,
       writeTimestamp: Long,
       snapshot: Array[Byte],
       serializerId: Int,
       serializerManifest: String,
       metadata: Option[SerializedSnapshotMetadata])
+      extends BySliceQuery.SerializedRow {
+    override def readDbTimestamp: Instant = dbTimestamp
+  }
 
   final case class SerializedSnapshotMetadata(payload: Array[Byte], serializerId: Int, serializerManifest: String)
 
@@ -31,7 +40,7 @@ private[r2dbc] object SnapshotDao {
  * INTERNAL API
  */
 @InternalApi
-private[r2dbc] trait SnapshotDao {
+private[r2dbc] trait SnapshotDao extends BySliceQuery.Dao[SnapshotDao.SerializedSnapshotRow] {
   import SnapshotDao._
 
   def load(persistenceId: String, criteria: SnapshotSelectionCriteria): Future[Option[SerializedSnapshotRow]]

--- a/core/src/main/scala/akka/persistence/r2dbc/internal/StartingFromSnapshotStage.scala
+++ b/core/src/main/scala/akka/persistence/r2dbc/internal/StartingFromSnapshotStage.scala
@@ -2,7 +2,7 @@
  * Copyright (C) 2022 - 2023 Lightbend Inc. <https://www.lightbend.com>
  */
 
-package akka.persistence.r2dbc.query.internal
+package akka.persistence.r2dbc.internal
 
 import java.time.Instant
 

--- a/core/src/main/scala/akka/persistence/r2dbc/internal/h2/H2Dialect.scala
+++ b/core/src/main/scala/akka/persistence/r2dbc/internal/h2/H2Dialect.scala
@@ -115,10 +115,11 @@ private[r2dbc] object H2Dialect extends Dialect {
 
     val sliceIndexes = if (createSliceIndexes) {
       val sliceIndexWithSchema = journalTableWithSchema + "_slice_idx"
+      val snapshotSliceIndexWithSchema = snapshotTableWithSchema + "_slice_idx"
       val durableStateSliceIndexWithSchema = durableStateTableWithSchema + "_slice_idx"
       Seq(
-        sql"""
-             CREATE INDEX IF NOT EXISTS $sliceIndexWithSchema ON $journalTableWithSchema(slice, entity_type, db_timestamp, seq_nr)""",
+        sql"""CREATE INDEX IF NOT EXISTS $sliceIndexWithSchema ON $journalTableWithSchema(slice, entity_type, db_timestamp, seq_nr)""",
+        sql"""CREATE INDEX IF NOT EXISTS $snapshotSliceIndexWithSchema ON $snapshotTableWithSchema(slice, entity_type, db_timestamp)""",
         sql"""CREATE INDEX IF NOT EXISTS $durableStateSliceIndexWithSchema ON durable_state(slice, entity_type, db_timestamp, revision)""")
     } else Seq.empty[String]
 
@@ -151,6 +152,7 @@ private[r2dbc] object H2Dialect extends Dialect {
           entity_type VARCHAR(255) NOT NULL,
           persistence_id VARCHAR(255) NOT NULL,
           seq_nr BIGINT NOT NULL,
+          db_timestamp timestamp with time zone,
           write_timestamp BIGINT NOT NULL,
           ser_id INTEGER NOT NULL,
           ser_manifest VARCHAR(255) NOT NULL,

--- a/core/src/main/scala/akka/persistence/r2dbc/internal/h2/H2Dialect.scala
+++ b/core/src/main/scala/akka/persistence/r2dbc/internal/h2/H2Dialect.scala
@@ -157,6 +157,7 @@ private[r2dbc] object H2Dialect extends Dialect {
           ser_id INTEGER NOT NULL,
           ser_manifest VARCHAR(255) NOT NULL,
           snapshot BYTEA NOT NULL,
+          tags TEXT ARRAY,
           meta_ser_id INTEGER,
           meta_ser_manifest VARCHAR(255),
           meta_payload BYTEA,

--- a/core/src/main/scala/akka/persistence/r2dbc/internal/h2/H2SnapshotDao.scala
+++ b/core/src/main/scala/akka/persistence/r2dbc/internal/h2/H2SnapshotDao.scala
@@ -28,9 +28,9 @@ private[r2dbc] final class H2SnapshotDao(settings: R2dbcSettings, connectionFact
 
   override protected def createUpsertSql: String = sql"""
     MERGE INTO $snapshotTable
-    (slice, entity_type, persistence_id, seq_nr, write_timestamp, snapshot, ser_id, ser_manifest, meta_payload, meta_ser_id, meta_ser_manifest)
+    (slice, entity_type, persistence_id, seq_nr, db_timestamp, write_timestamp, snapshot, ser_id, ser_manifest, meta_payload, meta_ser_id, meta_ser_manifest)
     KEY (persistence_id)
-    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
   """
 
 }

--- a/core/src/main/scala/akka/persistence/r2dbc/internal/h2/H2SnapshotDao.scala
+++ b/core/src/main/scala/akka/persistence/r2dbc/internal/h2/H2SnapshotDao.scala
@@ -12,8 +12,9 @@ import akka.persistence.r2dbc.internal.postgres.PostgresSnapshotDao
 import io.r2dbc.spi.ConnectionFactory
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
-
 import scala.concurrent.ExecutionContext
+
+import io.r2dbc.spi.Row
 
 /**
  * INTERNAL API
@@ -28,9 +29,12 @@ private[r2dbc] final class H2SnapshotDao(settings: R2dbcSettings, connectionFact
 
   override protected def createUpsertSql: String = sql"""
     MERGE INTO $snapshotTable
-    (slice, entity_type, persistence_id, seq_nr, db_timestamp, write_timestamp, snapshot, ser_id, ser_manifest, meta_payload, meta_ser_id, meta_ser_manifest)
+    (slice, entity_type, persistence_id, seq_nr, db_timestamp, write_timestamp, snapshot, ser_id, ser_manifest, tags, meta_payload, meta_ser_id, meta_ser_manifest)
     KEY (persistence_id)
-    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
   """
+
+  override protected def tagsFromDb(row: Row, columnName: String): Set[String] =
+    H2Utils.tagsFromDb(row, columnName)
 
 }

--- a/core/src/main/scala/akka/persistence/r2dbc/internal/postgres/PostgresJournalDao.scala
+++ b/core/src/main/scala/akka/persistence/r2dbc/internal/postgres/PostgresJournalDao.scala
@@ -35,22 +35,6 @@ import scala.concurrent.Future
 @InternalApi
 private[r2dbc] object PostgresJournalDao {
   private val log: Logger = LoggerFactory.getLogger(classOf[PostgresJournalDao])
-  val EmptyDbTimestamp: Instant = Instant.EPOCH
-
-  final case class SerializedJournalRow(
-      slice: Int,
-      entityType: String,
-      persistenceId: String,
-      seqNr: Long,
-      dbTimestamp: Instant,
-      readDbTimestamp: Instant,
-      payload: Option[Array[Byte]],
-      serId: Int,
-      serManifest: String,
-      writerUuid: String,
-      tags: Set[String],
-      metadata: Option[SerializedEventMetadata])
-      extends BySliceQuery.SerializedRow
 
   def readMetadata(row: Row): Option[SerializedEventMetadata] = {
     row.get("meta_payload", classOf[Array[Byte]]) match {

--- a/core/src/main/scala/akka/persistence/r2dbc/internal/postgres/PostgresQueryDao.scala
+++ b/core/src/main/scala/akka/persistence/r2dbc/internal/postgres/PostgresQueryDao.scala
@@ -154,7 +154,7 @@ private[r2dbc] class PostgresQueryDao(settings: R2dbcSettings, connectionFactory
   protected def tagsFromDb(row: Row, columnName: String): Set[String] =
     setFromDb(row.get("tags", classOf[Array[String]]))
 
-  def rowsBySlices(
+  override def rowsBySlices(
       entityType: String,
       minSlice: Int,
       maxSlice: Int,
@@ -262,7 +262,7 @@ private[r2dbc] class PostgresQueryDao(settings: R2dbcSettings, connectionFactory
    */
   override def countBucketsMayChange: Boolean = false
 
-  def timestampOfEvent(persistenceId: String, seqNr: Long): Future[Option[Instant]] = {
+  override def timestampOfEvent(persistenceId: String, seqNr: Long): Future[Option[Instant]] = {
     r2dbcExecutor.selectOne("select timestampOfEvent")(
       connection =>
         connection
@@ -272,7 +272,7 @@ private[r2dbc] class PostgresQueryDao(settings: R2dbcSettings, connectionFactory
       row => row.get("db_timestamp", classOf[Instant]))
   }
 
-  def loadEvent(persistenceId: String, seqNr: Long): Future[Option[SerializedJournalRow]] =
+  override def loadEvent(persistenceId: String, seqNr: Long): Future[Option[SerializedJournalRow]] =
     r2dbcExecutor.selectOne("select one event")(
       connection =>
         connection
@@ -294,7 +294,7 @@ private[r2dbc] class PostgresQueryDao(settings: R2dbcSettings, connectionFactory
           tags = tagsFromDb(row, "tags"),
           metadata = readMetadata(row)))
 
-  def eventsByPersistenceId(
+  override def eventsByPersistenceId(
       persistenceId: String,
       fromSequenceNr: Long,
       toSequenceNr: Long): Source[SerializedJournalRow, NotUsed] = {
@@ -328,7 +328,7 @@ private[r2dbc] class PostgresQueryDao(settings: R2dbcSettings, connectionFactory
     Source.futureSource(result.map(Source(_))).mapMaterializedValue(_ => NotUsed)
   }
 
-  def persistenceIds(entityType: String, afterId: Option[String], limit: Long): Source[String, NotUsed] = {
+  override def persistenceIds(entityType: String, afterId: Option[String], limit: Long): Source[String, NotUsed] = {
     val likeStmtPostfix = PersistenceId.DefaultSeparator + "%"
     val result = r2dbcExecutor.select(s"select persistenceIds by entity type")(
       connection =>
@@ -353,7 +353,7 @@ private[r2dbc] class PostgresQueryDao(settings: R2dbcSettings, connectionFactory
     Source.futureSource(result.map(Source(_))).mapMaterializedValue(_ => NotUsed)
   }
 
-  def persistenceIds(afterId: Option[String], limit: Long): Source[String, NotUsed] = {
+  override def persistenceIds(afterId: Option[String], limit: Long): Source[String, NotUsed] = {
     val result = r2dbcExecutor.select(s"select persistenceIds")(
       connection =>
         afterId match {

--- a/core/src/main/scala/akka/persistence/r2dbc/internal/postgres/PostgresSnapshotDao.scala
+++ b/core/src/main/scala/akka/persistence/r2dbc/internal/postgres/PostgresSnapshotDao.scala
@@ -4,26 +4,33 @@
 
 package akka.persistence.r2dbc.internal.postgres
 
+import java.time.Instant
+
+import scala.concurrent.ExecutionContext
+import scala.concurrent.Future
+import scala.concurrent.duration.FiniteDuration
+
+import akka.NotUsed
 import akka.actor.typed.ActorSystem
+import akka.actor.typed.scaladsl.LoggerOps
 import akka.annotation.InternalApi
 import akka.dispatch.ExecutionContexts
-import akka.persistence.Persistence
 import akka.persistence.SnapshotSelectionCriteria
 import akka.persistence.r2dbc.R2dbcSettings
+import akka.persistence.r2dbc.internal.BySliceQuery.Buckets
+import akka.persistence.r2dbc.internal.BySliceQuery.Buckets.Bucket
+import akka.persistence.r2dbc.internal.InstantFactory
 import akka.persistence.r2dbc.internal.PayloadCodec
 import akka.persistence.r2dbc.internal.PayloadCodec.RichRow
 import akka.persistence.r2dbc.internal.PayloadCodec.RichStatement
 import akka.persistence.r2dbc.internal.R2dbcExecutor
 import akka.persistence.r2dbc.internal.SnapshotDao
 import akka.persistence.r2dbc.internal.Sql.Interpolation
-import akka.persistence.typed.PersistenceId
+import akka.stream.scaladsl.Source
 import io.r2dbc.spi.ConnectionFactory
 import io.r2dbc.spi.Row
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
-
-import scala.concurrent.ExecutionContext
-import scala.concurrent.Future
 
 /**
  * INTERNAL API
@@ -46,17 +53,18 @@ private[r2dbc] class PostgresSnapshotDao(settings: R2dbcSettings, connectionFact
 
   protected val snapshotTable = settings.snapshotsTableWithSchema
   private implicit val snapshotPayloadCodec: PayloadCodec = settings.snapshotPayloadCodec
-  private val persistenceExt = Persistence(system)
   private val r2dbcExecutor = new R2dbcExecutor(connectionFactory, log, settings.logDbCallsExceeding)(ec, system)
+  private val queryDao = settings.connectionFactorySettings.dialect.createQueryDao(settings, connectionFactory)
 
   protected def createUpsertSql: String =
     sql"""
       INSERT INTO $snapshotTable
-      (slice, entity_type, persistence_id, seq_nr, write_timestamp, snapshot, ser_id, ser_manifest, meta_payload, meta_ser_id, meta_ser_manifest)
-      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+      (slice, entity_type, persistence_id, seq_nr, db_timestamp, write_timestamp, snapshot, ser_id, ser_manifest, meta_payload, meta_ser_id, meta_ser_manifest)
+      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
       ON CONFLICT (persistence_id)
       DO UPDATE SET
         seq_nr = excluded.seq_nr,
+        db_timestamp = excluded.db_timestamp,
         write_timestamp = excluded.write_timestamp,
         snapshot = excluded.snapshot,
         ser_id = excluded.ser_id,
@@ -85,7 +93,7 @@ private[r2dbc] class PostgresSnapshotDao(settings: R2dbcSettings, connectionFact
       else ""
 
     sql"""
-      SELECT persistence_id, seq_nr, write_timestamp, snapshot, ser_id, ser_manifest, meta_payload, meta_ser_id, meta_ser_manifest
+      SELECT slice, entity_type, persistence_id, seq_nr, db_timestamp, write_timestamp, snapshot, ser_id, ser_manifest, meta_payload, meta_ser_id, meta_ser_manifest
       FROM $snapshotTable
       WHERE persistence_id = ?
       $maxSeqNrCondition $minSeqNrCondition $maxTimestampCondition $minTimestampCondition
@@ -115,10 +123,41 @@ private[r2dbc] class PostgresSnapshotDao(settings: R2dbcSettings, connectionFact
       $maxSeqNrCondition $minSeqNrCondition $maxTimestampCondition $minTimestampCondition"""
   }
 
+  private val currentDbTimestampSql =
+    sql"SELECT CURRENT_TIMESTAMP AS db_timestamp"
+
+  protected def snapshotsBySlicesRangeSql(minSlice: Int, maxSlice: Int): String = {
+
+    sql"""
+      SELECT slice, entity_type, persistence_id, seq_nr, db_timestamp, write_timestamp, snapshot, ser_id, ser_manifest, meta_payload, meta_ser_id, meta_ser_manifest
+      FROM $snapshotTable
+      WHERE entity_type = ?
+      AND ${sliceCondition(minSlice, maxSlice)}
+      ORDER BY db_timestamp, seq_nr
+      LIMIT ?"""
+  }
+
+  private def selectBucketsSql(entityType: String, minSlice: Int, maxSlice: Int): String = {
+    sql"""
+     SELECT extract(EPOCH from db_timestamp)::BIGINT / 10 AS bucket, count(*) AS count
+     FROM $snapshotTable
+     WHERE entity_type = ?
+     AND ${sliceCondition(minSlice, maxSlice)}
+     AND db_timestamp >= ? AND db_timestamp <= ?
+     GROUP BY bucket ORDER BY bucket LIMIT ?
+     """
+  }
+
+  protected def sliceCondition(minSlice: Int, maxSlice: Int): String =
+    s"slice in (${(minSlice to maxSlice).mkString(",")})"
+
   private def collectSerializedSnapshot(row: Row): SerializedSnapshotRow =
     SerializedSnapshotRow(
+      row.get[Integer]("slice", classOf[Integer]),
+      row.get("entity_type", classOf[String]),
       row.get("persistence_id", classOf[String]),
       row.get[java.lang.Long]("seq_nr", classOf[java.lang.Long]),
+      row.get("db_timestamp", classOf[Instant]),
       row.get[java.lang.Long]("write_timestamp", classOf[java.lang.Long]),
       row.getPayload("snapshot"),
       row.get[Integer]("ser_id", classOf[Integer]),
@@ -168,40 +207,42 @@ private[r2dbc] class PostgresSnapshotDao(settings: R2dbcSettings, connectionFact
   }
 
   def store(serializedRow: SerializedSnapshotRow): Future[Unit] = {
-    val entityType = PersistenceId.extractEntityType(serializedRow.persistenceId)
-    val slice = persistenceExt.sliceForPersistenceId(serializedRow.persistenceId)
+    queryDao.timestampOfEvent(serializedRow.persistenceId, serializedRow.seqNr).flatMap { eventTimestamp =>
+      val timestamp = eventTimestamp.getOrElse(Instant.ofEpochMilli(serializedRow.writeTimestamp))
 
-    r2dbcExecutor
-      .updateOne(s"upsert snapshot [${serializedRow.persistenceId}], sequence number [${serializedRow.seqNr}]") {
-        connection =>
-          val statement =
-            connection
-              .createStatement(upsertSql)
-              .bind(0, slice)
-              .bind(1, entityType)
-              .bind(2, serializedRow.persistenceId)
-              .bind(3, serializedRow.seqNr)
-              .bind(4, serializedRow.writeTimestamp)
-              .bindPayload(5, serializedRow.snapshot)
-              .bind(6, serializedRow.serializerId)
-              .bind(7, serializedRow.serializerManifest)
+      r2dbcExecutor
+        .updateOne(s"upsert snapshot [${serializedRow.persistenceId}], sequence number [${serializedRow.seqNr}]") {
+          connection =>
+            val statement =
+              connection
+                .createStatement(upsertSql)
+                .bind(0, serializedRow.slice)
+                .bind(1, serializedRow.entityType)
+                .bind(2, serializedRow.persistenceId)
+                .bind(3, serializedRow.seqNr)
+                .bind(4, timestamp)
+                .bind(5, serializedRow.writeTimestamp)
+                .bindPayload(6, serializedRow.snapshot)
+                .bind(7, serializedRow.serializerId)
+                .bind(8, serializedRow.serializerManifest)
 
-          serializedRow.metadata match {
-            case Some(SerializedSnapshotMetadata(serializedMeta, serializerId, serializerManifest)) =>
-              statement
-                .bind(8, serializedMeta)
-                .bind(9, serializerId)
-                .bind(10, serializerManifest)
-            case None =>
-              statement
-                .bindNull(8, classOf[Array[Byte]])
-                .bindNull(9, classOf[Integer])
-                .bindNull(10, classOf[String])
-          }
+            serializedRow.metadata match {
+              case Some(SerializedSnapshotMetadata(serializedMeta, serializerId, serializerManifest)) =>
+                statement
+                  .bind(9, serializedMeta)
+                  .bind(10, serializerId)
+                  .bind(11, serializerManifest)
+              case None =>
+                statement
+                  .bindNull(9, classOf[Array[Byte]])
+                  .bindNull(10, classOf[Integer])
+                  .bindNull(11, classOf[String])
+            }
 
-          statement
-      }
-      .map(_ => ())(ExecutionContexts.parasitic)
+            statement
+        }
+        .map(_ => ())(ExecutionContexts.parasitic)
+    }
   }
 
   def delete(persistenceId: String, criteria: SnapshotSelectionCriteria): Future[Unit] = {
@@ -230,5 +271,85 @@ private[r2dbc] class PostgresSnapshotDao(settings: R2dbcSettings, connectionFact
       statement
     }
   }.map(_ => ())(ExecutionContexts.parasitic)
+
+  override def currentDbTimestamp(): Future[Instant] = {
+    r2dbcExecutor
+      .selectOne("select current db timestamp")(
+        connection => connection.createStatement(currentDbTimestampSql),
+        row => row.get("db_timestamp", classOf[Instant]))
+      .map {
+        case Some(time) => time
+        case None       => throw new IllegalStateException(s"Expected one row for: $currentDbTimestampSql")
+      }
+  }
+
+  override def rowsBySlices(
+      entityType: String,
+      minSlice: Int,
+      maxSlice: Int,
+      fromTimestamp: Instant,
+      toTimestamp: Option[Instant],
+      behindCurrentTime: FiniteDuration,
+      backtracking: Boolean): Source[SerializedSnapshotRow, NotUsed] = {
+    val result = r2dbcExecutor.select(s"select snapshotsBySlices [$minSlice - $maxSlice]")(
+      connection => {
+        val stmt = connection
+          .createStatement(snapshotsBySlicesRangeSql(minSlice, maxSlice))
+          .bind(0, entityType)
+          .bind(1, fromTimestamp)
+          .bind(2, settings.querySettings.bufferSize)
+        stmt
+      },
+      collectSerializedSnapshot)
+
+    if (log.isDebugEnabled)
+      result.foreach(rows => log.debugN("Read [{}] snapshots from slices [{} - {}]", rows.size, minSlice, maxSlice))
+
+    Source.futureSource(result.map(Source(_))).mapMaterializedValue(_ => NotUsed)
+  }
+
+  /**
+   * Counts for a bucket may become inaccurate when existing snapshots are updated since the timestamp is changed.
+   */
+  override def countBucketsMayChange: Boolean = true
+
+  override def countBuckets(
+      entityType: String,
+      minSlice: Int,
+      maxSlice: Int,
+      fromTimestamp: Instant,
+      limit: Int): Future[Seq[Bucket]] = {
+
+    val toTimestamp = {
+      val now = InstantFactory.now() // not important to use database time
+      if (fromTimestamp == Instant.EPOCH)
+        now
+      else {
+        // max buckets, just to have some upper bound
+        val t = fromTimestamp.plusSeconds(Buckets.BucketDurationSeconds * limit + Buckets.BucketDurationSeconds)
+        if (t.isAfter(now)) now else t
+      }
+    }
+
+    val result = r2dbcExecutor.select(s"select bucket counts [$minSlice - $maxSlice]")(
+      connection =>
+        connection
+          .createStatement(selectBucketsSql(entityType, minSlice, maxSlice))
+          .bind(0, entityType)
+          .bind(1, fromTimestamp)
+          .bind(2, toTimestamp)
+          .bind(3, limit),
+      row => {
+        val bucketStartEpochSeconds = row.get("bucket", classOf[java.lang.Long]).toLong * 10
+        val count = row.get[java.lang.Long]("count", classOf[java.lang.Long]).toLong
+        Bucket(bucketStartEpochSeconds, count)
+      })
+
+    if (log.isDebugEnabled)
+      result.foreach(rows => log.debugN("Read [{}] bucket counts from slices [{} - {}]", rows.size, minSlice, maxSlice))
+
+    result
+
+  }
 
 }

--- a/core/src/main/scala/akka/persistence/r2dbc/internal/postgres/PostgresSnapshotDao.scala
+++ b/core/src/main/scala/akka/persistence/r2dbc/internal/postgres/PostgresSnapshotDao.scala
@@ -134,6 +134,7 @@ private[r2dbc] class PostgresSnapshotDao(settings: R2dbcSettings, connectionFact
       FROM $snapshotTable
       WHERE entity_type = ?
       AND ${sliceCondition(minSlice, maxSlice)}
+      AND db_timestamp >= ?
       ORDER BY db_timestamp, seq_nr
       LIMIT ?"""
   }

--- a/core/src/main/scala/akka/persistence/r2dbc/internal/postgres/YugabyteDialect.scala
+++ b/core/src/main/scala/akka/persistence/r2dbc/internal/postgres/YugabyteDialect.scala
@@ -34,7 +34,7 @@ private[r2dbc] object YugabyteDialect extends Dialect {
 
   override def createSnapshotDao(settings: R2dbcSettings, connectionFactory: ConnectionFactory)(implicit
       system: ActorSystem[_]): SnapshotDao =
-    new PostgresSnapshotDao(settings, connectionFactory)(system.executionContext, system)
+    new YugabyteSnapshotDao(settings, connectionFactory)(system.executionContext, system)
 
   override def createQueryDao(settings: R2dbcSettings, connectionFactory: ConnectionFactory)(implicit
       system: ActorSystem[_]): QueryDao =

--- a/core/src/main/scala/akka/persistence/r2dbc/internal/postgres/YugabyteSnapshotDao.scala
+++ b/core/src/main/scala/akka/persistence/r2dbc/internal/postgres/YugabyteSnapshotDao.scala
@@ -1,0 +1,31 @@
+/*
+ * Copyright (C) 2022 - 2023 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.persistence.r2dbc.internal.postgres
+
+import scala.concurrent.ExecutionContext
+
+import akka.actor.typed.ActorSystem
+import akka.annotation.InternalApi
+import akka.persistence.r2dbc.R2dbcSettings
+import io.r2dbc.spi.ConnectionFactory
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
+
+/**
+ * INTERNAL API
+ */
+@InternalApi
+private[r2dbc] final class YugabyteSnapshotDao(settings: R2dbcSettings, connectionFactory: ConnectionFactory)(implicit
+    ec: ExecutionContext,
+    system: ActorSystem[_])
+    extends PostgresSnapshotDao(settings, connectionFactory) {
+
+  override protected lazy val log: Logger = LoggerFactory.getLogger(classOf[YugabyteSnapshotDao])
+
+  override protected def sliceCondition(minSlice: Int, maxSlice: Int): String = {
+    s"slice BETWEEN $minSlice AND $maxSlice"
+  }
+
+}

--- a/core/src/main/scala/akka/persistence/r2dbc/query/internal/StartingFromSnapshotStage.scala
+++ b/core/src/main/scala/akka/persistence/r2dbc/query/internal/StartingFromSnapshotStage.scala
@@ -7,6 +7,7 @@ package akka.persistence.r2dbc.query.internal
 import java.time.Instant
 
 import akka.NotUsed
+import akka.annotation.InternalApi
 import akka.persistence.query.TimestampOffset.toTimestampOffset
 import akka.persistence.query.typed.EventEnvelope
 import akka.stream.Attributes
@@ -19,7 +20,10 @@ import akka.stream.stage.GraphStageLogic
 import akka.stream.stage.InHandler
 import akka.stream.stage.OutHandler
 
-class StartingFromSnapshotStage[Event](
+/**
+ * INTERNAL API
+ */
+@InternalApi private[r2dbc] class StartingFromSnapshotStage[Event](
     snapshotSource: Source[EventEnvelope[Event], NotUsed],
     primarySource: Map[String, (Long, Instant)] => Source[EventEnvelope[Event], NotUsed])
     extends GraphStage[SourceShape[EventEnvelope[Event]]] {

--- a/core/src/main/scala/akka/persistence/r2dbc/query/internal/StartingFromSnapshotStage.scala
+++ b/core/src/main/scala/akka/persistence/r2dbc/query/internal/StartingFromSnapshotStage.scala
@@ -1,0 +1,100 @@
+/*
+ * Copyright (C) 2022 - 2023 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.persistence.r2dbc.query.internal
+
+import java.time.Instant
+
+import akka.NotUsed
+import akka.persistence.query.TimestampOffset.toTimestampOffset
+import akka.persistence.query.typed.EventEnvelope
+import akka.stream.Attributes
+import akka.stream.Outlet
+import akka.stream.SourceShape
+import akka.stream.scaladsl.Keep
+import akka.stream.scaladsl.Source
+import akka.stream.stage.GraphStage
+import akka.stream.stage.GraphStageLogic
+import akka.stream.stage.InHandler
+import akka.stream.stage.OutHandler
+
+class StartingFromSnapshotStage[Event](
+    snapshotSource: Source[EventEnvelope[Event], NotUsed],
+    primarySource: Map[String, (Long, Instant)] => Source[EventEnvelope[Event], NotUsed])
+    extends GraphStage[SourceShape[EventEnvelope[Event]]] {
+
+  val out: Outlet[EventEnvelope[Event]] = Outlet("out")
+
+  override val shape: SourceShape[EventEnvelope[Event]] = SourceShape(out)
+
+  override def createLogic(inheritedAttributes: Attributes): GraphStageLogic =
+    new GraphStageLogic(shape) { self =>
+      setHandler(
+        out,
+        new OutHandler {
+          override def onPull(): Unit = {
+            val snapshotHandler = new SnapshotHandler
+            setHandler(out, snapshotHandler)
+
+            subFusingMaterializer.materialize(
+              snapshotSource.toMat(snapshotHandler.subSink.sink)(Keep.left),
+              inheritedAttributes)
+          }
+        })
+
+      class SnapshotHandler extends OutHandler with InHandler {
+        private var snapshotOffsets = Map.empty[String, (Long, Instant)]
+
+        val subSink = new SubSinkInlet[EventEnvelope[Event]]("snapshots")
+        subSink.pull()
+        subSink.setHandler(this)
+
+        override def onPull(): Unit = {
+          subSink.pull()
+        }
+
+        override def onPush(): Unit = {
+          val env = subSink.grab()
+          snapshotOffsets =
+            snapshotOffsets.updated(env.persistenceId, env.sequenceNr -> toTimestampOffset(env.offset).timestamp)
+          push(out, env)
+        }
+
+        override def onUpstreamFinish(): Unit = {
+          val primaryHandler = new PrimaryHandler
+          self.setHandler(out, primaryHandler)
+
+          subFusingMaterializer.materialize(
+            primarySource(snapshotOffsets).toMat(primaryHandler.subSink.sink)(Keep.left),
+            inheritedAttributes)
+        }
+
+        override def onDownstreamFinish(cause: Throwable): Unit = {
+          subSink.cancel(cause)
+          completeStage()
+        }
+      }
+
+      class PrimaryHandler extends OutHandler with InHandler {
+        val subSink = new SubSinkInlet[EventEnvelope[Event]]("snapshots")
+        subSink.pull()
+        subSink.setHandler(this)
+
+        override def onPull(): Unit = {
+          subSink.pull()
+        }
+
+        override def onPush(): Unit = {
+          push(out, subSink.grab())
+        }
+
+        override def onDownstreamFinish(cause: Throwable): Unit = {
+          subSink.cancel(cause)
+          completeStage()
+        }
+      }
+
+    }
+
+}

--- a/core/src/main/scala/akka/persistence/r2dbc/query/javadsl/R2dbcReadJournal.scala
+++ b/core/src/main/scala/akka/persistence/r2dbc/query/javadsl/R2dbcReadJournal.scala
@@ -55,12 +55,86 @@ final class R2dbcReadJournal(delegate: scaladsl.R2dbcReadJournal)
       offset: Offset): Source[EventEnvelope[Event], NotUsed] =
     delegate.currentEventsBySlices(entityType, minSlice, maxSlice, offset).asJava
 
+  /**
+   * Query events for given slices. A slice is deterministically defined based on the persistence id. The purpose is to
+   * evenly distribute all persistence ids over the slices.
+   *
+   * The consumer can keep track of its current position in the event stream by storing the `offset` and restart the
+   * query from a given `offset` after a crash/restart.
+   *
+   * The supported offset is [[akka.persistence.query.TimestampOffset]] and [[Offset.noOffset]].
+   *
+   * The timestamp is based on the database `CURRENT_TIMESTAMP` when the event was stored. `CURRENT_TIMESTAMP` is the
+   * time when the transaction started, not when it was committed. This means that a "later" event may be visible first
+   * and when retrieving events after the previously seen timestamp we may miss some events. In distributed SQL
+   * databases there can also be clock skews for the database timestamps. For that reason it will perform additional
+   * backtracking queries to catch missed events. Events from backtracking will typically be duplicates of previously
+   * emitted events. It's the responsibility of the consumer to filter duplicates and make sure that events are
+   * processed in exact sequence number order for each persistence id. Such deduplication is provided by the R2DBC
+   * Projection.
+   *
+   * Events emitted by the backtracking don't contain the event payload (`EventBySliceEnvelope.event` is None) and the
+   * consumer can load the full `EventBySliceEnvelope` with [[R2dbcReadJournal.loadEnvelope]].
+   *
+   * The events will be emitted in the timestamp order with the caveat of duplicate events as described above. Events
+   * with the same timestamp are ordered by sequence number.
+   *
+   * The stream is not completed when it reaches the end of the currently stored events, but it continues to push new
+   * events when new events are persisted. Corresponding query that is completed when it reaches the end of the
+   * currently stored events is provided by [[R2dbcReadJournal.currentEventsBySlices]].
+   */
   override def eventsBySlices[Event](
       entityType: String,
       minSlice: Int,
       maxSlice: Int,
       offset: Offset): Source[EventEnvelope[Event], NotUsed] =
     delegate.eventsBySlices(entityType, minSlice, maxSlice, offset).asJava
+
+  /**
+   * Same as `currentEventsBySlices` but with the purpose to use snapshots as starting points and thereby reducing
+   * number of events that have to be loaded. This can be useful if the consumer start from zero without any previously
+   * processed offset or if it has been disconnected for a long while and its offset is far behind.
+   *
+   * First it loads all snapshots with timestamps greater than or equal to the offset timestamp. There is at most one
+   * snapshot per persistenceId. The snapshots are transformed to events with the given `transformSnapshot` function.
+   *
+   * After emitting the snapshot events the ordinary events with sequence numbers after the snapshots are emitted.
+   *
+   * To use `currentEventsBySlicesStartingFromSnapshots` you must enable configuration
+   * `akka.persistence.r2dbc.query.start-from-snapshot.enabled` and follow instructions in migration guide
+   * https://doc.akka.io/docs/akka-persistence-r2dbc/current/migration.html#eventsBySlicesStartingFromSnapshots
+   */
+  def currentEventsBySlicesStartingFromSnapshots[Snapshot, Event](
+      entityType: String,
+      minSlice: Int,
+      maxSlice: Int,
+      offset: Offset,
+      transformSnapshot: java.util.function.Function[Snapshot, Event]): Source[EventEnvelope[Event], NotUsed] =
+    delegate
+      .currentEventsBySlicesStartingFromSnapshots(entityType, minSlice, maxSlice, offset, transformSnapshot(_))
+      .asJava
+
+  /**
+   * Same as `eventsBySlices` but with the purpose to use snapshots as starting points and thereby reducing number of
+   * events that have to be loaded. This can be useful if the consumer start from zero without any previously processed
+   * offset or if it has been disconnected for a long while and its offset is far behind.
+   *
+   * First it loads all snapshots with timestamps greater than or equal to the offset timestamp. There is at most one
+   * snapshot per persistenceId. The snapshots are transformed to events with the given `transformSnapshot` function.
+   *
+   * After emitting the snapshot events the ordinary events with sequence numbers after the snapshots are emitted.
+   *
+   * To use `eventsBySlicesStartingFromSnapshots` you must enable configuration
+   * `akka.persistence.r2dbc.query.start-from-snapshot.enabled` and follow instructions in migration guide
+   * https://doc.akka.io/docs/akka-persistence-r2dbc/current/migration.html#eventsBySlicesStartingFromSnapshots
+   */
+  def eventsBySlicesStartingFromSnapshots[Snapshot, Event](
+      entityType: String,
+      minSlice: Int,
+      maxSlice: Int,
+      offset: Offset,
+      transformSnapshot: java.util.function.Function[Snapshot, Event]): Source[EventEnvelope[Event], NotUsed] =
+    delegate.eventsBySlicesStartingFromSnapshots(entityType, minSlice, maxSlice, offset, transformSnapshot(_)).asJava
 
   override def sliceRanges(numberOfRanges: Int): util.List[Pair[Integer, Integer]] = {
     import akka.util.ccompat.JavaConverters._

--- a/core/src/main/scala/akka/persistence/r2dbc/query/javadsl/R2dbcReadJournal.scala
+++ b/core/src/main/scala/akka/persistence/r2dbc/query/javadsl/R2dbcReadJournal.scala
@@ -102,7 +102,7 @@ final class R2dbcReadJournal(delegate: scaladsl.R2dbcReadJournal)
    *
    * To use `currentEventsBySlicesStartingFromSnapshots` you must enable configuration
    * `akka.persistence.r2dbc.query.start-from-snapshot.enabled` and follow instructions in migration guide
-   * https://doc.akka.io/docs/akka-persistence-r2dbc/current/migration.html#eventsBySlicesStartingFromSnapshots
+   * https://doc.akka.io/docs/akka-persistence-r2dbc/current/migration-guide.html#eventsBySlicesStartingFromSnapshots
    */
   def currentEventsBySlicesStartingFromSnapshots[Snapshot, Event](
       entityType: String,
@@ -126,7 +126,7 @@ final class R2dbcReadJournal(delegate: scaladsl.R2dbcReadJournal)
    *
    * To use `eventsBySlicesStartingFromSnapshots` you must enable configuration
    * `akka.persistence.r2dbc.query.start-from-snapshot.enabled` and follow instructions in migration guide
-   * https://doc.akka.io/docs/akka-persistence-r2dbc/current/migration.html#eventsBySlicesStartingFromSnapshots
+   * https://doc.akka.io/docs/akka-persistence-r2dbc/current/migration-guide.html#eventsBySlicesStartingFromSnapshots
    */
   def eventsBySlicesStartingFromSnapshots[Snapshot, Event](
       entityType: String,

--- a/core/src/main/scala/akka/persistence/r2dbc/query/javadsl/R2dbcReadJournal.scala
+++ b/core/src/main/scala/akka/persistence/r2dbc/query/javadsl/R2dbcReadJournal.scala
@@ -8,23 +8,20 @@ import java.time.Instant
 import java.util
 import java.util.Optional
 import java.util.concurrent.CompletionStage
+
 import scala.compat.java8.OptionConverters._
 import scala.compat.java8.FutureConverters._
+
 import akka.NotUsed
 import akka.dispatch.ExecutionContexts
 import akka.japi.Pair
-import akka.persistence.query.{ EventEnvelope => ClassicEventEnvelope }
+import akka.persistence.query.{EventEnvelope => ClassicEventEnvelope}
 import akka.persistence.query.Offset
 import akka.persistence.query.javadsl._
 import akka.persistence.query.typed.EventEnvelope
-import akka.persistence.query.typed.javadsl.{
-  CurrentEventsByPersistenceIdTypedQuery,
-  CurrentEventsBySliceQuery,
-  EventTimestampQuery,
-  EventsByPersistenceIdTypedQuery,
-  EventsBySliceQuery,
-  LoadEventQuery
-}
+import akka.persistence.query.typed.javadsl.CurrentEventsBySliceStartingFromSnapshotsQuery
+import akka.persistence.query.typed.javadsl.EventsBySliceStartingFromSnapshotsQuery
+import akka.persistence.query.typed.javadsl.{CurrentEventsByPersistenceIdTypedQuery, CurrentEventsBySliceQuery, EventTimestampQuery, EventsByPersistenceIdTypedQuery, EventsBySliceQuery, LoadEventQuery}
 import akka.persistence.r2dbc.query.scaladsl
 import akka.stream.javadsl.Source
 
@@ -36,6 +33,8 @@ final class R2dbcReadJournal(delegate: scaladsl.R2dbcReadJournal)
     extends ReadJournal
     with CurrentEventsBySliceQuery
     with EventsBySliceQuery
+      with CurrentEventsBySliceStartingFromSnapshotsQuery
+      with EventsBySliceStartingFromSnapshotsQuery
     with EventTimestampQuery
     with LoadEventQuery
     with CurrentEventsByPersistenceIdQuery
@@ -104,7 +103,7 @@ final class R2dbcReadJournal(delegate: scaladsl.R2dbcReadJournal)
    * `akka.persistence.r2dbc.query.start-from-snapshot.enabled` and follow instructions in migration guide
    * https://doc.akka.io/docs/akka-persistence-r2dbc/current/migration-guide.html#eventsBySlicesStartingFromSnapshots
    */
-  def currentEventsBySlicesStartingFromSnapshots[Snapshot, Event](
+  override def currentEventsBySlicesStartingFromSnapshots[Snapshot, Event](
       entityType: String,
       minSlice: Int,
       maxSlice: Int,
@@ -128,7 +127,7 @@ final class R2dbcReadJournal(delegate: scaladsl.R2dbcReadJournal)
    * `akka.persistence.r2dbc.query.start-from-snapshot.enabled` and follow instructions in migration guide
    * https://doc.akka.io/docs/akka-persistence-r2dbc/current/migration-guide.html#eventsBySlicesStartingFromSnapshots
    */
-  def eventsBySlicesStartingFromSnapshots[Snapshot, Event](
+  override def eventsBySlicesStartingFromSnapshots[Snapshot, Event](
       entityType: String,
       minSlice: Int,
       maxSlice: Int,

--- a/core/src/main/scala/akka/persistence/r2dbc/query/javadsl/R2dbcReadJournal.scala
+++ b/core/src/main/scala/akka/persistence/r2dbc/query/javadsl/R2dbcReadJournal.scala
@@ -15,13 +15,20 @@ import scala.compat.java8.FutureConverters._
 import akka.NotUsed
 import akka.dispatch.ExecutionContexts
 import akka.japi.Pair
-import akka.persistence.query.{EventEnvelope => ClassicEventEnvelope}
+import akka.persistence.query.{ EventEnvelope => ClassicEventEnvelope }
 import akka.persistence.query.Offset
 import akka.persistence.query.javadsl._
 import akka.persistence.query.typed.EventEnvelope
 import akka.persistence.query.typed.javadsl.CurrentEventsBySliceStartingFromSnapshotsQuery
 import akka.persistence.query.typed.javadsl.EventsBySliceStartingFromSnapshotsQuery
-import akka.persistence.query.typed.javadsl.{CurrentEventsByPersistenceIdTypedQuery, CurrentEventsBySliceQuery, EventTimestampQuery, EventsByPersistenceIdTypedQuery, EventsBySliceQuery, LoadEventQuery}
+import akka.persistence.query.typed.javadsl.{
+  CurrentEventsByPersistenceIdTypedQuery,
+  CurrentEventsBySliceQuery,
+  EventTimestampQuery,
+  EventsByPersistenceIdTypedQuery,
+  EventsBySliceQuery,
+  LoadEventQuery
+}
 import akka.persistence.r2dbc.query.scaladsl
 import akka.stream.javadsl.Source
 
@@ -33,8 +40,8 @@ final class R2dbcReadJournal(delegate: scaladsl.R2dbcReadJournal)
     extends ReadJournal
     with CurrentEventsBySliceQuery
     with EventsBySliceQuery
-      with CurrentEventsBySliceStartingFromSnapshotsQuery
-      with EventsBySliceStartingFromSnapshotsQuery
+    with CurrentEventsBySliceStartingFromSnapshotsQuery
+    with EventsBySliceStartingFromSnapshotsQuery
     with EventTimestampQuery
     with LoadEventQuery
     with CurrentEventsByPersistenceIdQuery

--- a/core/src/main/scala/akka/persistence/r2dbc/query/scaladsl/R2dbcReadJournal.scala
+++ b/core/src/main/scala/akka/persistence/r2dbc/query/scaladsl/R2dbcReadJournal.scala
@@ -135,8 +135,7 @@ final class R2dbcReadJournal(system: ExtendedActorSystem, config: Config, cfgPat
         row.slice,
         filtered = false,
         source = "",
-        tags = Set.empty
-      ) // FIXME tags would be needed for filters. We could store same tags as for the corresponding event.
+        tags = row.tags)
     }
 
     val extractOffset: EventEnvelope[Event] => TimestampOffset = env => env.offset.asInstanceOf[TimestampOffset]
@@ -496,7 +495,7 @@ final class R2dbcReadJournal(system: ExtendedActorSystem, config: Config, cfgPat
   //LoadEventQuery
   override def loadEnvelope[Event](persistenceId: String, sequenceNr: Long): Future[EventEnvelope[Event]] = {
     queryDao
-      .loadEvent(persistenceId, sequenceNr)
+      .loadEvent(persistenceId, sequenceNr, includePayload = true)
       .map {
         case Some(row) => deserializeBySliceRow(row)
         case None =>

--- a/core/src/main/scala/akka/persistence/r2dbc/query/scaladsl/R2dbcReadJournal.scala
+++ b/core/src/main/scala/akka/persistence/r2dbc/query/scaladsl/R2dbcReadJournal.scala
@@ -40,7 +40,7 @@ import akka.persistence.r2dbc.internal.EnvelopeOrigin
 import akka.persistence.r2dbc.internal.JournalDao.SerializedJournalRow
 import akka.persistence.r2dbc.internal.PubSub
 import akka.persistence.r2dbc.internal.SnapshotDao.SerializedSnapshotRow
-import akka.persistence.r2dbc.query.internal.StartingFromSnapshotStage
+import akka.persistence.r2dbc.internal.StartingFromSnapshotStage
 import akka.persistence.typed.PersistenceId
 import akka.serialization.SerializationExtension
 import akka.stream.OverflowStrategy

--- a/core/src/main/scala/akka/persistence/r2dbc/query/scaladsl/R2dbcReadJournal.scala
+++ b/core/src/main/scala/akka/persistence/r2dbc/query/scaladsl/R2dbcReadJournal.scala
@@ -241,8 +241,12 @@ final class R2dbcReadJournal(system: ExtendedActorSystem, config: Config, cfgPat
             if (timestampOffset == TimestampOffset.Zero && snapshotOffsets.nonEmpty) {
               val minTimestamp = snapshotOffsets.valuesIterator.minBy { case (_, timestamp) => timestamp }._2
               TimestampOffset(minTimestamp, Map.empty)
-            } else
-              offset // FIXME not sure if we should adjust also for this case
+            } else {
+              // don't adjust because then there is a risk that there was no found snapshot for a persistenceId
+              // but there can still be events between the given `offset` parameter and the min timestamp of the
+              // snapshots and those would then be missed
+              offset
+            }
 
           log.debug(
             "currentEventsBySlicesStartingFromSnapshots initOffset [{}] with [{}] snapshots",
@@ -294,8 +298,12 @@ final class R2dbcReadJournal(system: ExtendedActorSystem, config: Config, cfgPat
             if (timestampOffset == TimestampOffset.Zero && snapshotOffsets.nonEmpty) {
               val minTimestamp = snapshotOffsets.valuesIterator.minBy { case (_, timestamp) => timestamp }._2
               TimestampOffset(minTimestamp, Map.empty)
-            } else
-              offset // FIXME not sure if we should adjust also for this case
+            } else {
+              // don't adjust because then there is a risk that there was no found snapshot for a persistenceId
+              // but there can still be events between the given `offset` parameter and the min timestamp of the
+              // snapshots and those would then be missed
+              offset
+            }
 
           log.debug(
             "eventsBySlicesStartingFromSnapshots initOffset [{}] with [{}] snapshots",

--- a/core/src/main/scala/akka/persistence/r2dbc/query/scaladsl/R2dbcReadJournal.scala
+++ b/core/src/main/scala/akka/persistence/r2dbc/query/scaladsl/R2dbcReadJournal.scala
@@ -348,10 +348,9 @@ final class R2dbcReadJournal(system: ExtendedActorSystem, config: Config, cfgPat
           case None                     => true
           case Some((snapshotSeqNr, _)) =>
             //  release memory by removing from the _snapshotOffsets Map
-            if (backtrackingEnabled) {
-              if (source == EnvelopeOrigin.SourceBacktracking)
-                _snapshotOffsets -= persistenceId
-            } else if (source == EnvelopeOrigin.SourceQuery) {
+            if (seqNr == snapshotSeqNr &&
+              ((backtrackingEnabled && source == EnvelopeOrigin.SourceBacktracking) ||
+              (!backtrackingEnabled && source == EnvelopeOrigin.SourceQuery))) {
               _snapshotOffsets -= persistenceId
             }
 

--- a/core/src/main/scala/akka/persistence/r2dbc/query/scaladsl/R2dbcReadJournal.scala
+++ b/core/src/main/scala/akka/persistence/r2dbc/query/scaladsl/R2dbcReadJournal.scala
@@ -27,9 +27,11 @@ import akka.persistence.query.scaladsl._
 import akka.persistence.query.typed.EventEnvelope
 import akka.persistence.query.typed.scaladsl.CurrentEventsByPersistenceIdTypedQuery
 import akka.persistence.query.typed.scaladsl.CurrentEventsBySliceQuery
+import akka.persistence.query.typed.scaladsl.CurrentEventsBySliceStartingFromSnapshotsQuery
 import akka.persistence.query.typed.scaladsl.EventTimestampQuery
 import akka.persistence.query.typed.scaladsl.EventsByPersistenceIdTypedQuery
 import akka.persistence.query.typed.scaladsl.EventsBySliceQuery
+import akka.persistence.query.typed.scaladsl.EventsBySliceStartingFromSnapshotsQuery
 import akka.persistence.query.typed.scaladsl.LoadEventQuery
 import akka.persistence.query.{ EventEnvelope => ClassicEventEnvelope }
 import akka.persistence.r2dbc.ConnectionFactoryProvider
@@ -61,6 +63,8 @@ final class R2dbcReadJournal(system: ExtendedActorSystem, config: Config, cfgPat
     extends ReadJournal
     with CurrentEventsBySliceQuery
     with EventsBySliceQuery
+    with CurrentEventsBySliceStartingFromSnapshotsQuery
+    with EventsBySliceStartingFromSnapshotsQuery
     with EventTimestampQuery
     with LoadEventQuery
     with CurrentEventsByPersistenceIdQuery
@@ -220,7 +224,7 @@ final class R2dbcReadJournal(system: ExtendedActorSystem, config: Config, cfgPat
    * `akka.persistence.r2dbc.query.start-from-snapshot.enabled` and follow instructions in migration guide
    * https://doc.akka.io/docs/akka-persistence-r2dbc/current/migration-guide.html#eventsBySlicesStartingFromSnapshots
    */
-  def currentEventsBySlicesStartingFromSnapshots[Snapshot, Event](
+  override def currentEventsBySlicesStartingFromSnapshots[Snapshot, Event](
       entityType: String,
       minSlice: Int,
       maxSlice: Int,
@@ -277,7 +281,7 @@ final class R2dbcReadJournal(system: ExtendedActorSystem, config: Config, cfgPat
    * `akka.persistence.r2dbc.query.start-from-snapshot.enabled` and follow instructions in migration guide
    * https://doc.akka.io/docs/akka-persistence-r2dbc/current/migration-guide.html#eventsBySlicesStartingFromSnapshots
    */
-  def eventsBySlicesStartingFromSnapshots[Snapshot, Event](
+  override def eventsBySlicesStartingFromSnapshots[Snapshot, Event](
       entityType: String,
       minSlice: Int,
       maxSlice: Int,

--- a/core/src/main/scala/akka/persistence/r2dbc/query/scaladsl/R2dbcReadJournal.scala
+++ b/core/src/main/scala/akka/persistence/r2dbc/query/scaladsl/R2dbcReadJournal.scala
@@ -240,7 +240,7 @@ final class R2dbcReadJournal(system: ExtendedActorSystem, config: Config, cfgPat
     Source.fromGraph(
       new StartingFromSnapshotStage[Event](
         snapshotSource,
-        snapshotOffsets => {
+        { snapshotOffsets =>
           val initOffset =
             if (timestampOffset == TimestampOffset.Zero && snapshotOffsets.nonEmpty) {
               val minTimestamp = snapshotOffsets.valuesIterator.minBy { case (_, timestamp) => timestamp }._2
@@ -297,7 +297,7 @@ final class R2dbcReadJournal(system: ExtendedActorSystem, config: Config, cfgPat
     Source.fromGraph(
       new StartingFromSnapshotStage[Event](
         snapshotSource,
-        snapshotOffsets => {
+        { snapshotOffsets =>
           val initOffset =
             if (timestampOffset == TimestampOffset.Zero && snapshotOffsets.nonEmpty) {
               val minTimestamp = snapshotOffsets.valuesIterator.minBy { case (_, timestamp) => timestamp }._2

--- a/core/src/main/scala/akka/persistence/r2dbc/state/scaladsl/R2dbcDurableStateStore.scala
+++ b/core/src/main/scala/akka/persistence/r2dbc/state/scaladsl/R2dbcDurableStateStore.scala
@@ -164,7 +164,7 @@ class R2dbcDurableStateStore[A](system: ExtendedActorSystem, config: Config, cfg
       minSlice: Int,
       maxSlice: Int,
       offset: Offset): Source[DurableStateChange[A], NotUsed] =
-    bySlice.liveBySlices("changesBySlices", entityType, minSlice, maxSlice, offset)
+    bySlice.liveBySlices("changesBySlices", entityType, minSlice, maxSlice, offset, Map.empty)
 
   /**
    * Note: If you have configured `custom-table` this query will look in both the default table and the custom tables.

--- a/core/src/main/scala/akka/persistence/r2dbc/state/scaladsl/R2dbcDurableStateStore.scala
+++ b/core/src/main/scala/akka/persistence/r2dbc/state/scaladsl/R2dbcDurableStateStore.scala
@@ -157,14 +157,14 @@ class R2dbcDurableStateStore[A](system: ExtendedActorSystem, config: Config, cfg
       minSlice: Int,
       maxSlice: Int,
       offset: Offset): Source[DurableStateChange[A], NotUsed] =
-    bySlice.currentBySlices("currentChangesBySlices", entityType, minSlice, maxSlice, offset, Map.empty)
+    bySlice.currentBySlices("currentChangesBySlices", entityType, minSlice, maxSlice, offset)
 
   override def changesBySlices(
       entityType: String,
       minSlice: Int,
       maxSlice: Int,
       offset: Offset): Source[DurableStateChange[A], NotUsed] =
-    bySlice.liveBySlices("changesBySlices", entityType, minSlice, maxSlice, offset, Map.empty)
+    bySlice.liveBySlices("changesBySlices", entityType, minSlice, maxSlice, offset)
 
   /**
    * Note: If you have configured `custom-table` this query will look in both the default table and the custom tables.

--- a/core/src/main/scala/akka/persistence/r2dbc/state/scaladsl/R2dbcDurableStateStore.scala
+++ b/core/src/main/scala/akka/persistence/r2dbc/state/scaladsl/R2dbcDurableStateStore.scala
@@ -157,7 +157,7 @@ class R2dbcDurableStateStore[A](system: ExtendedActorSystem, config: Config, cfg
       minSlice: Int,
       maxSlice: Int,
       offset: Offset): Source[DurableStateChange[A], NotUsed] =
-    bySlice.currentBySlices("currentChangesBySlices", entityType, minSlice, maxSlice, offset)
+    bySlice.currentBySlices("currentChangesBySlices", entityType, minSlice, maxSlice, offset, Map.empty)
 
   override def changesBySlices(
       entityType: String,

--- a/core/src/test/scala/akka/persistence/r2dbc/query/EventsBySliceSpec.scala
+++ b/core/src/test/scala/akka/persistence/r2dbc/query/EventsBySliceSpec.scala
@@ -114,7 +114,7 @@ class EventsBySliceSpec
       "return all events for NoOffset" in new Setup {
         for (i <- 1 to 20) {
           persister ! PersistWithAck(s"e-$i", probe.ref)
-          probe.expectMessage(10.seconds, Done)
+          probe.expectMessage(Done)
         }
         val result: TestSubscriber.Probe[EventEnvelope[String]] =
           doQuery(entityType, slice, slice, NoOffset)
@@ -159,7 +159,7 @@ class EventsBySliceSpec
           persister ! PersistAll(List(s"e-$i-$n", s"e-$i-${n + 1}"))
         }
         persister ! Ping(probe.ref)
-        probe.expectMessage(10.seconds, Done)
+        probe.expectMessage(Done)
         val result: TestSubscriber.Probe[EventEnvelope[String]] =
           doQuery(entityType, slice, slice, NoOffset, queryWithSmallBuffer)
             .runWith(sinkProbe)
@@ -206,7 +206,7 @@ class EventsBySliceSpec
       "support EventTimestampQuery" in new Setup {
         for (i <- 1 to 3) {
           persister ! PersistWithAck(s"e-$i", probe.ref)
-          probe.expectMessage(10.seconds, Done)
+          probe.expectMessage(Done)
         }
 
         query.isInstanceOf[EventTimestampQuery] shouldBe true
@@ -218,7 +218,7 @@ class EventsBySliceSpec
       "support LoadEventQuery" in new Setup {
         for (i <- 1 to 3) {
           persister ! PersistWithAck(s"e-$i", probe.ref)
-          probe.expectMessage(10.seconds, Done)
+          probe.expectMessage(Done)
         }
 
         query.isInstanceOf[LoadEventQuery] shouldBe true
@@ -234,7 +234,7 @@ class EventsBySliceSpec
           spawn(TestActors.Persister(PersistenceId.ofUniqueId(persistenceId), tags = Set("tag-A")))
         for (i <- 1 to 3) {
           taggingPersister ! PersistWithAck(s"f-$i", probe.ref)
-          probe.expectMessage(10.seconds, Done)
+          probe.expectMessage(Done)
         }
 
         val result: TestSubscriber.Probe[EventEnvelope[String]] =

--- a/core/src/test/scala/akka/persistence/r2dbc/query/EventsBySliceSpec.scala
+++ b/core/src/test/scala/akka/persistence/r2dbc/query/EventsBySliceSpec.scala
@@ -66,12 +66,12 @@ object EventsBySliceSpec {
 }
 
 class EventsBySliceSpec
-    extends ScalaTestWithActorTestKit(EventsBySliceStartingFromSnapshotSpec.config)
+    extends ScalaTestWithActorTestKit(EventsBySliceSpec.config)
     with AnyWordSpecLike
     with TestDbLifecycle
     with TestData
     with LogCapturing {
-  import EventsBySliceStartingFromSnapshotSpec._
+  import EventsBySliceSpec._
 
   override def typedSystem: ActorSystem[_] = system
   private val settings = R2dbcSettings(system.settings.config.getConfig("akka.persistence.r2dbc"))

--- a/core/src/test/scala/akka/persistence/r2dbc/query/EventsBySliceStartingFromSnapshotSpec.scala
+++ b/core/src/test/scala/akka/persistence/r2dbc/query/EventsBySliceStartingFromSnapshotSpec.scala
@@ -44,6 +44,8 @@ object EventsBySliceStartingFromSnapshotSpec {
   def config: Config =
     TestConfig.backtrackingDisabledConfig
       .withFallback(ConfigFactory.parseString(s"""
+    akka.persistence.r2dbc.query.start-from-snapshot.enabled = true
+
     # This test is not using backtracking, so increase behind-current-time to
     # reduce risk of missing events
     akka.persistence.r2dbc.query.behind-current-time = 500 millis

--- a/core/src/test/scala/akka/persistence/r2dbc/query/StartingFromSnapshotStageSpec.scala
+++ b/core/src/test/scala/akka/persistence/r2dbc/query/StartingFromSnapshotStageSpec.scala
@@ -1,0 +1,114 @@
+/*
+ * Copyright (C) 2022 - 2023 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.persistence.r2dbc.query
+
+import java.time.Instant
+
+import akka.actor.testkit.typed.TestException
+import akka.actor.testkit.typed.scaladsl.LogCapturing
+import akka.actor.testkit.typed.scaladsl.ScalaTestWithActorTestKit
+import akka.actor.typed.ActorSystem
+import akka.persistence.Persistence
+import akka.persistence.query.TimestampOffset
+import akka.persistence.query.typed.EventEnvelope
+import akka.persistence.r2dbc.query.internal.StartingFromSnapshotStage
+import akka.persistence.typed.PersistenceId
+import akka.stream.scaladsl.Source
+import akka.stream.testkit.scaladsl.TestSink
+import org.scalatest.wordspec.AnyWordSpecLike
+
+class StartingFromSnapshotStageSpec extends ScalaTestWithActorTestKit with AnyWordSpecLike with LogCapturing {
+  private val entityType = "TestEntity"
+  private val persistence = Persistence(system)
+  private implicit val sys: ActorSystem[_] = system
+
+  private def createEnvelope(
+      pid: PersistenceId,
+      seqNr: Long,
+      evt: String,
+      tags: Set[String] = Set.empty): EventEnvelope[Any] = {
+    val now = Instant.now()
+    EventEnvelope(
+      TimestampOffset(Instant.now, Map(pid.id -> seqNr)),
+      pid.id,
+      seqNr,
+      evt,
+      now.toEpochMilli,
+      pid.entityTypeHint,
+      persistence.sliceForPersistenceId(pid.id),
+      filtered = false,
+      source = "",
+      tags = tags)
+  }
+
+  private val snapshotEnvelopes = Vector(
+    createEnvelope(PersistenceId(entityType, "a"), 2, "snap-a2"),
+    createEnvelope(PersistenceId(entityType, "b"), 3, "snap-b3"),
+    createEnvelope(PersistenceId(entityType, "c"), 1, "snap-c1"))
+
+  private val primaryEnvelopes = Vector(
+    createEnvelope(PersistenceId(entityType, "a"), 3, "a3"),
+    createEnvelope(PersistenceId(entityType, "a"), 4, "a4"),
+    createEnvelope(PersistenceId(entityType, "b"), 4, "b4"))
+
+  "StartingFromSnapshotStage" must {
+    "emit envelopes from snapshots and then from primary" in {
+      val source =
+        Source.fromGraph(new StartingFromSnapshotStage(Source(snapshotEnvelopes), _ => Source(primaryEnvelopes)))
+
+      val probe = source.runWith(TestSink())
+      probe.request(100)
+      probe.expectNextN(snapshotEnvelopes ++ primaryEnvelopes)
+      probe.expectComplete()
+    }
+
+    "collect offsets from snapshots" in {
+      val source =
+        Source.fromGraph(
+          new StartingFromSnapshotStage(
+            Source(snapshotEnvelopes),
+            snapshotOffsets => {
+              val moreEnvelopes =
+                snapshotOffsets.iterator
+                  .map { case (pid, (seqNr, _)) =>
+                    createEnvelope(
+                      PersistenceId.ofUniqueId(pid),
+                      seqNr + 1,
+                      s"${PersistenceId.ofUniqueId(pid).entityId}${seqNr + 1}")
+                  }
+                  .toVector
+                  .sortBy(_.persistenceId)
+              Source(moreEnvelopes)
+            }))
+
+      val probe = source.runWith(TestSink())
+      probe.request(100)
+      probe.expectNextN(snapshotEnvelopes)
+      probe.expectNext().event shouldBe "a3"
+      probe.expectNext().event shouldBe "b4"
+      probe.expectNext().event shouldBe "c2"
+    }
+
+    "fail if snapshots fail" in {
+      val source =
+        Source.fromGraph(
+          new StartingFromSnapshotStage(Source.failed(TestException("err")), _ => Source(primaryEnvelopes)))
+
+      val probe = source.runWith(TestSink())
+      probe.request(100)
+      probe.expectError(TestException("err"))
+    }
+
+    "fail if primary fail" in {
+      val source =
+        Source.fromGraph(new StartingFromSnapshotStage(Source.empty, _ => Source.failed(TestException("err"))))
+
+      val probe = source.runWith(TestSink())
+      probe.request(100)
+      probe.expectError(TestException("err"))
+    }
+  }
+
+}

--- a/core/src/test/scala/akka/persistence/r2dbc/query/StartingFromSnapshotStageSpec.scala
+++ b/core/src/test/scala/akka/persistence/r2dbc/query/StartingFromSnapshotStageSpec.scala
@@ -13,7 +13,7 @@ import akka.actor.typed.ActorSystem
 import akka.persistence.Persistence
 import akka.persistence.query.TimestampOffset
 import akka.persistence.query.typed.EventEnvelope
-import akka.persistence.r2dbc.query.internal.StartingFromSnapshotStage
+import akka.persistence.r2dbc.internal.StartingFromSnapshotStage
 import akka.persistence.typed.PersistenceId
 import akka.stream.scaladsl.Source
 import akka.stream.testkit.scaladsl.TestSink

--- a/core/src/test/scala/akka/persistence/r2dbc/query/StartingFromSnapshotStageSpec.scala
+++ b/core/src/test/scala/akka/persistence/r2dbc/query/StartingFromSnapshotStageSpec.scala
@@ -69,7 +69,7 @@ class StartingFromSnapshotStageSpec extends ScalaTestWithActorTestKit with AnyWo
         Source.fromGraph(
           new StartingFromSnapshotStage(
             Source(snapshotEnvelopes),
-            snapshotOffsets => {
+            { snapshotOffsets =>
               val moreEnvelopes =
                 snapshotOffsets.iterator
                   .map { case (pid, (seqNr, _)) =>

--- a/ddl-scripts/create_tables_postgres.sql
+++ b/ddl-scripts/create_tables_postgres.sql
@@ -29,7 +29,7 @@ CREATE TABLE IF NOT EXISTS snapshot(
   entity_type VARCHAR(255) NOT NULL,
   persistence_id VARCHAR(255) NOT NULL,
   seq_nr BIGINT NOT NULL,
-  db_timestamp timestamp with time zone NOT NULL,
+  db_timestamp timestamp with time zone,
   write_timestamp BIGINT NOT NULL,
   ser_id INTEGER NOT NULL,
   ser_manifest VARCHAR(255) NOT NULL,
@@ -42,7 +42,7 @@ CREATE TABLE IF NOT EXISTS snapshot(
 );
 
 -- `snapshot_slice_idx` is only needed if the slice based queries are used together with snapshot as starting point
-CREATE INDEX IF NOT EXISTS snapshot_slice_idx ON snapshot(slice, entity_type, db_timestamp, seq_nr);
+CREATE INDEX IF NOT EXISTS snapshot_slice_idx ON snapshot(slice, entity_type, db_timestamp);
 
 CREATE TABLE IF NOT EXISTS durable_state (
   slice INT NOT NULL,

--- a/ddl-scripts/create_tables_postgres.sql
+++ b/ddl-scripts/create_tables_postgres.sql
@@ -34,6 +34,7 @@ CREATE TABLE IF NOT EXISTS snapshot(
   ser_id INTEGER NOT NULL,
   ser_manifest VARCHAR(255) NOT NULL,
   snapshot BYTEA NOT NULL,
+  tags TEXT ARRAY,
   meta_ser_id INTEGER,
   meta_ser_manifest VARCHAR(255),
   meta_payload BYTEA,

--- a/ddl-scripts/create_tables_postgres.sql
+++ b/ddl-scripts/create_tables_postgres.sql
@@ -29,6 +29,7 @@ CREATE TABLE IF NOT EXISTS snapshot(
   entity_type VARCHAR(255) NOT NULL,
   persistence_id VARCHAR(255) NOT NULL,
   seq_nr BIGINT NOT NULL,
+  db_timestamp timestamp with time zone NOT NULL,
   write_timestamp BIGINT NOT NULL,
   ser_id INTEGER NOT NULL,
   ser_manifest VARCHAR(255) NOT NULL,
@@ -39,6 +40,9 @@ CREATE TABLE IF NOT EXISTS snapshot(
 
   PRIMARY KEY(persistence_id)
 );
+
+-- `snapshot_slice_idx` is only needed if the slice based queries are used together with snapshot as starting point
+CREATE INDEX IF NOT EXISTS snapshot_slice_idx ON snapshot(slice, entity_type, db_timestamp, seq_nr);
 
 CREATE TABLE IF NOT EXISTS durable_state (
   slice INT NOT NULL,

--- a/ddl-scripts/create_tables_postgres_jsonb.sql
+++ b/ddl-scripts/create_tables_postgres_jsonb.sql
@@ -34,6 +34,7 @@ CREATE TABLE IF NOT EXISTS snapshot(
   ser_id INTEGER NOT NULL,
   ser_manifest VARCHAR(255) NOT NULL,
   snapshot JSONB NOT NULL,
+  tags TEXT ARRAY,
   meta_ser_id INTEGER,
   meta_ser_manifest VARCHAR(255),
   meta_payload BYTEA,

--- a/ddl-scripts/create_tables_postgres_jsonb.sql
+++ b/ddl-scripts/create_tables_postgres_jsonb.sql
@@ -29,6 +29,7 @@ CREATE TABLE IF NOT EXISTS snapshot(
   entity_type VARCHAR(255) NOT NULL,
   persistence_id VARCHAR(255) NOT NULL,
   seq_nr BIGINT NOT NULL,
+  db_timestamp timestamp with time zone,
   write_timestamp BIGINT NOT NULL,
   ser_id INTEGER NOT NULL,
   ser_manifest VARCHAR(255) NOT NULL,
@@ -39,6 +40,9 @@ CREATE TABLE IF NOT EXISTS snapshot(
 
   PRIMARY KEY(persistence_id)
 );
+
+-- `snapshot_slice_idx` is only needed if the slice based queries are used together with snapshot as starting point
+CREATE INDEX IF NOT EXISTS snapshot_slice_idx ON snapshot(slice, entity_type, db_timestamp);
 
 CREATE TABLE IF NOT EXISTS durable_state (
   slice INT NOT NULL,

--- a/ddl-scripts/create_tables_yugabyte.sql
+++ b/ddl-scripts/create_tables_yugabyte.sql
@@ -30,6 +30,7 @@ CREATE TABLE IF NOT EXISTS snapshot(
   entity_type VARCHAR(255) NOT NULL,
   persistence_id VARCHAR(255) NOT NULL,
   seq_nr BIGINT NOT NULL,
+  db_timestamp timestamp with time zone,
   write_timestamp BIGINT NOT NULL,
   ser_id INTEGER NOT NULL,
   ser_manifest VARCHAR(255) NOT NULL,
@@ -40,6 +41,10 @@ CREATE TABLE IF NOT EXISTS snapshot(
 
   PRIMARY KEY(persistence_id HASH)
 );
+
+-- `snapshot_slice_idx` is only needed if the slice based queries are used together with snapshot as starting point
+CREATE INDEX IF NOT EXISTS snapshot_slice_idx ON snapshot(slice ASC, entity_type ASC, db_timestamp ASC, persistence_id)
+  SPLIT AT VALUES ((127), (255), (383), (511), (639), (767), (895));
 
 CREATE TABLE IF NOT EXISTS durable_state (
   slice INT NOT NULL,

--- a/ddl-scripts/create_tables_yugabyte.sql
+++ b/ddl-scripts/create_tables_yugabyte.sql
@@ -35,6 +35,7 @@ CREATE TABLE IF NOT EXISTS snapshot(
   ser_id INTEGER NOT NULL,
   ser_manifest VARCHAR(255) NOT NULL,
   snapshot BYTEA NOT NULL,
+  tags TEXT ARRAY,
   meta_ser_id INTEGER,
   meta_ser_manifest VARCHAR(255),
   meta_payload BYTEA,

--- a/docs/src/main/paradox/migration-guide.md
+++ b/docs/src/main/paradox/migration-guide.md
@@ -11,7 +11,7 @@ Remove `akka.persistence.r2dbc.dialect` from the config if present
 Choose dialect by configuring the `connection-factory` block:
 
 Postgres:
-```hocon
+: ```hocon
 akka.persistence.r2dbc.connection-factory = ${akka.persistence.r2dbc.postgres}
 akka.persistence.r2dbc.connection-factory {
   # only overrides from the default values needs to be defined
@@ -21,7 +21,7 @@ akka.persistence.r2dbc.connection-factory {
 ```
 
 Yugabyte:
-```hocon
+: ```hocon
 akka.persistence.r2dbc.connection-factory = ${akka.persistence.r2dbc.yugabyte}
 akka.persistence.r2dbc.connection-factory {
   # only overrides from the default values needs to be defined
@@ -37,8 +37,8 @@ Some accessors on the @apidoc[R2dbcSettings] class has been removed, the `Connec
 
 ### Optional changes for eventsBySlicesStartingFromSnapshots
 
-These changes are only needed if you use the new feature of using snapshots as starting points for
-`eventsBySlices` queries. the `snapshot` table.
+These changes are only needed if you use the @ref:[new feature of using snapshots as starting points](query.md#eventsbyslicesstartingfromsnapshots)
+for `eventsBySlices` queries.
 
 The `snapshot` table must be altered to add two new columns:
 
@@ -58,12 +58,12 @@ Populate the two new columns in the `snapshot` table from corresponding events i
 
 Postgres:
 : ```sql
-update snapshot s set db_timestamp = e.db_timestamp, tags = e.tags from event_journal e where s.persistence_id = e.persistence_id and s.seq_nr = e.seq_nr;
+UPDATE snapshot s SET db_timestamp = e.db_timestamp, tags = e.tags FROM event_journal e WHERE s.persistence_id = e.persistence_id and s.seq_nr = e.seq_nr;
 ```
 
 Yugabyte:
 : ```sql
-update snapshot s set db_timestamp = e.db_timestamp, tags = e.tags from event_journal e where s.persistence_id = e.persistence_id and s.seq_nr = e.seq_nr;
+UPDATE snapshot s SET db_timestamp = e.db_timestamp, tags = e.tags FROM event_journal e WHERE s.persistence_id = e.persistence_id and s.seq_nr = e.seq_nr;
 ```
 
 A new index must be added to the `snapshot` table:

--- a/docs/src/main/paradox/migration-guide.md
+++ b/docs/src/main/paradox/migration-guide.md
@@ -32,3 +32,62 @@ akka.persistence.r2dbc.connection-factory {
 
 ### API changes
 Some accessors on the @apidoc[R2dbcSettings] class has been removed, the `ConnectionFactorySettings` and `Dialect` classes has been removed. A public API for looking at what dialect is used is now provided through `R2dbcSettings.dialectName`.
+
+<a id="eventsBySlicesStartingFromSnapshots"></a>
+
+### Optional changes for eventsBySlicesStartingFromSnapshots
+
+These changes are only needed if you use the new feature of using snapshots as starting points for
+`eventsBySlices` queries. the `snapshot` table.
+
+The `snapshot` table must be altered to add two new columns:
+
+Postgres:
+: ```sql
+ALTER TABLE snapshot ADD COLUMN IF NOT EXISTS db_timestamp timestamp with time zone;
+ALTER TABLE snapshot ADD COLUMN IF NOT EXISTS tags TEXT ARRAY;
+```
+
+Yugabyte:
+: ```sql
+ALTER TABLE snapshot ADD COLUMN IF NOT EXISTS db_timestamp timestamp with time zone;
+ALTER TABLE snapshot ADD COLUMN IF NOT EXISTS tags TEXT ARRAY;
+```
+
+Populate the two new columns in the `snapshot` table from corresponding events in the `event_journal` table.
+
+Postgres:
+: ```sql
+update snapshot s set db_timestamp = e.db_timestamp, tags = e.tags from event_journal e where s.persistence_id = e.persistence_id and s.seq_nr = e.seq_nr;
+```
+
+Yugabyte:
+: ```sql
+update snapshot s set db_timestamp = e.db_timestamp, tags = e.tags from event_journal e where s.persistence_id = e.persistence_id and s.seq_nr = e.seq_nr;
+```
+
+A new index must be added to the `snapshot` table:
+
+Postgres:
+: ```sql
+CREATE INDEX IF NOT EXISTS snapshot_slice_idx ON snapshot(slice, entity_type, db_timestamp);
+```
+
+Yugabyte:
+: ```sql
+CREATE INDEX IF NOT EXISTS snapshot_slice_idx ON snapshot(slice ASC, entity_type ASC, db_timestamp ASC, persistence_id)
+  SPLIT AT VALUES ((127), (255), (383), (511), (639), (767), (895));
+```
+
+The feature must be enabled with configuration:
+
+```hocon
+akka.persistence.r2dbc.query.start-from-snapshot.enabled = true
+```
+
+These changes can be made in a rolling update process.
+
+1. While running the old version, alter tables to add the two columns.
+2. Enable configuration and roll out new version. Don't use `eventsBySlicesStartingFromSnapshots` yet.
+3. Populate the columns with the update statement. Create the index.
+4. Roll out another version where you can use `eventsBySlicesStartingFromSnapshots`.

--- a/docs/src/main/paradox/query.md
+++ b/docs/src/main/paradox/query.md
@@ -88,7 +88,25 @@ with the same timestamp are ordered by sequence number.
 `currentEventsBySlices` doesn't perform these backtracking queries and will not emit duplicates and the
 event payload is always full loaded.
 
-## Publish events for lower latency of eventsBySlices
+### eventsBySlicesStartingFromSnapshots
+
+Same as `eventsBySlices` but with the purpose to use snapshots as starting points and thereby reducing number of
+events that have to be loaded. This can be useful if the consumer start from zero without any previously processed
+offset or if it has been disconnected for a long while and its offset is far behind.
+
+First it loads all snapshots with timestamps greater than or equal to the offset timestamp. There is at most one
+snapshot per persistenceId. The snapshots are transformed to events with the given `transformSnapshot` function.
+
+After emitting the snapshot events the ordinary events with sequence numbers after the snapshots are emitted.
+
+To use `eventsBySlicesStartingFromSnapshots` or `currentEventsBySlicesStartingFromSnapshots` you must follow
+instructions in @ref:[migration guide](migration-guide.md#eventsBySlicesStartingFromSnapshots) and enable configuration:
+
+```hcon
+akka.persistence.r2dbc.query.start-from-snapshot.enabled = true
+```
+
+### Publish events for lower latency of eventsBySlices
 
 The `eventsBySlices` query polls the database periodically to find new events. By default, this interval is a
 few seconds, see `akka.persistence.r2dbc.query.refresh-interval` in the @ref:[Configuration](#configuration).

--- a/migration/src/main/scala/akka/persistence/r2dbc/migration/MigrationTool.scala
+++ b/migration/src/main/scala/akka/persistence/r2dbc/migration/MigrationTool.scala
@@ -308,9 +308,15 @@ class MigrationTool(system: ActorSystem[_]) {
       SerializedSnapshotMetadata(serializedMeta, metaSerializer.identifier, metaManifest)
     }
 
+    val slice = persistenceExt.sliceForPersistenceId(snapshotMetadata.persistenceId)
+    val entityType = PersistenceId.extractEntityType(snapshotMetadata.persistenceId)
+
     val serializedRow = SerializedSnapshotRow(
+      slice,
+      entityType,
       snapshotMetadata.persistenceId,
       snapshotMetadata.sequenceNr,
+      Instant.ofEpochMilli(snapshotMetadata.timestamp),
       snapshotMetadata.timestamp,
       serializedSnapshot,
       snapshotSerializer.identifier,

--- a/migration/src/main/scala/akka/persistence/r2dbc/migration/MigrationTool.scala
+++ b/migration/src/main/scala/akka/persistence/r2dbc/migration/MigrationTool.scala
@@ -283,6 +283,7 @@ class MigrationTool(system: ActorSystem[_]) {
       case Some(selectedSnapshot @ SelectedSnapshot(snapshotMetadata, _)) =>
         for {
           seqNr <- {
+            // TODO we could load the timestamp and tags from corresponding event, see R2dbcSnapshotStore.saveAsync
             val serializedRow = serializedSnapotRow(selectedSnapshot)
             targetSnapshotDao
               .store(serializedRow)
@@ -321,6 +322,7 @@ class MigrationTool(system: ActorSystem[_]) {
       serializedSnapshot,
       snapshotSerializer.identifier,
       snapshotManifest,
+      tags = Set.empty,
       serializedMeta)
     serializedRow
   }

--- a/migration/src/main/scala/akka/persistence/r2dbc/migration/MigrationTool.scala
+++ b/migration/src/main/scala/akka/persistence/r2dbc/migration/MigrationTool.scala
@@ -283,7 +283,9 @@ class MigrationTool(system: ActorSystem[_]) {
       case Some(selectedSnapshot @ SelectedSnapshot(snapshotMetadata, _)) =>
         for {
           seqNr <- {
-            // TODO we could load the timestamp and tags from corresponding event, see R2dbcSnapshotStore.saveAsync
+            // We could load the timestamp and tags from corresponding event, see R2dbcSnapshotStore.saveAsync,
+            // but when enabling eventsBySlicesStartingFromSnapshots the sql updates should anyway be run.
+            // See https://doc.akka.io/docs/akka-persistence-r2dbc/current/migration-guide.html#eventsBySlicesStartingFromSnapshots
             val serializedRow = serializedSnapotRow(selectedSnapshot)
             targetSnapshotDao
               .store(serializedRow)

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -10,7 +10,7 @@ object Dependencies {
   val Scala3 = "3.2.2"
   val Scala2Versions = Seq(Scala213, Scala212)
   val ScalaVersions = Dependencies.Scala2Versions :+ Dependencies.Scala3
-  val AkkaVersion = System.getProperty("override.akka.version", "2.8.2+23-cf4e70ec-SNAPSHOT")
+  val AkkaVersion = System.getProperty("override.akka.version", "2.8.3")
   val AkkaVersionInDocs = AkkaVersion.take(3)
   val AkkaPersistenceJdbcVersion = "5.2.0" // only in migration tool tests
   val AkkaProjectionVersionInDocs = "current"

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -10,7 +10,7 @@ object Dependencies {
   val Scala3 = "3.2.2"
   val Scala2Versions = Seq(Scala213, Scala212)
   val ScalaVersions = Dependencies.Scala2Versions :+ Dependencies.Scala3
-  val AkkaVersion = System.getProperty("override.akka.version", "2.8.1")
+  val AkkaVersion = System.getProperty("override.akka.version", "2.8.2+23-cf4e70ec-SNAPSHOT")
   val AkkaVersionInDocs = AkkaVersion.take(3)
   val AkkaPersistenceJdbcVersion = "5.2.0" // only in migration tool tests
   val AkkaProjectionVersionInDocs = "current"


### PR DESCRIPTION
This is an alternative to https://github.com/akka/akka-persistence-r2dbc/pull/409 and I think this approach is better because it doesn't add a new concept that must be thought of when implementing the entity. It's using the existing snapshots but transforming them to events.