### PR TITLE
chore: Make Sql.Interpolation backwards compatible

### DIFF
--- a/core/src/main/mima-filters/1.2.1.backwards.excludes/mssql-dialect.excludes
+++ b/core/src/main/mima-filters/1.2.1.backwards.excludes/mssql-dialect.excludes
@@ -1,8 +1,4 @@
 ProblemFilters.exclude[DirectMissingMethodProblem]("akka.persistence.r2dbc.R2dbcSettings.this")
-ProblemFilters.exclude[MissingClassProblem]("akka.persistence.r2dbc.internal.Sql$Interpolation$")
-ProblemFilters.exclude[DirectMissingMethodProblem]("akka.persistence.r2dbc.internal.Sql.Interpolation")
-ProblemFilters.exclude[DirectMissingMethodProblem]("akka.persistence.r2dbc.internal.Sql.Interpolation")
-ProblemFilters.exclude[DirectMissingMethodProblem]("akka.persistence.r2dbc.internal.Sql#Interpolation.this")
 ProblemFilters.exclude[MissingClassProblem]("akka.persistence.r2dbc.internal.h2.H2Utils")
 ProblemFilters.exclude[MissingClassProblem]("akka.persistence.r2dbc.internal.h2.H2Utils$")
 ProblemFilters.exclude[IncompatibleResultTypeProblem]("akka.persistence.r2dbc.R2dbcSettings.journalPayloadCodec")

--- a/core/src/main/scala/akka/persistence/r2dbc/R2dbcSettings.scala
+++ b/core/src/main/scala/akka/persistence/r2dbc/R2dbcSettings.scala
@@ -54,20 +54,11 @@ object R2dbcSettings {
           s"Expected akka.persistence.r2dbc.$prefix.payload-column-type to be one of 'BYTEA', 'JSON' or 'JSONB' but found '$t'")
     }
 
-    val journalPayloadCodec: PayloadCodec =
-      if (useJsonPayload("journal")) PayloadCodec.JsonCodec else PayloadCodec.ByteArrayCodec
-
     val journalPublishEvents: Boolean = config.getBoolean("journal.publish-events")
 
     val snapshotsTable: String = config.getString("snapshot.table")
 
-    val snapshotPayloadCodec: PayloadCodec =
-      if (useJsonPayload("snapshot")) PayloadCodec.JsonCodec else PayloadCodec.ByteArrayCodec
-
     val durableStateTable: String = config.getString("state.table")
-
-    val durableStatePayloadCodec: PayloadCodec =
-      if (useJsonPayload("state")) PayloadCodec.JsonCodec else PayloadCodec.ByteArrayCodec
 
     val durableStateTableByEntityType: Map[String, String] =
       configToMap(config.getConfig("state.custom-table"))
