### PR TITLE
chore: change docs project name to disambiguate from  in pom files

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -130,7 +130,7 @@ lazy val docs = project
   .settings(common)
   .settings(dontPublish)
   .settings(
-    name := "Akka Persistence R2DBC",
+    name := "Akka Persistence plugin for R2DBC",
     libraryDependencies ++= Dependencies.docs,
     makeSite := makeSite.dependsOn(LocalRootProject / ScalaUnidoc / doc).value,
     previewPath := (Paradox / siteSubdirName).value,


### PR DESCRIPTION
As it turns out, sbt translates the project name into the pom identifier `artifactId`. This PR changes the project name for the documentation sbt project so that sbt creates unique pom identifiers for the core project and the docs project. This helps other tools to consume the pom files correctly.