### PR TITLE
fix: backtracking queries and filtered events (#445)

### DIFF
--- a/core/src/main/mima-filters/1.1.1.backwards.excludes/internal.BySliceQuery.QueryState.excludes
+++ b/core/src/main/mima-filters/1.1.1.backwards.excludes/internal.BySliceQuery.QueryState.excludes
@@ -1,0 +1,6 @@
+# changes to internal QueryState for tracking latest seen count for backtracking
+ProblemFilters.exclude[DirectMissingMethodProblem]("akka.persistence.r2dbc.internal.BySliceQuery#QueryState.apply")
+ProblemFilters.exclude[DirectMissingMethodProblem]("akka.persistence.r2dbc.internal.BySliceQuery#QueryState.copy")
+ProblemFilters.exclude[DirectMissingMethodProblem]("akka.persistence.r2dbc.internal.BySliceQuery#QueryState.this")
+ProblemFilters.exclude[IncompatibleResultTypeProblem]("akka.persistence.r2dbc.internal.BySliceQuery#QueryState.copy$default$8")
+ProblemFilters.exclude[IncompatibleSignatureProblem]("akka.persistence.r2dbc.internal.BySliceQuery#QueryState.unapply")

--- a/core/src/main/mima-filters/1.2.0-M4.backwards.excludes/internal.BySliceQuery.QueryState.excludes
+++ b/core/src/main/mima-filters/1.2.0-M4.backwards.excludes/internal.BySliceQuery.QueryState.excludes
@@ -1,0 +1,6 @@
+# changes to internal QueryState for tracking latest seen count for backtracking
+ProblemFilters.exclude[DirectMissingMethodProblem]("akka.persistence.r2dbc.internal.BySliceQuery#QueryState.apply")
+ProblemFilters.exclude[DirectMissingMethodProblem]("akka.persistence.r2dbc.internal.BySliceQuery#QueryState.copy")
+ProblemFilters.exclude[DirectMissingMethodProblem]("akka.persistence.r2dbc.internal.BySliceQuery#QueryState.this")
+ProblemFilters.exclude[IncompatibleResultTypeProblem]("akka.persistence.r2dbc.internal.BySliceQuery#QueryState.copy$default$8")
+ProblemFilters.exclude[IncompatibleSignatureProblem]("akka.persistence.r2dbc.internal.BySliceQuery#QueryState.unapply")


### PR DESCRIPTION
Forward port of https://github.com/akka/akka-persistence-r2dbc/pull/445

* update: add mima filters for QueryState

(cherry picked from commit 6c465cbccd864196c20ab50626c9300d6d74c6fb)
