### PR TITLE
fix: Close connection if execution takes too long (fw port)

### DIFF
--- a/core/src/main/resources/reference.conf
+++ b/core/src/main/resources/reference.conf
@@ -218,6 +218,19 @@ akka.persistence.r2dbc {
     # Enabling this has some performance overhead.
     # A fast query for Postgres is "SELECT 1"
     validation-query = ""
+
+    # Maximum SQL statement execution duration. The current connection is closed if exceeded,
+    # and will not be reused by the pool.
+    # This timeout is handled on the client side and should be used in case the database server
+    # is unresponsive or the connection is broken but not closed.
+    # It can be used in combination with `statement-timeout`, which should be less than this
+    # timeout.
+    # The timeout is needed to handle some failure scenarios, when the database server is
+    # terminated in a non graceful way and there is a load balancer in front. The client
+    # connection and current execution in progress would not be completed without this timeout,
+    # resulting in a "connection leak".
+    # Set to "off" to disable this timeout.
+    close-calls-exceeding = 20 seconds
     // #connection-pool-settings
   }
 
@@ -276,6 +289,11 @@ akka.persistence.r2dbc {
     # 0 means no cache, negative values will select an unbounded cache
     # a positive value will configure a bounded cache with the passed size.
     statement-cache-size = 5000
+
+    # Abort any statement that takes more than the specified amount of time.
+    # This timeout is handled by the database server.
+    # This timeout should be less than `close-calls-exceeding`.
+    statement-timeout = off
     // #connection-settings-postgres
     // #connection-settings-yugabyte
   }
