### PR TITLE
feat: Migration of Durable State, #504

### DIFF
--- a/core/src/test/scala/akka/persistence/r2dbc/TestActors.scala
+++ b/core/src/test/scala/akka/persistence/r2dbc/TestActors.scala
@@ -146,7 +146,10 @@ object TestActors {
     def apply(pid: String): Behavior[Command] =
       apply(PersistenceId.ofUniqueId(pid))
 
-    def apply(pid: PersistenceId): Behavior[Command] = {
+    def apply(pid: PersistenceId): Behavior[Command] =
+      apply(pid, storePluginId = "")
+
+    def apply(pid: PersistenceId, storePluginId: String): Behavior[Command] = {
       Behaviors.setup { context =>
         DurableStateBehavior[Command, Any](
           persistenceId = pid,
@@ -185,6 +188,7 @@ object TestActors {
                 Effect.stop()
             }
           })
+          .withDurableStateStorePluginId(storePluginId)
       }
     }
   }

--- a/docs/src/main/paradox/migration.md
+++ b/docs/src/main/paradox/migration.md
@@ -30,9 +30,10 @@ Additionally, add the dependency as below.
 ## Progress table
 
 To speed up processing of subsequent runs it stores migrated persistence ids and sequence
-numbers in the table `migration_progress`. In a subsequent run it will only migrate new events and snapshots
-compared to what was stored in `migration_progress`. It will also find and migrate new persistence ids in a
-subsequent run. You can delete from `migration_progress` if you want to re-run the full migration.
+numbers in the table `migration_progress`. In a subsequent run it will only migrate new events, snapshots
+and durable states compared to what was stored in `migration_progress`. It will also find and migrate
+new persistence ids in a subsequent run. You can delete from `migration_progress` if you want to
+re-run the full migration.
 
 It's recommended that you create the `migration_progress` table before running the migration tool, but
 if it doesn't exist the tool will try to create the table.
