### PR TITLE
fix: Close connection if execution takes too long

### DIFF
--- a/core/src/main/resources/reference.conf
+++ b/core/src/main/resources/reference.conf
@@ -253,6 +253,25 @@ akka.persistence.r2dbc {
     # Enabling this has some performance overhead.
     # A fast query for Postgres is "SELECT 1"
     validation-query = ""
+
+
+    # Abort any statement that takes more than the specified amount of time.
+    # This timeout is handled by the database server.
+    # This timeout should be less than `close-calls-exceeding`.
+    statement-timeout = off
+
+    # Maximum SQL statement execution duration. The current connection is closed if exceeded,
+    # and will not be reused by the pool.
+    # This timeout is handled on the client side and should be used in case the database server
+    # is unresponsive or the connection is broken but not closed.
+    # It can be used in combination with `statement-timeout`, which should be less than this
+    # timeout.
+    # The timeout is needed to handle some failure scenarios, when the database server is
+    # terminated in a non graceful way and there is a load balancer in front. The client
+    # connection and current execution in progress would not be completed without this timeout,
+    # resulting in a "connection leak".
+    # Set to "off" to disable this timeout.
+    close-calls-exceeding = 20 seconds
   }
 
   # If database timestamp is guaranteed to not move backwards for two subsequent

--- a/core/src/main/scala/akka/persistence/r2dbc/ConnectionFactoryProvider.scala
+++ b/core/src/main/scala/akka/persistence/r2dbc/ConnectionFactoryProvider.scala
@@ -82,6 +82,11 @@ class ConnectionFactoryProvider(system: ActorSystem[_]) extends Extension {
         PostgresqlConnectionFactoryProvider.PREPARED_STATEMENT_CACHE_QUERIES,
         Integer.valueOf(settings.statementCacheSize))
 
