### PR TITLE
fix: backtracking queries and filtered events

### DIFF
--- a/core/src/main/mima-filters/1.1.1.backwards.excludes/internal.BySliceQuery.QueryState.excludes
+++ b/core/src/main/mima-filters/1.1.1.backwards.excludes/internal.BySliceQuery.QueryState.excludes
@@ -1,0 +1,6 @@
+# changes to internal QueryState for tracking latest seen count for backtracking
+ProblemFilters.exclude[DirectMissingMethodProblem]("akka.persistence.r2dbc.internal.BySliceQuery#QueryState.apply")
+ProblemFilters.exclude[DirectMissingMethodProblem]("akka.persistence.r2dbc.internal.BySliceQuery#QueryState.copy")
+ProblemFilters.exclude[DirectMissingMethodProblem]("akka.persistence.r2dbc.internal.BySliceQuery#QueryState.this")
+ProblemFilters.exclude[IncompatibleResultTypeProblem]("akka.persistence.r2dbc.internal.BySliceQuery#QueryState.copy$default$8")
+ProblemFilters.exclude[IncompatibleSignatureProblem]("akka.persistence.r2dbc.internal.BySliceQuery#QueryState.unapply")

--- a/core/src/main/scala/akka/persistence/r2dbc/internal/BySliceQuery.scala
+++ b/core/src/main/scala/akka/persistence/r2dbc/internal/BySliceQuery.scala
@@ -305,8 +305,6 @@ import org.slf4j.Logger
           throw new IllegalArgumentException(
             s"Unexpected offset [$offset] before latestBacktracking [${state.latestBacktracking}].")
 
-        // TODO: Could be nicer to track the seen count in TimestampOffset itself, along with the latest seen map.
-        //       Either as a seen count directly, or as a range of seen sequence numbers for each persistence id.
         val newSeenCount =
           if (offset.timestamp == state.latestBacktracking.timestamp) state.latestBacktrackingSeenCount + 1 else 1
 

--- a/core/src/main/scala/akka/persistence/r2dbc/internal/BySliceQuery.scala
+++ b/core/src/main/scala/akka/persistence/r2dbc/internal/BySliceQuery.scala
@@ -31,7 +31,7 @@ import org.slf4j.Logger
 
   object QueryState {
     val empty: QueryState =
-      QueryState(TimestampOffset.Zero, 0, 0, 0, 0, backtrackingCount = 0, TimestampOffset.Zero, Buckets.empty)
+      QueryState(TimestampOffset.Zero, 0, 0, 0, 0, backtrackingCount = 0, TimestampOffset.Zero, 0, 0, Buckets.empty)
   }
 
   final case class QueryState(
@@ -42,6 +42,8 @@ import org.slf4j.Logger
       idleCount: Long,
       backtrackingCount: Int,
       latestBacktracking: TimestampOffset,
+      latestBacktrackingSeenCount: Int,
+      backtrackingExpectFiltered: Int,
       buckets: Buckets) {
 
     def backtracking: Boolean = backtrackingCount > 0
@@ -303,10 +305,29 @@ import org.slf4j.Logger
           throw new IllegalArgumentException(
             s"Unexpected offset [$offset] before latestBacktracking [${state.latestBacktracking}].")
 
-        state.copy(latestBacktracking = offset, rowCount = state.rowCount + 1)
+        // TODO: Could be nicer to track the seen count in TimestampOffset itself, along with the latest seen map.
+        //       Either as a seen count directly, or as a range of seen sequence numbers for each persistence id.
+        val newSeenCount =
+          if (offset.timestamp == state.latestBacktracking.timestamp) state.latestBacktrackingSeenCount + 1 else 1
+
+        state.copy(
+          latestBacktracking = offset,
+          latestBacktrackingSeenCount = newSeenCount,
+          rowCount = state.rowCount + 1)
+
       } else {
         if (offset.timestamp.isBefore(state.latest.timestamp))
           throw new IllegalArgumentException(s"Unexpected offset [$offset] before latest [${state.latest}].")
+
+        if (log.isDebugEnabled()) {
+          if (state.latestBacktracking.seen.nonEmpty &&
+            offset.timestamp.isAfter(state.latestBacktracking.timestamp.plus(firstBacktrackingQueryWindow)))
+            log.debugN(
+              "{} next offset is outside the backtracking window, latestBacktracking: [{}], offset: [{}]",
+              logPrefix,
+              state.latestBacktracking,
+              offset)
+        }
 
         state.copy(latest = offset, rowCount = state.rowCount + 1)
       }
@@ -338,7 +359,7 @@ import org.slf4j.Logger
     }
 
     def switchFromBacktracking(state: QueryState): Boolean = {
-      state.backtracking && state.rowCount < settings.querySettings.bufferSize - 1
+      state.backtracking && state.rowCount < settings.querySettings.bufferSize - state.backtrackingExpectFiltered
     }
 
     def nextQuery(state: QueryState): (QueryState, Option[Source[Envelope, NotUsed]]) = {
@@ -368,7 +389,8 @@ import org.slf4j.Logger
             queryCount = state.queryCount + 1,
             idleCount = newIdleCount,
             backtrackingCount = 1,
-            latestBacktracking = fromOffset)
+            latestBacktracking = fromOffset,
+            backtrackingExpectFiltered = state.latestBacktrackingSeenCount)
         } else if (switchFromBacktracking(state)) {
           // switch from backtracking
           state.copy(
@@ -385,7 +407,8 @@ import org.slf4j.Logger
             rowCountSinceBacktracking = state.rowCountSinceBacktracking + state.rowCount,
             queryCount = state.queryCount + 1,
             idleCount = newIdleCount,
-            backtrackingCount = newBacktrackingCount)
+            backtrackingCount = newBacktrackingCount,
+            backtrackingExpectFiltered = state.latestBacktrackingSeenCount)
         }
 
       val behindCurrentTime =

