### PR TITLE
fix: explicitly set isolation level to read committed

### DIFF
--- a/core/src/main/scala/akka/persistence/r2dbc/internal/R2dbcExecutor.scala
+++ b/core/src/main/scala/akka/persistence/r2dbc/internal/R2dbcExecutor.scala
@@ -25,6 +25,7 @@ import akka.annotation.InternalStableApi
 import akka.dispatch.ExecutionContexts
 import io.r2dbc.spi.Connection
 import io.r2dbc.spi.ConnectionFactory
+import io.r2dbc.spi.IsolationLevel
 import io.r2dbc.spi.Result
 import io.r2dbc.spi.Row
 import io.r2dbc.spi.Statement
@@ -268,7 +269,7 @@ class R2dbcExecutor(
   def withConnection[A](logPrefix: String)(fun: Connection => Future[A]): Future[A] = {
     getConnection(logPrefix).flatMap { connection =>
       val startTime = nanoTime()
-      connection.beginTransaction().asFutureDone().flatMap { _ =>
+      connection.beginTransaction(IsolationLevel.READ_COMMITTED).asFutureDone().flatMap { _ =>
         val timeoutTask = closeCallsExceeding.map { timeout =>
           system.scheduler.scheduleOnce(timeout, () => closeAfterTimeout(connection))
         }


### PR DESCRIPTION
Refs https://github.com/akka/akka-projection/issues/992.

When trying to reproduce in https://github.com/akka/akka-projection/pull/997, it behaves as if it's not read committed — which is expected to be the [default for H2](https://www.h2database.com/html/advanced.html#transaction_isolation)? But when setting it explicitly, can no longer reproduce the issue. So is it not actually the default?

Experimental draft for further checking and testing.