### PR TITLE
docs: fix note rendering in Running section

### DIFF
--- a/docs/src/main/paradox/migration.md
+++ b/docs/src/main/paradox/migration.md
@@ -56,7 +56,7 @@ The migration tool can be run as main class `akka.persistence.r2dbc.migration.Mi
 
 Durable State is not migrated by `MigrationTool.migrateAll`, instead you need to use `MigrationTool.migrateDurableStates` for a given list of persistence ids.
 
-@@@ note
+@@@
 
 ## Configuration
 


### PR DESCRIPTION
A `@@@ note` does not need to be closed like it was before this PR, and for me it even breaks the rendering.

<img width="204" alt="Screenshot 2024-02-03 at 10 33 55" src="https://github.com/akka/akka-persistence-r2dbc/assets/546816/b563f903-47eb-4edb-bc43-0f0d23e2125c">