--- a/core/src/test/scala/akka/persistence/r2dbc/query/EventsBySliceBacktrackingSpec.scala
+++ b/core/src/test/scala/akka/persistence/r2dbc/query/EventsBySliceBacktrackingSpec.scala
@@ -5,6 +5,7 @@
 package akka.persistence.r2dbc.query
 
 import java.time.Instant
+import java.time.temporal.ChronoUnit
 
 import scala.concurrent.duration._
 
@@ -15,6 +16,7 @@ import akka.actor.typed.scaladsl.LoggerOps
 import akka.persistence.query.NoOffset
 import akka.persistence.query.Offset
 import akka.persistence.query.PersistenceQuery
+import akka.persistence.query.TimestampOffset
 import akka.persistence.query.typed.EventEnvelope
 import akka.persistence.r2dbc.R2dbcSettings
 import akka.persistence.r2dbc.internal.PayloadCodec
@@ -35,9 +37,12 @@ import org.scalatest.wordspec.AnyWordSpecLike
 import org.slf4j.LoggerFactory
 
 object EventsBySliceBacktrackingSpec {
+  private val BufferSize = 10 // small buffer for testing
+
   private val config = ConfigFactory
-    .parseString("""
+    .parseString(s"""
     akka.persistence.r2dbc.journal.publish-events = off
+    akka.persistence.r2dbc.query.buffer-size = $BufferSize
     """)
     .withFallback(TestConfig.config)
 }
@@ -227,6 +232,53 @@ class EventsBySliceBacktrackingSpec
       expect(result2.expectNext(), pid2, 3L, Some("e2-3"))
 
     }
+
+    "predict backtracking filtered events based on latest seen counts" in {
+      val entityType = nextEntityType()
+      val pid = nextPid(entityType)
+      val slice = query.sliceForPersistenceId(pid)
+      val sinkProbe = TestSink[EventEnvelope[String]]()(system.classicSystem)
+
+      // use times in the past well outside behind-current-time
+      val timeZero = InstantFactory.now().truncatedTo(ChronoUnit.SECONDS).minusSeconds(10 * 60)
+
+      // events around the buffer size (of 10) will share the same timestamp
+      // to test tracking of seen events that will be filtered on the next cycle
+
+      val numberOfCycles = 5 // loop through the grouped events this many times
+      val maxGroupSize = 7 // max size for groups of events that share the same timestamp
+      val eventsPerCycle = maxGroupSize * (maxGroupSize + 1) / 2 // each cycle has groups of size 1 to maxGroupSize
+      val numberOfEvents = numberOfCycles * eventsPerCycle // total number of events that will be generated
+
+      // generate a timestamp pattern like 1, 2, 2, 4, 4, 4, 7, 7, 7, 7, 11, 11, 11, 11, 11, ...
+      for (cycle <- 1 to numberOfCycles) {
+        for (groupSize <- 1 to maxGroupSize) {
+          for (shift <- 1 to groupSize) {
+            val seqNr = (cycle - 1) * eventsPerCycle + (groupSize - 1) * groupSize / 2 + shift
+            val eventTime = seqNr - shift + 1
+            writeEvent(slice, pid, seqNr, timeZero.plusMillis(eventTime), s"event-$pid-$seqNr")
+          }
+        }
+      }
+
+      // start the query with a latest timestamp ahead of all events, to only run in backtracking mode
+      val latestOffset = TimestampOffset(timeZero.plusMillis(numberOfEvents + 1), Map.empty)
+
+      val result: TestSubscriber.Probe[EventEnvelope[String]] =
+        query
+          .eventsBySlices[String](entityType, 0, persistenceExt.numberOfSlices - 1, latestOffset)
+          .runWith(sinkProbe)
+          .request(numberOfEvents)
+
+      // test that backtracking queries continued through all the written events, catching up with latest offset
+      for (seqNr <- 1 to numberOfEvents) {
+        val envelope = result.expectNext()
+        envelope.persistenceId shouldBe pid
+        envelope.sequenceNr shouldBe seqNr
+        envelope.source shouldBe EnvelopeOrigin.SourceBacktracking
+      }
+    }
+
   }
 
 }


### PR DESCRIPTION
Backtracking queries can stop too early. This can create a gap between the normal db queries and the backtracking queries that's longer than the backtracking window, and if a projection instance is then restarted, there are events that are completely missed, or rejected because of earlier missed events.

The switch-from-backtracking check compares how many rows were returned by the past query to the buffer size - 1. The 1 is for the event at the initial timestamp, which has already been seen by the previous query and will be filtered from the result. If there are events that share timestamps (because they were emitted together), then there can be multiple events filtered out of the result set. In this case, it will switch from backtracking mode before catching up, and while it can still progress one query at a time, it can fall too far behind.

Fix this by keeping track of the seen count for the latest timestamp when backtracking, and then copying this over as the number of events expected to be filtered for the next query. Added this to the internal state here for now, but could be nicer to have it in TimestampOffset itself — for something compatible, there could be an additional map of seen counts, or first seen sequence numbers, along with the latest seen map.

This should fix the underlying issue for #444.

Based on `release-1.1` first, from testing with Kalix, and can then forward-port to main.