### PR TITLE
feat: Cleanup events by time

### DIFF
--- a/core/src/main/scala/akka/persistence/r2dbc/cleanup/javadsl/EventSourcedCleanup.scala
+++ b/core/src/main/scala/akka/persistence/r2dbc/cleanup/javadsl/EventSourcedCleanup.scala
@@ -4,6 +4,7 @@
 
 package akka.persistence.r2dbc.cleanup.javadsl
 
+import java.time.Instant
 import java.util.concurrent.CompletionStage
 import java.util.{ List => JList }
 
@@ -63,6 +64,44 @@ final class EventSourcedCleanup private (delegate: scaladsl.EventSourcedCleanup)
    */
   def deleteAllEvents(persistenceIds: JList[String], resetSequenceNumber: Boolean): CompletionStage[Done] =
     delegate.deleteAllEvents(persistenceIds.asScala.toVector, resetSequenceNumber).toJava
+
+  /**
+   * Delete events before a timestamp for the given persistence id. Snapshots are not deleted.
+   *
+   * This can be useful for `DurableStateBehavior` with change events, where the events are only used for the
+   * Projections and not for the recovery of the `DurableStateBehavior` state. The timestamp may correspond to the the
+   * offset timestamp of the Projections, if events are not needed after all Projections have processed them.
+   *
+   * Be aware of that if all events of a persistenceId are removed the sequence number will start from 1 again if an
+   * `EventSourcedBehavior` with the same persistenceId is used again.
+   *
+   * @param persistenceId
+   *   the persistence id to delete for
+   * @param timestamp
+   *   timestamp (exclusive) to delete up to
+   */
+  def deleteEventsBefore(persistenceId: String, timestamp: Instant): CompletionStage[Done] =
+    delegate.deleteEventsBefore(persistenceId, timestamp).toJava
+
+  /**
+   * Delete events before a timestamp for the given entityType and slice. Snapshots are not deleted.
+   *
+   * This can be useful for `DurableStateBehavior` with change events, where the events are only used for the
+   * Projections and not for the recovery of the `DurableStateBehavior` state. The timestamp may correspond to the the
+   * offset timestamp of the Projections, if events are not needed after all Projections have processed them.
+   *
+   * Be aware of that if all events of a persistenceId are removed the sequence number will start from 1 again if an
+   * `EventSourcedBehavior` with the same persistenceId is used again.
+   *
+   * @param entityType
+   *   the entity type to delete for
+   * @param slice
+   *   the slice to delete for
+   * @param timestamp
+   *   timestamp (exclusive) to delete up to
+   */
+  def deleteEventsBefore(entityType: String, slice: Int, timestamp: Instant): CompletionStage[Done] =
+    delegate.deleteEventsBefore(entityType, slice, timestamp).toJava
 
   /**
    * Delete snapshots related to one single `persistenceId`. Events are not deleted.

--- a/core/src/main/scala/akka/persistence/r2dbc/internal/JournalDao.scala
+++ b/core/src/main/scala/akka/persistence/r2dbc/internal/JournalDao.scala
@@ -62,4 +62,8 @@ private[r2dbc] trait JournalDao {
 
   def deleteEventsTo(persistenceId: String, toSequenceNr: Long, resetSequenceNumber: Boolean): Future[Unit]
 
+  def deleteEventsBefore(persistenceId: String, timestamp: Instant): Future[Unit]
+
+  def deleteEventsBefore(entityType: String, slice: Int, timestamp: Instant): Future[Unit]
+
 }

--- a/core/src/main/scala/akka/persistence/r2dbc/internal/postgres/PostgresJournalDao.scala
+++ b/core/src/main/scala/akka/persistence/r2dbc/internal/postgres/PostgresJournalDao.scala
@@ -123,6 +123,14 @@ private[r2dbc] class PostgresJournalDao(journalSettings: R2dbcSettings, connecti
     (slice, entity_type, persistence_id, seq_nr, db_timestamp, writer, adapter_manifest, event_ser_id, event_ser_manifest, event_payload, deleted)
     VALUES (?, ?, ?, ?, CURRENT_TIMESTAMP, ?, ?, ?, ?, ?, ?)"""
 
+  private val deleteEventsByPersistenceIdBeforeTimestampSql = sql"""
+    DELETE FROM $journalTable
+    WHERE persistence_id = ? AND db_timestamp < ?"""
+
+  private val deleteEventsBySliceBeforeTimestampSql = sql"""
+    DELETE FROM $journalTable
+    WHERE slice = ? AND entity_type = ? AND db_timestamp < ?"""
+
   /**
    * All events must be for the same persistenceId.
    *
@@ -337,6 +345,37 @@ private[r2dbc] class PostgresJournalDao(journalSettings: R2dbcSettings, connecti
       fromSeqNr <- lowestSequenceNrForDelete(persistenceId, toSeqNr, batchSize)
       _ <- deleteInBatches(fromSeqNr, toSeqNr)
     } yield ()
+  }
+
+  override def deleteEventsBefore(persistenceId: String, timestamp: Instant): Future[Unit] = {
+    r2dbcExecutor
+      .updateOne(s"delete [$persistenceId]") { connection =>
+        connection
+          .createStatement(deleteEventsByPersistenceIdBeforeTimestampSql)
+          .bind(0, persistenceId)
+          .bind(1, timestamp)
+      }
+      .map(deletedRows =>
+        log.debugN("Deleted [{}] events for persistenceId [{}], before [{}]", deletedRows, persistenceId, timestamp))(
+        ExecutionContexts.parasitic)
+  }
+
+  override def deleteEventsBefore(entityType: String, slice: Int, timestamp: Instant): Future[Unit] = {
+    r2dbcExecutor
+      .updateOne(s"delete [$entityType]") { connection =>
+        connection
+          .createStatement(deleteEventsBySliceBeforeTimestampSql)
+          .bind(0, slice)
+          .bind(1, entityType)
+          .bind(2, timestamp)
+      }
+      .map(deletedRows =>
+        log.debugN(
+          "Deleted [{}] events for entityType [{}], slice [{}], before [{}]",
+          deletedRows,
+          entityType,
+          slice,
+          timestamp))(ExecutionContexts.parasitic)
   }
 
 }

--- a/docs/src/main/paradox/cleanup.md
+++ b/docs/src/main/paradox/cleanup.md
@@ -30,6 +30,7 @@ not emit further events after that and typically stop itself if it receives more
 * Delete all events for one or many persistence ids
 * Delete all snapshots for one or many persistence ids
 * Delete events before snapshot for one or many persistence ids
+* Delete events before a timestamp
 
 The cleanup tool can be combined with the @ref[query plugin](./query.md) which has a query to get all persistence ids.
 


### PR DESCRIPTION
* This can be useful for `DurableStateBehavior` with change events, where the events are only used for the Projections and not for the recovery of the `DurableStateBehavior` state. The timestamp may correspond to the the offset timestamp of the Projections, if events are not needed after all Projections have processed them.