+    settings.statementTimeout.foreach { timeout =>
+      import akka.util.JavaDurationConverters._
+      builder.option(PostgresqlConnectionFactoryProvider.STATEMENT_TIMEOUT, timeout.asJava)
+    }
+
     if (settings.sslEnabled) {
       builder.option(ConnectionFactoryOptions.SSL, java.lang.Boolean.TRUE)
 

--- a/core/src/main/scala/akka/persistence/r2dbc/R2dbcSettings.scala
+++ b/core/src/main/scala/akka/persistence/r2dbc/R2dbcSettings.scala
@@ -161,6 +161,17 @@ final class QuerySettings(config: Config) {
 /**
  * INTERNAL API
  */
+@InternalApi private[akka] object ConnectionFactorySettings {
+  def closeCallsExceeding(config: Config): Option[FiniteDuration] =
+    config.getString("close-calls-exceeding").toLowerCase(Locale.ROOT) match {
+      case "off" => None
+      case _     => Some(config.getDuration("close-calls-exceeding").asScala)
+    }
+}
+
+/**
+ * INTERNAL API
+ */
 @InternalStableApi
 final class ConnectionFactorySettings(config: Config) {
 
@@ -194,6 +205,14 @@ final class ConnectionFactorySettings(config: Config) {
   val validationQuery: String = config.getString("validation-query")
 
   val statementCacheSize: Int = config.getInt("statement-cache-size")
+
+  val statementTimeout: Option[FiniteDuration] =
+    config.getString("statement-timeout").toLowerCase(Locale.ROOT) match {
+      case "off" => None
+      case _     => Some(config.getDuration("statement-timeout").asScala)
+    }
+
+  val closeCallsExceeding: Option[FiniteDuration] = ConnectionFactorySettings.closeCallsExceeding(config)
 }
 
 /**

--- a/core/src/main/scala/akka/persistence/r2dbc/internal/R2dbcExecutor.scala
+++ b/core/src/main/scala/akka/persistence/r2dbc/internal/R2dbcExecutor.scala
@@ -5,13 +5,19 @@
 package akka.persistence.r2dbc.internal
 
 import java.util.function.BiConsumer
+
 import scala.collection.immutable
 import scala.collection.mutable
 import scala.compat.java8.FutureConverters._
 import scala.concurrent.ExecutionContext
 import scala.concurrent.Future
 import scala.concurrent.duration.FiniteDuration
+import scala.concurrent.duration._
+import scala.util.Failure
+import scala.util.Success
+import scala.util.control.Exception.Catcher
 import scala.util.control.NonFatal
+
 import akka.Done
 import akka.actor.typed.ActorSystem
 import akka.actor.typed.scaladsl.LoggerOps
@@ -22,6 +28,7 @@ import io.r2dbc.spi.ConnectionFactory
 import io.r2dbc.spi.Result
 import io.r2dbc.spi.Row
 import io.r2dbc.spi.Statement
+import io.r2dbc.spi.Wrapped
 import org.reactivestreams.Publisher
 import org.slf4j.Logger
 import reactor.core.publisher.Flux
@@ -90,14 +97,23 @@ import reactor.core.publisher.Mono
  * INTERNAL API:
  */
 @InternalStableApi
-class R2dbcExecutor(val connectionFactory: ConnectionFactory, log: Logger, logDbCallsExceeding: FiniteDuration)(implicit
-    ec: ExecutionContext,
-    system: ActorSystem[_]) {
+class R2dbcExecutor(
+    val connectionFactory: ConnectionFactory,
+    log: Logger,
+    logDbCallsExceeding: FiniteDuration,
+    closeCallsExceeding: Option[FiniteDuration])(implicit ec: ExecutionContext, system: ActorSystem[_]) {
 
   import R2dbcExecutor._
 
   private val logDbCallsExceedingMicros = logDbCallsExceeding.toMicros
   private val logDbCallsExceedingEnabled = logDbCallsExceedingMicros >= 0
+
+  // for backwards compatibility, closeCallsExceeding should be defined
+  @deprecated("Use constructor with closeCallsExceeding", "1.2.0")
+  def this(connectionFactory: ConnectionFactory, log: Logger, logDbCallsExceeding: FiniteDuration)(implicit
+      ec: ExecutionContext,
+      system: ActorSystem[_]) =
+    this(connectionFactory, log, logDbCallsExceeding, closeCallsExceeding = Some(20.seconds))
 
   private def nanoTime(): Long =
     if (logDbCallsExceedingEnabled) System.nanoTime() else 0L
@@ -253,6 +269,10 @@ class R2dbcExecutor(val connectionFactory: ConnectionFactory, log: Logger, logDb
     getConnection(logPrefix).flatMap { connection =>
       val startTime = nanoTime()
       connection.beginTransaction().asFutureDone().flatMap { _ =>
+        val timeoutTask = closeCallsExceeding.map { timeout =>
+          system.scheduler.scheduleOnce(timeout, () => closeAfterTimeout(connection))
+        }
+
         val result =
           try {
             fun(connection)
@@ -266,16 +286,20 @@ class R2dbcExecutor(val connectionFactory: ConnectionFactory, log: Logger, logDb
           if (log.isDebugEnabled())
             log.debug2("{} - DB call failed: {}", logPrefix, exc.toString)
           // ok to rollback async like this, or should it be before completing the returned Future?
-          rollbackAndClose(connection)
+          val done = rollbackAndClose(connection)
+          timeoutTask.foreach { task => done.onComplete(_ => task.cancel()) }
         }
 
         result.flatMap { r =>
-          commitAndClose(connection).map { _ =>
-            val durationMicros = durationInMicros(startTime)
-            if (durationMicros >= logDbCallsExceedingMicros)
-              log.info("{} - DB call completed in [{}] µs", logPrefix, durationMicros)
-            r
-          }
+          val done = commitAndClose(connection)
+            .map { _ =>
+              val durationMicros = durationInMicros(startTime)
+              if (durationMicros >= logDbCallsExceedingMicros)
+                log.info("{} - DB call completed in [{}] µs", logPrefix, durationMicros)
+              r
+            }
+          timeoutTask.foreach { task => done.onComplete(_ => task.cancel()) }
+          done
         }
 
       }
@@ -288,6 +312,10 @@ class R2dbcExecutor(val connectionFactory: ConnectionFactory, log: Logger, logDb
   def withAutoCommitConnection[A](logPrefix: String)(fun: Connection => Future[A]): Future[A] = {
     getConnection(logPrefix).flatMap { connection =>
       val startTime = nanoTime()
+      val timeoutTask = closeCallsExceeding.map { timeout =>
+        system.scheduler.scheduleOnce(timeout, () => closeAfterTimeout(connection))
+      }
+
       connection.setAutoCommit(true).asFutureDone().flatMap { _ =>
         val result =
           try {
@@ -301,26 +329,63 @@ class R2dbcExecutor(val connectionFactory: ConnectionFactory, log: Logger, logDb
         result.failed.foreach { exc =>
           log.debug2("{} - DB call failed: {}", logPrefix, exc)
           // auto-commit so nothing to rollback
-          connection.close().asFutureDone()
+          val done = connection.close().asFutureDone()
+          timeoutTask.foreach { task => done.onComplete(_ => task.cancel()) }
         }
 
         result.flatMap { r =>
-          connection.close().asFutureDone().map { _ =>
-            val durationMicros = durationInMicros(startTime)
-            if (durationMicros >= logDbCallsExceedingMicros)
-              log.infoN("{} - DB call completed [{}] in [{}] µs", logPrefix, r, durationMicros)
-            r
-          }
+          val done = connection
+            .close()
+            .asFutureDone()
+            .map { _ =>
+              val durationMicros = durationInMicros(startTime)
+              if (durationMicros >= logDbCallsExceedingMicros)
+                log.infoN("{} - DB call completed [{}] in [{}] µs", logPrefix, r, durationMicros)
+              r
+            }
+          timeoutTask.foreach { task => done.onComplete(_ => task.cancel()) }
+          done
         }
       }
     }
   }
 
   private def commitAndClose(connection: Connection): Future[Done] = {
-    connection.commitTransaction().asFutureDone().andThen { case _ => connection.close().asFutureDone() }
+    connection.commitTransaction().asFutureDone().andThen { case _ =>
+      try connection.close().asFutureDone()
+      catch ignoreConnectionClosedException
+    }
   }
 
   private def rollbackAndClose(connection: Connection): Future[Done] = {
-    connection.rollbackTransaction().asFutureDone().andThen { case _ => connection.close().asFutureDone() }
+    try connection
+      .rollbackTransaction()
+      .asFutureDone()
+      .andThen { case _ =>
+        try connection.close().asFutureDone()
+        catch ignoreConnectionClosedException
+
+      } catch ignoreConnectionClosedException
+  }
+
+  private def closeAfterTimeout(connection: Connection): Unit = {
+    log.warn("Timeout after [{}], will try to close connection", closeCallsExceeding.map(_.toCoarsest).getOrElse(""))
+
+    val done = connection match {
+      case wrapped: Wrapped[Connection] @unchecked => wrapped.unwrap().close.asFutureDone()
+      case _                                       => connection.close.asFutureDone()
+    }
+
+    done.onComplete {
+      case Success(_) =>
+        log.debug("Connection closed after timeout")
+      case Failure(exc) =>
+        log.debug("Tried to close connection after timeout, but {}", exc.toString)
+    }
+  }
+
+  private def ignoreConnectionClosedException: Catcher[Future[Done]] = { case _: IllegalStateException =>
+    // throw by PooledConnection assertNotClosed, if connection closed after timeout
+    Future.successful(Done)
   }
 }

--- a/core/src/main/scala/akka/persistence/r2dbc/journal/JournalDao.scala
+++ b/core/src/main/scala/akka/persistence/r2dbc/journal/JournalDao.scala
@@ -82,7 +82,12 @@ private[r2dbc] class JournalDao(journalSettings: R2dbcSettings, connectionFactor
 
   private val persistenceExt = Persistence(system)
 
-  private val r2dbcExecutor = new R2dbcExecutor(connectionFactory, log, journalSettings.logDbCallsExceeding)(ec, system)
+  private val r2dbcExecutor =
+    new R2dbcExecutor(
+      connectionFactory,
+      log,
+      journalSettings.logDbCallsExceeding,
+      journalSettings.connectionFactorySettings.closeCallsExceeding)(ec, system)
 
   private val journalTable = journalSettings.journalTableWithSchema
   private implicit val journalPayloadCodec: PayloadCodec = journalSettings.journalPayloadCodec

--- a/core/src/main/scala/akka/persistence/r2dbc/query/scaladsl/QueryDao.scala
+++ b/core/src/main/scala/akka/persistence/r2dbc/query/scaladsl/QueryDao.scala
@@ -139,7 +139,11 @@ private[r2dbc] class QueryDao(settings: R2dbcSettings, connectionFactory: Connec
   private val persistenceIdsForEntityTypeAfterSql =
     sql"SELECT DISTINCT(persistence_id) from $journalTable WHERE persistence_id LIKE ? AND persistence_id > ? ORDER BY persistence_id LIMIT ?"
 
-  private val r2dbcExecutor = new R2dbcExecutor(connectionFactory, log, settings.logDbCallsExceeding)(ec, system)
+  private val r2dbcExecutor = new R2dbcExecutor(
+    connectionFactory,
+    log,
+    settings.logDbCallsExceeding,
+    settings.connectionFactorySettings.closeCallsExceeding)(ec, system)
 
   def currentDbTimestamp(): Future[Instant] = {
     r2dbcExecutor

--- a/core/src/main/scala/akka/persistence/r2dbc/snapshot/SnapshotDao.scala
+++ b/core/src/main/scala/akka/persistence/r2dbc/snapshot/SnapshotDao.scala
@@ -57,7 +57,11 @@ private[r2dbc] final class SnapshotDao(settings: R2dbcSettings, connectionFactor
   private val snapshotTable = settings.snapshotsTableWithSchema
   private implicit val snapshotPayloadCodec: PayloadCodec = settings.snapshotPayloadCodec
   private val persistenceExt = Persistence(system)
-  private val r2dbcExecutor = new R2dbcExecutor(connectionFactory, log, settings.logDbCallsExceeding)(ec, system)
+  private val r2dbcExecutor = new R2dbcExecutor(
+    connectionFactory,
+    log,
+    settings.logDbCallsExceeding,
+    settings.connectionFactorySettings.closeCallsExceeding)(ec, system)
 
   private val upsertSql = sql"""
     INSERT INTO $snapshotTable

--- a/core/src/main/scala/akka/persistence/r2dbc/state/scaladsl/DurableStateDao.scala
+++ b/core/src/main/scala/akka/persistence/r2dbc/state/scaladsl/DurableStateDao.scala
@@ -91,7 +91,11 @@ private[r2dbc] class DurableStateDao(settings: R2dbcSettings, connectionFactory:
   import DurableStateDao._
 
   private val persistenceExt = Persistence(system)
-  private val r2dbcExecutor = new R2dbcExecutor(connectionFactory, log, settings.logDbCallsExceeding)(ec, system)
+  private val r2dbcExecutor = new R2dbcExecutor(
+    connectionFactory,
+    log,
+    settings.logDbCallsExceeding,
+    settings.connectionFactorySettings.closeCallsExceeding)(ec, system)
 
   private implicit val statePayloadCodec: PayloadCodec = settings.durableStatePayloadCodec
 

--- a/core/src/test/scala/akka/persistence/r2dbc/TestDbLifecycle.scala
+++ b/core/src/test/scala/akka/persistence/r2dbc/TestDbLifecycle.scala
@@ -27,7 +27,8 @@ trait TestDbLifecycle extends BeforeAndAfterAll { this: Suite =>
     new R2dbcExecutor(
       ConnectionFactoryProvider(typedSystem).connectionFactoryFor(testConfigPath + ".connection-factory"),
       LoggerFactory.getLogger(getClass),
-      r2dbcSettings.logDbCallsExceeding)(typedSystem.executionContext, typedSystem)
+      r2dbcSettings.logDbCallsExceeding,
+      r2dbcSettings.connectionFactorySettings.closeCallsExceeding)(typedSystem.executionContext, typedSystem)
   }
 
   lazy val persistenceExt: Persistence = Persistence(typedSystem)

--- a/core/src/test/scala/akka/persistence/r2dbc/internal/R2dbcExecutorSpec.scala
+++ b/core/src/test/scala/akka/persistence/r2dbc/internal/R2dbcExecutorSpec.scala
@@ -1,0 +1,106 @@
+/*
+ * Copyright (C) 2022 - 2023 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.persistence.r2dbc.internal
+
+import scala.concurrent.Await
+import scala.concurrent.duration._
+
+import akka.actor.testkit.typed.scaladsl.LogCapturing
+import akka.actor.testkit.typed.scaladsl.ScalaTestWithActorTestKit
+import akka.actor.typed.ActorSystem
+import akka.persistence.r2dbc.TestConfig
+import akka.persistence.r2dbc.TestData
+import akka.persistence.r2dbc.TestDbLifecycle
+import com.typesafe.config.Config
+import com.typesafe.config.ConfigFactory
+import io.r2dbc.spi.Connection
+import io.r2dbc.spi.R2dbcNonTransientResourceException
+import io.r2dbc.spi.Wrapped
+import org.scalatest.wordspec.AnyWordSpecLike
+
+object R2dbcExecutorSpec {
+  val config: Config = ConfigFactory
+    .parseString("""
+    akka.persistence.r2dbc.connection-factory {
+      initial-size = 1
+      max-size = 1
+      close-calls-exceeding = 3 seconds
+    }
+    """)
+    .withFallback(TestConfig.config)
+}
+
+class R2dbcExecutorSpec
+    extends ScalaTestWithActorTestKit(R2dbcExecutorSpec.config)
+    with AnyWordSpecLike
+    with TestDbLifecycle
+    with TestData
+    with LogCapturing {
+
+  override def typedSystem: ActorSystem[_] = system
+  private val table = "r2dbc_executor_spec"
+
+  case class Row(col: String)
+
+  override protected def beforeAll(): Unit = {
+    super.beforeAll()
+
+    Await.result(
+      r2dbcExecutor.executeDdl(s"beforeAll create table $table")(
+        _.createStatement(s"create table if not exists $table (col text)")),
+      20.seconds)
+
+    r2dbcExecutor.updateOne("test")(_.createStatement(s"delete from $table")).futureValue
+  }
+
+  "R2dbcExecutor" should {
+
+    "close connection when no response from update" in {
+      @volatile var c1: Connection = null
+      @volatile var c2: Connection = null
+
+      val result = r2dbcExecutor.update("test") { connection =>
+        c1 = connection.asInstanceOf[Wrapped[Connection]].unwrap()
+        Vector(
+          connection.createStatement(s"insert into $table (col) values ('a')"),
+          connection.createStatement("select pg_sleep(4)"),
+          connection.createStatement(s"insert into $table (col) values ('b')"))
+      }
+
+      Thread.sleep(r2dbcSettings.connectionFactorySettings.closeCallsExceeding.get.toMillis)
+
+      // The request will fail with PostgresConnectionClosedException
+      result.failed.futureValue shouldBe a[R2dbcNonTransientResourceException]
+
+      r2dbcExecutor
+        .selectOne("test")(
+          { connection =>
+            c2 = connection.asInstanceOf[Wrapped[Connection]].unwrap()
+            connection.createStatement(s"select col from $table where col = 'a'")
+          },
+          row => Row(row.get("col", classOf[String])))
+        .futureValue shouldBe None
+
+      r2dbcExecutor
+        .selectOne("test")(
+          _.createStatement(s"select col from $table where col = 'b'"),
+          row => Row(row.get("col", classOf[String])))
+        .futureValue shouldBe None
+
+      // it shouldn't reuse the connection
+      c1 should not be theSameInstanceAs(c2)
+    }
+
+    "close connection when no response from update with auto-commit" in {
+      val result = r2dbcExecutor.updateOne("test")(_.createStatement("select pg_sleep(4)"))
+
+      Thread.sleep(r2dbcSettings.connectionFactorySettings.closeCallsExceeding.get.toMillis)
+
+      // The request will fail with PostgresConnectionClosedException
+      result.failed.futureValue shouldBe a[R2dbcNonTransientResourceException]
+    }
+
+  }
+}

--- a/migration/src/main/scala/akka/persistence/r2dbc/migration/MigrationTool.scala
+++ b/migration/src/main/scala/akka/persistence/r2dbc/migration/MigrationTool.scala
@@ -129,7 +129,10 @@ class MigrationTool(system: ActorSystem[_]) {
   private lazy val sourceSnapshotStore = Persistence(system).snapshotStoreFor(sourceSnapshotPluginId)
 
   private[r2dbc] val migrationDao =
-    new MigrationToolDao(targetConnectionFactory, targetR2dbcSettings.logDbCallsExceeding)
+    new MigrationToolDao(
+      targetConnectionFactory,
+      targetR2dbcSettings.logDbCallsExceeding,
+      targetR2dbcSettings.connectionFactorySettings.closeCallsExceeding)
 
   private lazy val createProgressTable: Future[Done] =
     migrationDao.createProgressTable()

--- a/migration/src/main/scala/akka/persistence/r2dbc/migration/MigrationToolDao.scala
+++ b/migration/src/main/scala/akka/persistence/r2dbc/migration/MigrationToolDao.scala
@@ -28,10 +28,12 @@ import io.r2dbc.spi.ConnectionFactory
  */
 @InternalApi private[r2dbc] class MigrationToolDao(
     connectionFactory: ConnectionFactory,
-    logDbCallsExceeding: FiniteDuration)(implicit ec: ExecutionContext, system: ActorSystem[_]) {
+    logDbCallsExceeding: FiniteDuration,
+    closeCallsExceeding: Option[FiniteDuration])(implicit ec: ExecutionContext, system: ActorSystem[_]) {
   import MigrationToolDao.CurrentProgress
 
-  private val r2dbcExecutor = new R2dbcExecutor(connectionFactory, log, logDbCallsExceeding)(ec, system)
+  private val r2dbcExecutor =
+    new R2dbcExecutor(connectionFactory, log, logDbCallsExceeding, closeCallsExceeding)(ec, system)
 
   def createProgressTable(): Future[Done] = {
     r2dbcExecutor.executeDdl("create migration progress table") { connection =>


### PR DESCRIPTION
* The current transaction will be rolled back and connection closed if exceeded.
* This timeout is needed to handle some failure scenarios, when the database server is terminated in a non graceful way and there is a load balancer in front. The client connection and current execution in progress would not be completed without this timeout, resulting in a "connection leak".

I have tried this by simulating execution that takes longer than the timeout with `pg_sleep`, but I haven't included tests yet. Will make a new test for this.