### PR TITLE
build: Bump plugins to only download from maven central

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -10,8 +10,8 @@ addSbtPlugin("com.github.sbt" % "sbt-ci-release" % "1.5.12")
 
 //// docs
 addSbtPlugin("com.lightbend.paradox" % "sbt-paradox-dependencies" % "0.2.4")
-addSbtPlugin("com.lightbend.akka" % "sbt-paradox-akka" % "0.53")
-addSbtPlugin("com.lightbend.sbt" % "sbt-publish-rsync" % "0.2")
+addSbtPlugin("com.lightbend.akka" % "sbt-paradox-akka" % "0.54")
+addSbtPlugin("com.lightbend.sbt" % "sbt-publish-rsync" % "0.3")
 addSbtPlugin("com.github.sbt" % "sbt-unidoc" % "0.5.0")
 addSbtPlugin("com.github.sbt" % "sbt-site-paradox" % "1.5.0")
 


### PR DESCRIPTION
As the other repos are unstable/going away: https://contributors.scala-lang.org/t/roadmap-for-the-sbt-community-repository/6195