@@ -88,18 +79,6 @@ object R2dbcSettings {
 
     val connectionFactorySettings = ConnectionFactorySettings(config.getConfig("connection-factory"))
 
-    val (tagsCodec: TagsCodec, timestampCodec: TimestampCodec, queryAdapter: QueryAdapter) = {
-      connectionFactorySettings.dialect.name match {
-        case "sqlserver" =>
-          (
-            new TagsCodec.SqlServerTagsCodec(connectionFactorySettings.config),
-            TimestampCodec.SqlServerTimestampCodec,
-            SqlServerQueryAdapter)
-        case "h2" => (TagsCodec.H2TagsCodec, TimestampCodec.H2TimestampCodec, IdentityAdapter)
-        case _    => (TagsCodec.PostgresTagsCodec, TimestampCodec.PostgresTimestampCodec, IdentityAdapter)
-      }
-    }
-
     val querySettings = new QuerySettings(config.getConfig("query"))
 
     val dbTimestampMonotonicIncreasing: Boolean = config.getBoolean("db-timestamp-monotonic-increasing")
@@ -112,24 +91,55 @@ object R2dbcSettings {
         case _     => config.getDuration("log-db-calls-exceeding").asScala
       }
 
+    val codecSettings = {
+      val journalPayloadCodec: PayloadCodec =
+        if (useJsonPayload("journal")) PayloadCodec.JsonCodec else PayloadCodec.ByteArrayCodec
+      val snapshotPayloadCodec: PayloadCodec =
+        if (useJsonPayload("snapshot")) PayloadCodec.JsonCodec else PayloadCodec.ByteArrayCodec
+      val durableStatePayloadCodec: PayloadCodec =
+        if (useJsonPayload("state")) PayloadCodec.JsonCodec else PayloadCodec.ByteArrayCodec
+
+      connectionFactorySettings.dialect.name match {
+        case "sqlserver" =>
+          new CodecSettings(
+            journalPayloadCodec,
+            snapshotPayloadCodec,
+            durableStatePayloadCodec,
+            tagsCodec = new TagsCodec.SqlServerTagsCodec(connectionFactorySettings.config),
+            timestampCodec = TimestampCodec.SqlServerTimestampCodec,
+            queryAdapter = SqlServerQueryAdapter)
+        case "h2" =>
+          new CodecSettings(
+            journalPayloadCodec,
+            snapshotPayloadCodec,
+            durableStatePayloadCodec,
+            tagsCodec = TagsCodec.H2TagsCodec,
+            timestampCodec = TimestampCodec.H2TimestampCodec,
+            queryAdapter = IdentityAdapter)
+        case _ =>
+          new CodecSettings(
+            journalPayloadCodec,
+            snapshotPayloadCodec,
+            durableStatePayloadCodec,
+            tagsCodec = TagsCodec.PostgresTagsCodec,
+            timestampCodec = TimestampCodec.PostgresTimestampCodec,
+            queryAdapter = IdentityAdapter)
+      }
+    }
+
     val cleanupSettings = new CleanupSettings(config.getConfig("cleanup"))
     val settingsFromConfig = new R2dbcSettings(
       schema,
       journalTable,
-      journalPayloadCodec,
       journalPublishEvents,
       snapshotsTable,
-      snapshotPayloadCodec,
-      tagsCodec,
-      timestampCodec,
-      queryAdapter,
       durableStateTable,
-      durableStatePayloadCodec,
       durableStateAssertSingleWriter,
       logDbCallsExceeding,
       querySettings,
       dbTimestampMonotonicIncreasing,
       cleanupSettings,
+      codecSettings,
       connectionFactorySettings,
       durableStateTableByEntityType,
       durableStateAdditionalColumnClasses,
@@ -153,20 +163,16 @@ object R2dbcSettings {
 final class R2dbcSettings private (
     val schema: Option[String],
     val journalTable: String,
-    val journalPayloadCodec: PayloadCodec,
     val journalPublishEvents: Boolean,
     val snapshotsTable: String,
-    val snapshotPayloadCodec: PayloadCodec,
-    val tagsCodec: TagsCodec,
-    val timestampCodec: TimestampCodec,
-    val queryAdapter: QueryAdapter,
     val durableStateTable: String,
-    val durableStatePayloadCodec: PayloadCodec,
     val durableStateAssertSingleWriter: Boolean,
     val logDbCallsExceeding: FiniteDuration,
     val querySettings: QuerySettings,
     val dbTimestampMonotonicIncreasing: Boolean,
     val cleanupSettings: CleanupSettings,
+    /** INTERNAL API */
+    @InternalApi private[akka] val codecSettings: CodecSettings,
     _connectionFactorySettings: ConnectionFactorySettings,
     _durableStateTableByEntityType: Map[String, String],
     _durableStateAdditionalColumnClasses: Map[String, immutable.IndexedSeq[String]],
@@ -234,20 +240,15 @@ final class R2dbcSettings private (
   private def copy(
       schema: Option[String] = schema,
       journalTable: String = journalTable,
-      journalPayloadCodec: PayloadCodec = journalPayloadCodec,
       journalPublishEvents: Boolean = journalPublishEvents,
       snapshotsTable: String = snapshotsTable,
-      snapshotPayloadCodec: PayloadCodec = snapshotPayloadCodec,
-      tagsCodec: TagsCodec = tagsCodec,
-      timestampCodec: TimestampCodec = timestampCodec,
-      queryAdapter: QueryAdapter = queryAdapter,
       durableStateTable: String = durableStateTable,
-      durableStatePayloadCodec: PayloadCodec = durableStatePayloadCodec,
       durableStateAssertSingleWriter: Boolean = durableStateAssertSingleWriter,
       logDbCallsExceeding: FiniteDuration = logDbCallsExceeding,
       querySettings: QuerySettings = querySettings,
       dbTimestampMonotonicIncreasing: Boolean = dbTimestampMonotonicIncreasing,
       cleanupSettings: CleanupSettings = cleanupSettings,
+      codecSettings: CodecSettings = codecSettings,
       connectionFactorySettings: ConnectionFactorySettings = connectionFactorySettings,
       durableStateTableByEntityType: Map[String, String] = _durableStateTableByEntityType,
       durableStateAdditionalColumnClasses: Map[String, immutable.IndexedSeq[String]] =
@@ -257,20 +258,15 @@ final class R2dbcSettings private (
     new R2dbcSettings(
       schema,
       journalTable,
-      journalPayloadCodec,
       journalPublishEvents,
       snapshotsTable,
-      snapshotPayloadCodec,
-      tagsCodec,
-      timestampCodec,
-      queryAdapter,
       durableStateTable,
-      durableStatePayloadCodec,
       durableStateAssertSingleWriter,
       logDbCallsExceeding,
       querySettings,
       dbTimestampMonotonicIncreasing,
       cleanupSettings,
+      codecSettings,
       connectionFactorySettings,
       _durableStateTableByEntityType,
       _durableStateAdditionalColumnClasses,
@@ -327,6 +323,18 @@ final class PublishEventsDynamicSettings(config: Config) {
   val throughputThreshold: Int = config.getInt("throughput-threshold")
   val throughputCollectInterval: FiniteDuration = config.getDuration("throughput-collect-interval").asScala
 }
+
+/**
+ * INTERNAL API
+ */
+@InternalStableApi
+final class CodecSettings(
+    val journalPayloadCodec: PayloadCodec,
+    val snapshotPayloadCodec: PayloadCodec,
+    val durableStatePayloadCodec: PayloadCodec,
+    val tagsCodec: TagsCodec,
+    val timestampCodec: TimestampCodec,
+    val queryAdapter: QueryAdapter)
 
 /**
  * INTERNAL API

--- a/core/src/main/scala/akka/persistence/r2dbc/internal/Sql.scala
+++ b/core/src/main/scala/akka/persistence/r2dbc/internal/Sql.scala
@@ -29,11 +29,13 @@ object Sql {
   }
 
   /**
-   * INTERNAL API: Scala string interpolation with `sql` prefix. Replaces `?` with numbered `\$1`, `\$2` for bind parameters. Use `??`
-   * to include a literal `?`. Trims whitespace, including line breaks. Standard string interpolation arguments `$` can
-   * be used.
+   * INTERNAL API: Scala string interpolation with `sql` prefix. Replaces `?` with numbered `\$1`, `\$2` for bind
+   * parameters. Use `??` to include a literal `?`. Trims whitespace, including line breaks. Standard string
+   * interpolation arguments `$` can be used.
    */
-  @InternalApi private[akka] implicit class InterpolationWithAdapter(val sc: StringContext)(implicit adapter: QueryAdapter) extends AnyRef {
+  @InternalApi private[akka] implicit class InterpolationWithAdapter(val sc: StringContext)(implicit
+      adapter: QueryAdapter)
+      extends AnyRef {
     def sql(args: Any*): String =
       adapter(fillInParameterNumbers(trimLineBreaks(sc.s(args: _*))))
   }

--- a/core/src/main/scala/akka/persistence/r2dbc/internal/Sql.scala
+++ b/core/src/main/scala/akka/persistence/r2dbc/internal/Sql.scala
@@ -5,6 +5,8 @@
 package akka.persistence.r2dbc.internal
 
 import scala.annotation.varargs
+
+import akka.annotation.InternalApi
 import akka.annotation.InternalStableApi
 import akka.persistence.r2dbc.internal.codec.IdentityAdapter
 import akka.persistence.r2dbc.internal.codec.QueryAdapter
@@ -21,7 +23,17 @@ object Sql {
    * to include a literal `?`. Trims whitespace, including line breaks. Standard string interpolation arguments `$` can
    * be used.
    */
-  implicit class Interpolation(val sc: StringContext)(implicit adapter: QueryAdapter) extends AnyRef {
+  implicit class Interpolation(val sc: StringContext) extends AnyVal {
+    def sql(args: Any*): String =
+      fillInParameterNumbers(trimLineBreaks(sc.s(args: _*)))
+  }
+
+  /**
+   * INTERNAL API: Scala string interpolation with `sql` prefix. Replaces `?` with numbered `\$1`, `\$2` for bind parameters. Use `??`
+   * to include a literal `?`. Trims whitespace, including line breaks. Standard string interpolation arguments `$` can
+   * be used.
+   */
+  @InternalApi private[akka] implicit class InterpolationWithAdapter(val sc: StringContext)(implicit adapter: QueryAdapter) extends AnyRef {
     def sql(args: Any*): String =
       adapter(fillInParameterNumbers(trimLineBreaks(sc.s(args: _*))))
   }

--- a/core/src/main/scala/akka/persistence/r2dbc/internal/h2/H2Dialect.scala
+++ b/core/src/main/scala/akka/persistence/r2dbc/internal/h2/H2Dialect.scala
@@ -13,7 +13,7 @@ import akka.persistence.r2dbc.internal.DurableStateDao
 import akka.persistence.r2dbc.internal.JournalDao
 import akka.persistence.r2dbc.internal.QueryDao
 import akka.persistence.r2dbc.internal.SnapshotDao
-import akka.persistence.r2dbc.internal.Sql.Interpolation
+import akka.persistence.r2dbc.internal.Sql.InterpolationWithAdapter
 import akka.util.ccompat.JavaConverters._
 import com.typesafe.config.Config
 import io.r2dbc.h2.H2ConnectionConfiguration

--- a/core/src/main/scala/akka/persistence/r2dbc/internal/h2/H2JournalDao.scala
+++ b/core/src/main/scala/akka/persistence/r2dbc/internal/h2/H2JournalDao.scala
@@ -10,7 +10,7 @@ import akka.dispatch.ExecutionContexts
 import akka.persistence.r2dbc.R2dbcSettings
 import akka.persistence.r2dbc.internal.JournalDao
 import akka.persistence.r2dbc.internal.codec.PayloadCodec.RichStatement
-import akka.persistence.r2dbc.internal.Sql.Interpolation
+import akka.persistence.r2dbc.internal.Sql.InterpolationWithAdapter
 import akka.persistence.r2dbc.internal.postgres.PostgresJournalDao
 import io.r2dbc.spi.ConnectionFactory
 import io.r2dbc.spi.Statement

--- a/core/src/main/scala/akka/persistence/r2dbc/internal/h2/H2QueryDao.scala
+++ b/core/src/main/scala/akka/persistence/r2dbc/internal/h2/H2QueryDao.scala
@@ -7,7 +7,7 @@ package akka.persistence.r2dbc.internal.h2
 import akka.actor.typed.ActorSystem
 import akka.annotation.InternalApi
 import akka.persistence.r2dbc.R2dbcSettings
-import akka.persistence.r2dbc.internal.Sql.Interpolation
+import akka.persistence.r2dbc.internal.Sql.InterpolationWithAdapter
 import akka.persistence.r2dbc.internal.postgres.PostgresQueryDao
 import io.r2dbc.spi.ConnectionFactory
 import io.r2dbc.spi.Row

--- a/core/src/main/scala/akka/persistence/r2dbc/internal/h2/H2SnapshotDao.scala
+++ b/core/src/main/scala/akka/persistence/r2dbc/internal/h2/H2SnapshotDao.scala
@@ -7,7 +7,7 @@ package akka.persistence.r2dbc.internal.h2
 import akka.actor.typed.ActorSystem
 import akka.annotation.InternalApi
 import akka.persistence.r2dbc.R2dbcSettings
-import akka.persistence.r2dbc.internal.Sql.Interpolation
+import akka.persistence.r2dbc.internal.Sql.InterpolationWithAdapter
 import akka.persistence.r2dbc.internal.postgres.PostgresSnapshotDao
 import io.r2dbc.spi.ConnectionFactory
 import org.slf4j.Logger

--- a/core/src/main/scala/akka/persistence/r2dbc/internal/postgres/PostgresDurableStateDao.scala
+++ b/core/src/main/scala/akka/persistence/r2dbc/internal/postgres/PostgresDurableStateDao.scala
@@ -47,7 +47,7 @@ import akka.persistence.r2dbc.internal.JournalDao.SerializedJournalRow
 import akka.persistence.r2dbc.internal.codec.PayloadCodec.RichRow
 import akka.persistence.r2dbc.internal.codec.PayloadCodec.RichStatement
 import akka.persistence.r2dbc.internal.R2dbcExecutor
-import akka.persistence.r2dbc.internal.Sql.Interpolation
+import akka.persistence.r2dbc.internal.Sql.InterpolationWithAdapter
 import akka.persistence.r2dbc.internal.codec.PayloadCodec
 import akka.persistence.r2dbc.internal.codec.QueryAdapter
 import akka.persistence.r2dbc.internal.codec.SqlServerQueryAdapter

--- a/core/src/main/scala/akka/persistence/r2dbc/internal/postgres/PostgresDurableStateDao.scala
+++ b/core/src/main/scala/akka/persistence/r2dbc/internal/postgres/PostgresDurableStateDao.scala
@@ -99,11 +99,11 @@ private[r2dbc] class PostgresDurableStateDao(
     settings.logDbCallsExceeding,
     settings.connectionFactorySettings.poolSettings.closeCallsExceeding)(ec, system)
 
-  private implicit val statePayloadCodec: PayloadCodec = settings.durableStatePayloadCodec
-  private implicit val tagsCodec: TagsCodec = settings.tagsCodec
+  private implicit val statePayloadCodec: PayloadCodec = settings.codecSettings.durableStatePayloadCodec
+  private implicit val tagsCodec: TagsCodec = settings.codecSettings.tagsCodec
 
-  protected implicit val timestampCodec: TimestampCodec = settings.timestampCodec
-  protected implicit val queryAdapter: QueryAdapter = settings.queryAdapter
+  protected implicit val timestampCodec: TimestampCodec = settings.codecSettings.timestampCodec
+  protected implicit val queryAdapter: QueryAdapter = settings.codecSettings.queryAdapter
 
   // used for change events
   private lazy val journalDao: JournalDao = dialect.createJournalDao(settings, connectionFactory)

--- a/core/src/main/scala/akka/persistence/r2dbc/internal/postgres/PostgresJournalDao.scala
+++ b/core/src/main/scala/akka/persistence/r2dbc/internal/postgres/PostgresJournalDao.scala
@@ -14,7 +14,7 @@ import akka.persistence.r2dbc.internal.JournalDao
 import akka.persistence.r2dbc.internal.codec.PayloadCodec.RichStatement
 import akka.persistence.r2dbc.internal.R2dbcExecutor
 import akka.persistence.r2dbc.internal.SerializedEventMetadata
-import akka.persistence.r2dbc.internal.Sql.Interpolation
+import akka.persistence.r2dbc.internal.Sql.InterpolationWithAdapter
 import akka.persistence.r2dbc.internal.codec.TagsCodec
 import akka.persistence.r2dbc.internal.codec.TagsCodec.TagsCodecRichStatement
 import akka.persistence.r2dbc.internal.codec.TimestampCodec

--- a/core/src/main/scala/akka/persistence/r2dbc/internal/postgres/PostgresJournalDao.scala
+++ b/core/src/main/scala/akka/persistence/r2dbc/internal/postgres/PostgresJournalDao.scala
@@ -80,10 +80,10 @@ private[r2dbc] class PostgresJournalDao(journalSettings: R2dbcSettings, connecti
       journalSettings.connectionFactorySettings.poolSettings.closeCallsExceeding)(ec, system)
 
   protected val journalTable: String = journalSettings.journalTableWithSchema
-  protected implicit val journalPayloadCodec: PayloadCodec = journalSettings.journalPayloadCodec
-  protected implicit val tagsCodec: TagsCodec = journalSettings.tagsCodec
-  protected implicit val timestampCodec: TimestampCodec = journalSettings.timestampCodec
-  protected implicit val queryAdapter: QueryAdapter = journalSettings.queryAdapter
+  protected implicit val journalPayloadCodec: PayloadCodec = journalSettings.codecSettings.journalPayloadCodec
+  protected implicit val tagsCodec: TagsCodec = journalSettings.codecSettings.tagsCodec
+  protected implicit val timestampCodec: TimestampCodec = journalSettings.codecSettings.timestampCodec
+  protected implicit val queryAdapter: QueryAdapter = journalSettings.codecSettings.queryAdapter
 
   protected val (insertEventWithParameterTimestampSql, insertEventWithTransactionTimestampSql) = {
     val baseSql =

--- a/core/src/main/scala/akka/persistence/r2dbc/internal/postgres/PostgresQueryDao.scala
+++ b/core/src/main/scala/akka/persistence/r2dbc/internal/postgres/PostgresQueryDao.scala
@@ -58,10 +58,10 @@ private[r2dbc] class PostgresQueryDao(settings: R2dbcSettings, connectionFactory
 
   protected def log: Logger = PostgresQueryDao.log
   protected val journalTable: String = settings.journalTableWithSchema
-  protected implicit val journalPayloadCodec: PayloadCodec = settings.journalPayloadCodec
-  protected implicit val timestampCodec: TimestampCodec = settings.timestampCodec
-  protected implicit val tagsCodec: TagsCodec = settings.tagsCodec
-  protected implicit val queryAdapter: QueryAdapter = settings.queryAdapter
+  protected implicit val journalPayloadCodec: PayloadCodec = settings.codecSettings.journalPayloadCodec
+  protected implicit val timestampCodec: TimestampCodec = settings.codecSettings.timestampCodec
+  protected implicit val tagsCodec: TagsCodec = settings.codecSettings.tagsCodec
+  protected implicit val queryAdapter: QueryAdapter = settings.codecSettings.queryAdapter
 
   protected def sqlFalse: String = "false"
   protected def sqlDbTimestamp = "CURRENT_TIMESTAMP"

--- a/core/src/main/scala/akka/persistence/r2dbc/internal/postgres/PostgresQueryDao.scala
+++ b/core/src/main/scala/akka/persistence/r2dbc/internal/postgres/PostgresQueryDao.scala
@@ -23,7 +23,7 @@ import akka.persistence.r2dbc.internal.JournalDao.SerializedJournalRow
 import akka.persistence.r2dbc.internal.codec.PayloadCodec.RichRow
 import akka.persistence.r2dbc.internal.QueryDao
 import akka.persistence.r2dbc.internal.R2dbcExecutor
-import akka.persistence.r2dbc.internal.Sql.Interpolation
+import akka.persistence.r2dbc.internal.Sql.InterpolationWithAdapter
 import akka.persistence.r2dbc.internal.codec.QueryAdapter
 import akka.persistence.r2dbc.internal.codec.TagsCodec
 import akka.persistence.r2dbc.internal.codec.TagsCodec.TagsCodecRichRow

--- a/core/src/main/scala/akka/persistence/r2dbc/internal/postgres/PostgresSnapshotDao.scala
+++ b/core/src/main/scala/akka/persistence/r2dbc/internal/postgres/PostgresSnapshotDao.scala
@@ -63,10 +63,10 @@ private[r2dbc] class PostgresSnapshotDao(settings: R2dbcSettings, connectionFact
 
   protected val snapshotTable: String = settings.snapshotsTableWithSchema
 
-  protected implicit val snapshotPayloadCodec: PayloadCodec = settings.snapshotPayloadCodec
-  protected implicit val timestampCodec: TimestampCodec = settings.timestampCodec
-  protected implicit val tagsCodec: TagsCodec = settings.tagsCodec
-  protected implicit val queryAdapter: QueryAdapter = settings.queryAdapter
+  protected implicit val snapshotPayloadCodec: PayloadCodec = settings.codecSettings.snapshotPayloadCodec
+  protected implicit val timestampCodec: TimestampCodec = settings.codecSettings.timestampCodec
+  protected implicit val tagsCodec: TagsCodec = settings.codecSettings.tagsCodec
+  protected implicit val queryAdapter: QueryAdapter = settings.codecSettings.queryAdapter
 
   protected val r2dbcExecutor = new R2dbcExecutor(
     connectionFactory,

--- a/core/src/main/scala/akka/persistence/r2dbc/internal/postgres/PostgresSnapshotDao.scala
+++ b/core/src/main/scala/akka/persistence/r2dbc/internal/postgres/PostgresSnapshotDao.scala
@@ -30,7 +30,7 @@ import akka.persistence.r2dbc.internal.codec.PayloadCodec.RichRow
 import akka.persistence.r2dbc.internal.codec.PayloadCodec.RichStatement
 import akka.persistence.r2dbc.internal.R2dbcExecutor
 import akka.persistence.r2dbc.internal.SnapshotDao
-import akka.persistence.r2dbc.internal.Sql.Interpolation
+import akka.persistence.r2dbc.internal.Sql.InterpolationWithAdapter
 import akka.persistence.r2dbc.internal.codec.PayloadCodec
 import akka.persistence.r2dbc.internal.codec.QueryAdapter
 import akka.persistence.r2dbc.internal.codec.TagsCodec

--- a/core/src/main/scala/akka/persistence/r2dbc/internal/sqlserver/SqlServerDurableStateDao.scala
+++ b/core/src/main/scala/akka/persistence/r2dbc/internal/sqlserver/SqlServerDurableStateDao.scala
@@ -16,7 +16,7 @@ import akka.actor.typed.ActorSystem
 import akka.annotation.InternalApi
 import akka.persistence.r2dbc.R2dbcSettings
 import akka.persistence.r2dbc.internal.Dialect
-import akka.persistence.r2dbc.internal.Sql.Interpolation
+import akka.persistence.r2dbc.internal.Sql.InterpolationWithAdapter
 import akka.persistence.r2dbc.internal.codec.TimestampCodec.TimestampCodecRichStatement
 import akka.persistence.r2dbc.internal.postgres.PostgresDurableStateDao
 import akka.persistence.r2dbc.internal.postgres.PostgresDurableStateDao.EvaluatedAdditionalColumnBindings

--- a/core/src/main/scala/akka/persistence/r2dbc/internal/sqlserver/SqlServerJournalDao.scala
+++ b/core/src/main/scala/akka/persistence/r2dbc/internal/sqlserver/SqlServerJournalDao.scala
@@ -9,7 +9,7 @@ import scala.concurrent.ExecutionContext
 import akka.actor.typed.ActorSystem
 import akka.annotation.InternalApi
 import akka.persistence.r2dbc.R2dbcSettings
-import akka.persistence.r2dbc.internal.Sql.Interpolation
+import akka.persistence.r2dbc.internal.Sql.InterpolationWithAdapter
 import akka.persistence.r2dbc.internal.codec.TimestampCodec.TimestampCodecRichStatement
 import akka.persistence.r2dbc.internal.postgres.PostgresJournalDao
 import io.r2dbc.spi.ConnectionFactory

--- a/core/src/main/scala/akka/persistence/r2dbc/internal/sqlserver/SqlServerQueryDao.scala
+++ b/core/src/main/scala/akka/persistence/r2dbc/internal/sqlserver/SqlServerQueryDao.scala
@@ -15,7 +15,7 @@ import akka.actor.typed.ActorSystem
 import akka.annotation.InternalApi
 import akka.persistence.r2dbc.R2dbcSettings
 import akka.persistence.r2dbc.internal.InstantFactory
-import akka.persistence.r2dbc.internal.Sql.Interpolation
+import akka.persistence.r2dbc.internal.Sql.InterpolationWithAdapter
 import akka.persistence.r2dbc.internal.codec.TimestampCodec.TimestampCodecRichStatement
 import akka.persistence.r2dbc.internal.postgres.PostgresQueryDao
 import io.r2dbc.spi.ConnectionFactory

--- a/core/src/main/scala/akka/persistence/r2dbc/internal/sqlserver/SqlServerSnapshotDao.scala
+++ b/core/src/main/scala/akka/persistence/r2dbc/internal/sqlserver/SqlServerSnapshotDao.scala
@@ -16,7 +16,7 @@ import akka.persistence.r2dbc.R2dbcSettings
 import akka.persistence.r2dbc.internal.codec.PayloadCodec.RichStatement
 import akka.persistence.r2dbc.internal.SnapshotDao.SerializedSnapshotMetadata
 import akka.persistence.r2dbc.internal.SnapshotDao.SerializedSnapshotRow
-import akka.persistence.r2dbc.internal.Sql.Interpolation
+import akka.persistence.r2dbc.internal.Sql.InterpolationWithAdapter
 import akka.persistence.r2dbc.internal.codec.TagsCodec.TagsCodecRichStatement
 import akka.persistence.r2dbc.internal.codec.TimestampCodec.TimestampCodecRichStatement
 import akka.persistence.r2dbc.internal.postgres.PostgresSnapshotDao

--- a/core/src/test/scala/akka/persistence/r2dbc/PayloadSpec.scala
+++ b/core/src/test/scala/akka/persistence/r2dbc/PayloadSpec.scala
@@ -89,7 +89,7 @@ class PayloadSpec
   }
 
   private def selectJournalRow(persistenceId: String): TestRow = {
-    implicit val journalPayloadCodec: PayloadCodec = settings.journalPayloadCodec
+    implicit val journalPayloadCodec: PayloadCodec = settings.codecSettings.journalPayloadCodec
 
     r2dbcExecutor
       .selectOne[TestRow]("test")(
@@ -108,7 +108,7 @@ class PayloadSpec
   }
 
   private def selectSnapshotRow(persistenceId: String): TestRow = {
-    implicit val snapshotPayloadCodec: PayloadCodec = settings.snapshotPayloadCodec
+    implicit val snapshotPayloadCodec: PayloadCodec = settings.codecSettings.snapshotPayloadCodec
 
     r2dbcExecutor
       .selectOne[TestRow]("test")(
@@ -127,7 +127,7 @@ class PayloadSpec
   }
 
   private def selectDurableStateRow(persistenceId: String): TestRow = {
-    implicit val durableStatePayloadCodec: PayloadCodec = settings.durableStatePayloadCodec
+    implicit val durableStatePayloadCodec: PayloadCodec = settings.codecSettings.durableStatePayloadCodec
 
     r2dbcExecutor
       .selectOne[TestRow]("test")(
@@ -205,7 +205,7 @@ class PayloadSpec
       testKit.stop(ref1)
 
       val row1 = selectDurableStateRow(persistenceId)
-      row1.payload.toVector shouldBe settings.durableStatePayloadCodec.nonePayload.toVector
+      row1.payload.toVector shouldBe settings.codecSettings.durableStatePayloadCodec.nonePayload.toVector
 
       val ref2 = spawn(DurableStatePersister(persistenceId))
       ref2 ! DurableStatePersister.GetState(probe.ref)
@@ -228,7 +228,7 @@ class PayloadSpec
       testKit.stop(ref3)
 
       val row3 = selectDurableStateRow(persistenceId)
-      row3.payload.toVector shouldBe settings.durableStatePayloadCodec.nonePayload.toVector
+      row3.payload.toVector shouldBe settings.codecSettings.durableStatePayloadCodec.nonePayload.toVector
     }
   }
 }

--- a/core/src/test/scala/akka/persistence/r2dbc/TestDbLifecycle.scala
+++ b/core/src/test/scala/akka/persistence/r2dbc/TestDbLifecycle.scala
@@ -12,7 +12,7 @@ import akka.persistence.r2dbc.internal.R2dbcExecutor
 import org.scalatest.BeforeAndAfterAll
 import org.scalatest.Suite
 import org.slf4j.LoggerFactory
-import akka.persistence.r2dbc.internal.Sql.Interpolation
+import akka.persistence.r2dbc.internal.Sql.InterpolationWithAdapter
 import akka.persistence.r2dbc.internal.h2.H2Dialect
 
 import java.time.Instant

--- a/core/src/test/scala/akka/persistence/r2dbc/internal/SqlSpec.scala
+++ b/core/src/test/scala/akka/persistence/r2dbc/internal/SqlSpec.scala
@@ -12,7 +12,7 @@ import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 
 class SqlSpec extends AnyWordSpec with TestSuite with Matchers {
-  import Sql.Interpolation
+  import Sql.InterpolationWithAdapter
   "SQL string interpolation" should {
     implicit val queryAdapter: QueryAdapter = IdentityAdapter
     "replace ? bind parameters with numbered $ (avoiding escaped ones)" in {

--- a/core/src/test/scala/akka/persistence/r2dbc/journal/PersistTagsSpec.scala
+++ b/core/src/test/scala/akka/persistence/r2dbc/journal/PersistTagsSpec.scala
@@ -29,7 +29,7 @@ class PersistTagsSpec
 
   override def typedSystem: ActorSystem[_] = system
   private val settings = R2dbcSettings(system.settings.config.getConfig("akka.persistence.r2dbc"))
-  private implicit val tagsCodec: TagsCodec = settings.tagsCodec
+  private implicit val tagsCodec: TagsCodec = settings.codecSettings.tagsCodec
   case class Row(pid: String, seqNr: Long, tags: Set[String])
 
   "Persist tags" should {

--- a/core/src/test/scala/akka/persistence/r2dbc/journal/PersistTimestampSpec.scala
+++ b/core/src/test/scala/akka/persistence/r2dbc/journal/PersistTimestampSpec.scala
@@ -34,7 +34,7 @@ class PersistTimestampSpec
   override def typedSystem: ActorSystem[_] = system
   private val settings = R2dbcSettings(system.settings.config.getConfig("akka.persistence.r2dbc"))
   private val serialization = SerializationExtension(system)
-  private implicit val journalPayloadCodec: PayloadCodec = settings.journalPayloadCodec
+  private implicit val journalPayloadCodec: PayloadCodec = settings.codecSettings.journalPayloadCodec
   case class Row(pid: String, seqNr: Long, dbTimestamp: Instant, event: String)
 
   implicit private val codec: TimestampCodec =

--- a/core/src/test/scala/akka/persistence/r2dbc/query/EventsBySliceBacktrackingSpec.scala
+++ b/core/src/test/scala/akka/persistence/r2dbc/query/EventsBySliceBacktrackingSpec.scala
@@ -57,9 +57,9 @@ class EventsBySliceBacktrackingSpec
 
   override def typedSystem: ActorSystem[_] = system
   private val settings = R2dbcSettings(system.settings.config.getConfig("akka.persistence.r2dbc"))
-  private implicit val journalPayloadCodec: PayloadCodec = settings.journalPayloadCodec
-  private implicit val timestampCodec: TimestampCodec = settings.timestampCodec
-  private implicit val queryAdapter: QueryAdapter = settings.queryAdapter
+  private implicit val journalPayloadCodec: PayloadCodec = settings.codecSettings.journalPayloadCodec
+  private implicit val timestampCodec: TimestampCodec = settings.codecSettings.timestampCodec
+  private implicit val queryAdapter: QueryAdapter = settings.codecSettings.queryAdapter
 
   private val query = PersistenceQuery(testKit.system)
     .readJournalFor[R2dbcReadJournal](R2dbcReadJournal.Identifier)

--- a/core/src/test/scala/akka/persistence/r2dbc/query/EventsBySliceBacktrackingSpec.scala
+++ b/core/src/test/scala/akka/persistence/r2dbc/query/EventsBySliceBacktrackingSpec.scala
@@ -20,7 +20,7 @@ import akka.persistence.r2dbc.R2dbcSettings
 import akka.persistence.r2dbc.internal.codec.TimestampCodec
 import akka.persistence.r2dbc.internal.codec.TimestampCodec.TimestampCodecRichStatement
 import akka.persistence.r2dbc.internal.codec.PayloadCodec.RichStatement
-import akka.persistence.r2dbc.internal.Sql.Interpolation
+import akka.persistence.r2dbc.internal.Sql.InterpolationWithAdapter
 import akka.persistence.r2dbc.TestConfig
 import akka.persistence.r2dbc.TestData
 import akka.persistence.r2dbc.TestDbLifecycle

--- a/core/src/test/scala/akka/persistence/r2dbc/state/DurableStateStoreChangeHandlerSpec.scala
+++ b/core/src/test/scala/akka/persistence/r2dbc/state/DurableStateStoreChangeHandlerSpec.scala
@@ -18,7 +18,7 @@ import akka.persistence.query.UpdatedDurableState
 import akka.persistence.r2dbc.TestConfig
 import akka.persistence.r2dbc.TestData
 import akka.persistence.r2dbc.TestDbLifecycle
-import akka.persistence.r2dbc.internal.Sql.Interpolation
+import akka.persistence.r2dbc.internal.Sql.InterpolationWithAdapter
 import akka.persistence.r2dbc.session.scaladsl.R2dbcSession
 import akka.persistence.r2dbc.state.DurableStateStoreChangeHandlerSpec.config
 import akka.persistence.r2dbc.state.scaladsl.ChangeHandler

--- a/migration/src/main/scala/akka/persistence/r2dbc/migration/MigrationToolDao.scala
+++ b/migration/src/main/scala/akka/persistence/r2dbc/migration/MigrationToolDao.scala
@@ -12,7 +12,7 @@ import akka.Done
 import akka.actor.typed.ActorSystem
 import akka.annotation.InternalApi
 import akka.dispatch.ExecutionContexts
-import akka.persistence.r2dbc.internal.Sql.Interpolation
+import akka.persistence.r2dbc.internal.Sql.InterpolationWithAdapter
 import akka.persistence.r2dbc.internal.R2dbcExecutor
 import akka.persistence.r2dbc.internal.codec.IdentityAdapter
 import akka.persistence.r2dbc.internal.codec.QueryAdapter


### PR DESCRIPTION
Follow up to https://github.com/akka/akka-persistence-r2dbc/pull/505
`Sql.Interpolation` is used in other projects that we don't want to break.

Also a cleanup of the codec settings.