@@ -42,13 +43,22 @@ CREATE TABLE IF NOT EXISTS migration_progress(
   persistence_id VARCHAR(255) NOT NULL,
   event_seq_nr BIGINT,
   snapshot_seq_nr BIGINT,
+  state_revision  BIGINT,
   PRIMARY KEY(persistence_id)
 ```
 
-## Configuration
+## Running
 
 The migration tool can be run as main class `akka.persistence.r2dbc.migration.MigrationTool` provided by the above
-`akka-persistence-r2dbc-migration` dependency.
+`akka-persistence-r2dbc-migration` dependency. The main method will run `MigrationTool.migrateAll`.
+
+@@@ note
+
+Durable State is not migrated by `MigrationTool.migrateAll`, instead you need to use `MigrationTool.migrateDurableStates` for a given list of persistence ids.
+
+@@@ note
+
+## Configuration
 
 You need to provide configuration for the source persistence plugin and the target Rd2BC plugin in your `application.conf`. An example of such configuration for migration from Akka Persistence JDBC: 
 
@@ -59,6 +69,11 @@ You need to provide configuration for the source persistence plugin and the targ
 Application specific serializers for events and snapshots must also be configured and included in classpath.
 
 @@@
+
+When running the migration tool for Durable State the single writer assertion must be disabled with configuration:
+```hcon
+akka.persistence.r2dbc.state.assert-single-writer = off
+```
 
 ### Reference configuration
 

--- a/migration/src/main/resources/reference.conf
+++ b/migration/src/main/resources/reference.conf
@@ -6,6 +6,7 @@ akka.persistence.r2dbc.migration {
   source {
     query-plugin-id = "jdbc-read-journal"
     snapshot-plugin-id = "jdbc-snapshot-store"
+    durable-state-plugin-id = "jdbc-durable-state-store"
   }
 
   # R2DBC Akka Persistence plugin to migrate to.

--- a/migration/src/main/scala/akka/persistence/r2dbc/migration/MigrationTool.scala
+++ b/migration/src/main/scala/akka/persistence/r2dbc/migration/MigrationTool.scala
@@ -5,12 +5,14 @@
 package akka.persistence.r2dbc.migration
 
 import java.time.Instant
+
 import scala.concurrent.ExecutionContext
 import scala.concurrent.Future
 import scala.concurrent.duration._
 import scala.util.Failure
 import scala.util.Success
 import scala.util.Try
+
 import akka.Done
 import akka.actor.typed.ActorSystem
 import akka.actor.typed.Behavior
@@ -46,6 +48,12 @@ import akka.util.Timeout
 import io.r2dbc.spi.R2dbcDataIntegrityViolationException
 import org.slf4j.LoggerFactory
 
+import akka.persistence.r2dbc.internal.DurableStateDao.SerializedStateRow
+import akka.persistence.state.DurableStateStoreRegistry
+import akka.persistence.state.scaladsl.DurableStateStore
+import akka.persistence.state.scaladsl.GetObjectResult
+import akka.stream.scaladsl.Source
+
 object MigrationTool {
   def main(args: Array[String]): Unit = {
     ActorSystem(MigrationTool(), "MigrationTool")
@@ -54,8 +62,12 @@ object MigrationTool {
   object Result {
     val empty: Result = Result(0, 0, 0)
   }
-
   final case class Result(persistenceIds: Long, events: Long, snapshots: Long)
+
+  object DurableStateResult {
+    val empty: DurableStateResult = DurableStateResult(0, 0)
+  }
+  final case class DurableStateResult(persistenceIds: Long, states: Long)
 
   private def apply(): Behavior[Try[Result]] = {
     Behaviors.setup { context =>
@@ -73,6 +85,8 @@ object MigrationTool {
       }
     }
   }
+
+  private final case class SelectedDurableState(persistenceId: String, revision: Long, value: Any)
 
 }
 
@@ -94,7 +108,8 @@ object MigrationTool {
  * Note: tags are not migrated.
  */
 class MigrationTool(system: ActorSystem[_]) {
-  import MigrationTool.Result
+  import MigrationTool.{ DurableStateResult, Result }
+  import MigrationTool.SelectedDurableState
   import system.executionContext
   private implicit val sys: ActorSystem[_] = system
 
@@ -118,6 +133,9 @@ class MigrationTool(system: ActorSystem[_]) {
   private val targetSnapshotDao =
     targetR2dbcSettings.connectionFactorySettings.dialect
       .createSnapshotDao(targetR2dbcSettings, targetConnectionFactory)
+  private val targetDurableStateDao =
+    targetR2dbcSettings.connectionFactorySettings.dialect
+      .createDurableStateDao(targetR2dbcSettings, targetConnectionFactory)
 
   private val targetBatch = migrationConfig.getInt("target.batch")
 
@@ -128,6 +146,10 @@ class MigrationTool(system: ActorSystem[_]) {
 
   private val sourceSnapshotPluginId = migrationConfig.getString("source.snapshot-plugin-id")
   private lazy val sourceSnapshotStore = Persistence(system).snapshotStoreFor(sourceSnapshotPluginId)
+
+  private val sourceDurableStatePluginId = migrationConfig.getString("source.durable-state-plugin-id")
+  private lazy val sourceDurableStateStore =
+    DurableStateStoreRegistry(system).durableStateStoreFor[DurableStateStore[Any]](sourceDurableStatePluginId)
 
   if (targetR2dbcSettings.dialectName == "h2") {
     log.error("Migrating to H2 using the migration tool not currently supported")
@@ -142,8 +164,10 @@ class MigrationTool(system: ActorSystem[_]) {
     migrationDao.createProgressTable()
 
   /**
-   * Migrates events and snapshots for all persistence ids.
-   * @return
+   * Migrates events, snapshots for all persistence ids.
+   *
+   * Note that Durable State is not migrated by this method, instead you need to use
+   * [[MigrationTool#migrateDurableStates]] for a given list of persistence ids.
    */
   def migrateAll(): Future[Result] = {
     log.info("Migration started.")
@@ -343,6 +367,115 @@ class MigrationTool(system: ActorSystem[_]) {
         .map(result => result.snapshot.flatMap(s => if (s.metadata.sequenceNr >= minSequenceNr) Some(s) else None))
     }
 
+  }
+
+  /**
+   * Migrate Durable State for a list of persistence ids.
+   */
+  def migrateDurableStates(persistenceIds: Seq[String]): Future[DurableStateResult] = {
+    log.info("Migration started.")
+    val result =
+      Source(persistenceIds)
+        .mapAsyncUnordered(parallelism) { persistenceId =>
+          for {
+            _ <- createProgressTable
+            currentProgress <- migrationDao.currentProgress(persistenceId)
+            stateCount <- migrateDurableState(persistenceId, currentProgress)
+          } yield persistenceId -> DurableStateResult(1, stateCount)
+        }
+        .map { case (pid, result @ DurableStateResult(_, states)) =>
+          log.debugN("Migrated persistenceId [{}] with [{}] durable state.", pid, states)
+          result
+        }
+        .runWith(Sink.fold(DurableStateResult.empty) { case (acc, DurableStateResult(_, states)) =>
+          val result = DurableStateResult(acc.persistenceIds + 1, acc.states + states)
+          if (result.persistenceIds % 100 == 0)
+            log.infoN("Migrated [{}] persistenceIds with [{}] durable states.", result.persistenceIds, result.states)
+          result
+        })
+
+    result.transform {
+      case s @ Success(DurableStateResult(persistenceIds, states)) =>
+        log.infoN(
+          "Migration successful. Migrated [{}] persistenceIds with [{}] durable states.",
+          persistenceIds,
+          states)
+        s
+      case f @ Failure(exc) =>
+        log.error("Migration failed.", exc)
+        f
+    }
+  }
+
+  /**
+   * Migrate Durable State for a single persistence id.
+   */
+  def migrateDurableState(persistenceId: String): Future[Int] = {
+    for {
+      _ <- createProgressTable
+      currentProgress <- migrationDao.currentProgress(persistenceId)
+      stateCount <- migrateDurableState(persistenceId, currentProgress)
+    } yield stateCount
+  }
+
+  private def migrateDurableState(persistenceId: String, currentProgress: Option[CurrentProgress]): Future[Int] = {
+    val progressRevision = currentProgress.map(_.durableStateRevision).getOrElse(0L)
+    loadSourceDurableState(persistenceId, progressRevision + 1).flatMap {
+      case None => Future.successful(0)
+      case Some(selectedDurableState) =>
+        for {
+          revision <- {
+            val serializedRow = serializedDurableStateRow(selectedDurableState)
+            targetDurableStateDao
+              .upsertState(serializedRow, selectedDurableState.value, changeEvent = None)
+              .map(_ => selectedDurableState.revision)(ExecutionContexts.parasitic)
+          }
+          _ <- migrationDao.updateDurableStateProgress(persistenceId, revision)
+        } yield 1
+    }
+  }
+
+  private lazy val checkAssertSingleWriter: Unit = {
+    if (targetR2dbcSettings.durableStateAssertSingleWriter) {
+      throw new IllegalArgumentException(
+        "When running the MigrationTool the " +
+        "`akka.persistence.r2dbc.state.assert-single-writer` configuration must be set to off.")
+    }
+  }
+
+  private def serializedDurableStateRow(selectedDurableState: SelectedDurableState): SerializedStateRow = {
+    val stateAnyRef = selectedDurableState.value.asInstanceOf[AnyRef]
+    val serializedState = serialization.serialize(stateAnyRef).get
+    val stateSerializer = serialization.findSerializerFor(stateAnyRef)
+    val stateManifest = Serializers.manifestFor(stateSerializer, stateAnyRef)
+
+    // not possible to preserve timestamp
+    val timestamp = Instant.now()
+
+    val serializedRow = SerializedStateRow(
+      selectedDurableState.persistenceId,
+      selectedDurableState.revision,
+      timestamp,
+      timestamp,
+      Some(serializedState),
+      stateSerializer.identifier,
+      stateManifest,
+      tags = Set.empty // not possible to preserve tags
+    )
+    serializedRow
+  }
+
+  private def loadSourceDurableState(persistenceId: String, minRevision: Long): Future[Option[SelectedDurableState]] = {
+    if (sourceDurableStatePluginId == "")
+      Future.successful(None)
+    else
+      sourceDurableStateStore
+        .getObject(persistenceId)
+        .map {
+          case GetObjectResult(Some(value), revision) if revision >= minRevision =>
+            Some(SelectedDurableState(persistenceId, revision, value))
+          case _ => None
+        }
   }
 
 }


### PR DESCRIPTION
* adding Durable State to the MigrationTool
* currently doesn't support retrieval of all persistenceIds because the jdbc plugin doesn't implement PersistenceIdsQuery, and jdbc plugin is currently the only other know plugin for durable state

References #504
