### PR TITLE
chore: ConnectionPoolSettings from ConnectionFactoryProvider

### DIFF
--- a/core/src/main/scala/akka/persistence/r2dbc/ConnectionFactoryProvider.scala
+++ b/core/src/main/scala/akka/persistence/r2dbc/ConnectionFactoryProvider.scala
@@ -22,6 +22,7 @@ import scala.concurrent.Future
 import scala.concurrent.duration.Duration
 
 import akka.annotation.InternalApi
+import akka.annotation.InternalStableApi
 
 object ConnectionFactoryProvider extends ExtensionId[ConnectionFactoryProvider] {
   def createExtension(system: ActorSystem[_]): ConnectionFactoryProvider = new ConnectionFactoryProvider(system)
@@ -70,6 +71,13 @@ class ConnectionFactoryProvider(system: ActorSystem[_]) extends Extension {
       case settings => settings
     }
   }
+
+  /**
+   * INTERNAL API
+   */
+  @InternalStableApi
+  def connectionPoolSettingsFor(configLocation: String): ConnectionPoolSettings =
+    connectionFactorySettingsFor(configLocation).poolSettings
 
   private def createConnectionPoolFactory(
       settings: ConnectionPoolSettings,


### PR DESCRIPTION
* for the new closeCallsExceeding paramater in R2dbcExecutor, needed from R2dbcProjection