@@ -323,8 +341,6 @@ akka.persistence.r2dbc {
     # Create database indexes to optimize slice queries on the journal and durable state
     # has a slight overhead so can be disabled if not using the slice queries
     create-slice-indexes = true
-
-
 
     # The H2 driver blocks in suprising places, run potentiall blocking tasks on this dispatcher,
     # can be configured to be a specific dispatcher but note that since it will be blocking it should

--- a/core/src/main/scala/akka/persistence/r2dbc/R2dbcSettings.scala
+++ b/core/src/main/scala/akka/persistence/r2dbc/R2dbcSettings.scala
@@ -283,6 +283,12 @@ final class ConnectionPoolSettings(config: Config) {
   val acquireRetry: Int = config.getInt("acquire-retry")
 
   val validationQuery: String = config.getString("validation-query")
+
+  val closeCallsExceeding: Option[FiniteDuration] =
+    config.getString("close-calls-exceeding").toLowerCase(Locale.ROOT) match {
+      case "off" => None
+      case _     => Some(config.getDuration("close-calls-exceeding").asScala)
+    }
 }
 
 /**

--- a/core/src/main/scala/akka/persistence/r2dbc/internal/ConnectionFactorySettings.scala
+++ b/core/src/main/scala/akka/persistence/r2dbc/internal/ConnectionFactorySettings.scala
@@ -6,6 +6,7 @@ package akka.persistence.r2dbc.internal
 
 import akka.actor.typed.ActorSystem
 import akka.annotation.InternalApi
+import akka.persistence.r2dbc.ConnectionPoolSettings
 import akka.persistence.r2dbc.internal.h2.H2Dialect
 import akka.persistence.r2dbc.internal.postgres.PostgresDialect
 import akka.persistence.r2dbc.internal.postgres.YugabyteDialect
@@ -31,7 +32,11 @@ private[r2dbc] object ConnectionFactorySettings {
           s"Unknown dialect [$other]. Supported dialects are [postgres, yugabyte, h2].")
     }
 
-    ConnectionFactorySettings(dialect, config)
+    // pool settings are common to all dialects but defined inline in the connection factory block
+    // for backwards compatibility/convenience
+    val poolSettings = new ConnectionPoolSettings(config)
+
+    ConnectionFactorySettings(dialect, config, poolSettings)
   }
 
 }
@@ -40,4 +45,7 @@ private[r2dbc] object ConnectionFactorySettings {
  * INTERNAL API
  */
 @InternalApi
-private[r2dbc] case class ConnectionFactorySettings(dialect: Dialect, config: Config)
+private[r2dbc] case class ConnectionFactorySettings(
+    dialect: Dialect,
+    config: Config,
+    poolSettings: ConnectionPoolSettings)

--- a/core/src/main/scala/akka/persistence/r2dbc/internal/postgres/PostgresDurableStateDao.scala
+++ b/core/src/main/scala/akka/persistence/r2dbc/internal/postgres/PostgresDurableStateDao.scala
@@ -79,7 +79,11 @@ private[r2dbc] class PostgresDurableStateDao(settings: R2dbcSettings, connection
   protected def log: Logger = PostgresDurableStateDao.log
 
   private val persistenceExt = Persistence(system)
-  private val r2dbcExecutor = new R2dbcExecutor(connectionFactory, log, settings.logDbCallsExceeding)(ec, system)
+  protected val r2dbcExecutor = new R2dbcExecutor(
+    connectionFactory,
+    log,
+    settings.logDbCallsExceeding,
+    settings.connectionFactorySettings.poolSettings.closeCallsExceeding)(ec, system)
 
   private implicit val statePayloadCodec: PayloadCodec = settings.durableStatePayloadCodec
 

--- a/core/src/main/scala/akka/persistence/r2dbc/internal/postgres/PostgresJournalDao.scala
+++ b/core/src/main/scala/akka/persistence/r2dbc/internal/postgres/PostgresJournalDao.scala
@@ -67,7 +67,11 @@ private[r2dbc] class PostgresJournalDao(journalSettings: R2dbcSettings, connecti
   private val persistenceExt = Persistence(system)
 
   protected val r2dbcExecutor =
-    new R2dbcExecutor(connectionFactory, log, journalSettings.logDbCallsExceeding)(ec, system)
+    new R2dbcExecutor(
+      connectionFactory,
+      log,
+      journalSettings.logDbCallsExceeding,
+      journalSettings.connectionFactorySettings.poolSettings.closeCallsExceeding)(ec, system)
 
   protected val journalTable = journalSettings.journalTableWithSchema
   protected implicit val journalPayloadCodec: PayloadCodec = journalSettings.journalPayloadCodec

--- a/core/src/main/scala/akka/persistence/r2dbc/internal/postgres/PostgresQueryDao.scala
+++ b/core/src/main/scala/akka/persistence/r2dbc/internal/postgres/PostgresQueryDao.scala
@@ -143,7 +143,11 @@ private[r2dbc] class PostgresQueryDao(settings: R2dbcSettings, connectionFactory
   private val persistenceIdsForEntityTypeAfterSql =
     sql"SELECT DISTINCT(persistence_id) from $journalTable WHERE persistence_id LIKE ? AND persistence_id > ? ORDER BY persistence_id LIMIT ?"
 
-  private val r2dbcExecutor = new R2dbcExecutor(connectionFactory, log, settings.logDbCallsExceeding)(ec, system)
+  protected val r2dbcExecutor = new R2dbcExecutor(
+    connectionFactory,
+    log,
+    settings.logDbCallsExceeding,
+    settings.connectionFactorySettings.poolSettings.closeCallsExceeding)(ec, system)
 
   def currentDbTimestamp(): Future[Instant] = {
     r2dbcExecutor

--- a/core/src/main/scala/akka/persistence/r2dbc/internal/postgres/PostgresSnapshotDao.scala
+++ b/core/src/main/scala/akka/persistence/r2dbc/internal/postgres/PostgresSnapshotDao.scala
@@ -55,7 +55,11 @@ private[r2dbc] class PostgresSnapshotDao(settings: R2dbcSettings, connectionFact
 
   protected val snapshotTable = settings.snapshotsTableWithSchema
   private implicit val snapshotPayloadCodec: PayloadCodec = settings.snapshotPayloadCodec
-  private val r2dbcExecutor = new R2dbcExecutor(connectionFactory, log, settings.logDbCallsExceeding)(ec, system)
+  protected val r2dbcExecutor = new R2dbcExecutor(
+    connectionFactory,
+    log,
+    settings.logDbCallsExceeding,
+    settings.connectionFactorySettings.poolSettings.closeCallsExceeding)(ec, system)
 
   protected def createUpsertSql: String = {
     // db_timestamp and tags columns were added in 1.2.0

--- a/core/src/test/scala/akka/persistence/r2dbc/TestDbLifecycle.scala
+++ b/core/src/test/scala/akka/persistence/r2dbc/TestDbLifecycle.scala
@@ -32,7 +32,10 @@ trait TestDbLifecycle extends BeforeAndAfterAll { this: Suite =>
       ConnectionFactoryProvider(typedSystem)
         .connectionFactoryFor(testConfigPath + ".connection-factory"),
       LoggerFactory.getLogger(getClass),
-      r2dbcSettings.logDbCallsExceeding)(typedSystem.executionContext, typedSystem)
+      r2dbcSettings.logDbCallsExceeding,
+      r2dbcSettings.connectionFactorySettings.poolSettings.closeCallsExceeding)(
+      typedSystem.executionContext,
+      typedSystem)
   }
 
   lazy val persistenceExt: Persistence = Persistence(typedSystem)

--- a/core/src/test/scala/akka/persistence/r2dbc/internal/R2dbcExecutorSpec.scala
+++ b/core/src/test/scala/akka/persistence/r2dbc/internal/R2dbcExecutorSpec.scala
@@ -1,0 +1,106 @@
+/*
+ * Copyright (C) 2022 - 2023 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.persistence.r2dbc.internal
+
+import scala.concurrent.Await
+import scala.concurrent.duration._
+
+import akka.actor.testkit.typed.scaladsl.LogCapturing
+import akka.actor.testkit.typed.scaladsl.ScalaTestWithActorTestKit
+import akka.actor.typed.ActorSystem
+import akka.persistence.r2dbc.TestConfig
+import akka.persistence.r2dbc.TestData
+import akka.persistence.r2dbc.TestDbLifecycle
+import com.typesafe.config.Config
+import com.typesafe.config.ConfigFactory
+import io.r2dbc.spi.Connection
+import io.r2dbc.spi.R2dbcNonTransientResourceException
+import io.r2dbc.spi.Wrapped
+import org.scalatest.wordspec.AnyWordSpecLike
+
+object R2dbcExecutorSpec {
+  val config: Config = ConfigFactory
+    .parseString("""
+    akka.persistence.r2dbc.connection-factory {
+      initial-size = 1
+      max-size = 1
+      close-calls-exceeding = 3 seconds
+    }
+    """)
+    .withFallback(TestConfig.config)
+}
+
+class R2dbcExecutorSpec
+    extends ScalaTestWithActorTestKit(R2dbcExecutorSpec.config)
+    with AnyWordSpecLike
+    with TestDbLifecycle
+    with TestData
+    with LogCapturing {
+
+  override def typedSystem: ActorSystem[_] = system
+  private val table = "r2dbc_executor_spec"
+
+  case class Row(col: String)
+
+  override protected def beforeAll(): Unit = {
+    super.beforeAll()
+
+    Await.result(
+      r2dbcExecutor.executeDdl(s"beforeAll create table $table")(
+        _.createStatement(s"create table if not exists $table (col text)")),
+      20.seconds)
+
+    r2dbcExecutor.updateOne("test")(_.createStatement(s"delete from $table")).futureValue
+  }
+
+  "R2dbcExecutor" should {
+
+    "close connection when no response from update" in {
+      @volatile var c1: Connection = null
+      @volatile var c2: Connection = null
+
+      val result = r2dbcExecutor.update("test") { connection =>
+        c1 = connection.asInstanceOf[Wrapped[Connection]].unwrap()
+        Vector(
+          connection.createStatement(s"insert into $table (col) values ('a')"),
+          connection.createStatement("select pg_sleep(4)"),
+          connection.createStatement(s"insert into $table (col) values ('b')"))
+      }
+
+      Thread.sleep(r2dbcSettings.connectionFactorySettings.poolSettings.closeCallsExceeding.get.toMillis)
+
+      // The request will fail with PostgresConnectionClosedException
+      result.failed.futureValue shouldBe a[R2dbcNonTransientResourceException]
+
+      r2dbcExecutor
+        .selectOne("test")(
+          { connection =>
+            c2 = connection.asInstanceOf[Wrapped[Connection]].unwrap()
+            connection.createStatement(s"select col from $table where col = 'a'")
+          },
+          row => Row(row.get("col", classOf[String])))
+        .futureValue shouldBe None
+
+      r2dbcExecutor
+        .selectOne("test")(
+          _.createStatement(s"select col from $table where col = 'b'"),
+          row => Row(row.get("col", classOf[String])))
+        .futureValue shouldBe None
+
+      // it shouldn't reuse the connection
+      c1 should not be theSameInstanceAs(c2)
+    }
+
+    "close connection when no response from update with auto-commit" in {
+      val result = r2dbcExecutor.updateOne("test")(_.createStatement("select pg_sleep(4)"))
+
+      Thread.sleep(r2dbcSettings.connectionFactorySettings.poolSettings.closeCallsExceeding.get.toMillis)
+
+      // The request will fail with PostgresConnectionClosedException
+      result.failed.futureValue shouldBe a[R2dbcNonTransientResourceException]
+    }
+
+  }
+}

--- a/migration/src/main/scala/akka/persistence/r2dbc/migration/MigrationTool.scala
+++ b/migration/src/main/scala/akka/persistence/r2dbc/migration/MigrationTool.scala
@@ -133,7 +133,10 @@ class MigrationTool(system: ActorSystem[_]) {
     log.error("Migrating to H2 using the migration tool not currently supported")
   }
   private[r2dbc] val migrationDao =
-    new MigrationToolDao(targetConnectionFactory, targetR2dbcSettings.logDbCallsExceeding)
+    new MigrationToolDao(
+      targetConnectionFactory,
+      targetR2dbcSettings.logDbCallsExceeding,
+      targetR2dbcSettings.connectionFactorySettings.poolSettings.closeCallsExceeding)
 
   private lazy val createProgressTable: Future[Done] =
     migrationDao.createProgressTable()

--- a/migration/src/main/scala/akka/persistence/r2dbc/migration/MigrationToolDao.scala
+++ b/migration/src/main/scala/akka/persistence/r2dbc/migration/MigrationToolDao.scala
@@ -30,9 +30,12 @@ import org.slf4j.LoggerFactory
  */
 @InternalApi private[r2dbc] class MigrationToolDao(
     connectionFactory: ConnectionFactory,
-    logDbCallsExceeding: FiniteDuration)(implicit ec: ExecutionContext, system: ActorSystem[_]) {
+    logDbCallsExceeding: FiniteDuration,
+    closeCallsExceeding: Option[FiniteDuration])(implicit ec: ExecutionContext, system: ActorSystem[_]) {
   import MigrationToolDao._
-  private val r2dbcExecutor = new R2dbcExecutor(connectionFactory, log, logDbCallsExceeding)(ec, system)
+
+  private val r2dbcExecutor =
+    new R2dbcExecutor(connectionFactory, log, logDbCallsExceeding, closeCallsExceeding)(ec, system)
 
   def createProgressTable(): Future[Done] = {
     r2dbcExecutor.executeDdl("create migration progress table") { connection =>

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -76,5 +76,9 @@ object Dependencies {
       r2dbcH2)
 
   val docs =
-    Seq(TestDeps.akkaPersistenceTyped)
+    Seq(
+      // r2dbcPostgres is already a transitive dependency from core, but
+      // sometimes sbt doesn't understand that ¯\_(ツ)_/¯
+      r2dbcPostgres,
+      TestDeps.akkaPersistenceTyped)
 }


### PR DESCRIPTION
* The underlying connection is closed if timeout exceeded, and connection will not be reused by the pool.
* This timeout is needed to handle some failure scenarios, when the database server is terminated in a non graceful way and there is a load balancer in front. The client connection and current execution in progress would not be completed without this timeout, resulting in a "connection leak".
* Also adding config for server side statement timeout
* forward port, cherry picked from commit 6e8b236583fc541d8e89fa53cb23a6291ebaeb9a

Forward port of https://github.com/akka/akka-persistence-r2dbc/pull/419