### PR TITLE
build: Update actions due to Node.js 16 deprecation

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -17,7 +17,9 @@ jobs:
     if: github.repository == 'akka/akka-persistence-r2dbc'
     steps:
       - name: Checkout
-        uses: actions/checkout@v3.1.0
+        # https://github.com/actions/checkout/releases
+        # v4.1.1
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
         with:
           # we don't know what commit the last tag was it's safer to get entire repo so previousStableVersion resolves
           fetch-depth: 0
@@ -32,7 +34,9 @@ jobs:
         uses: coursier/cache-action@v6.4.0
 
       - name: Set up JDK 11
-        uses: coursier/setup-action@v1.3.0
+        # https://github.com/coursier/setup-action/releases
+        # v1.3.4
+        uses: coursier/setup-action@48280172a2c999022e42527711d6b28e4945e6f0
         with:
           jvm: temurin:1.11.0
 
@@ -47,7 +51,9 @@ jobs:
     if: github.repository == 'akka/akka-persistence-r2dbc'
     steps:
       - name: Checkout
-        uses: actions/checkout@v3.1.0
+        # https://github.com/actions/checkout/releases
+        # v4.1.1
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
         with:
           fetch-depth: 0
 
@@ -58,10 +64,14 @@ jobs:
           git checkout scratch
 
       - name: Cache Coursier cache
-        uses: coursier/cache-action@v6.4.0
+        # https://github.com/coursier/cache-action/releases
+        # v6.4.4
+        uses: coursier/cache-action@a0e7cd24be81bc84f0d7461e02bd1a96980553d7
 
       - name: Set up JDK 11
-        uses: coursier/setup-action@v1.3.0
+        # https://github.com/coursier/setup-action/releases
+        # v1.3.4
+        uses: coursier/setup-action@48280172a2c999022e42527711d6b28e4945e6f0
         with:
           jvm: temurin:1.11.0
 
@@ -81,7 +91,9 @@ jobs:
     if: github.repository == 'akka/akka-persistence-r2dbc'
     steps:
       - name: Checkout
-        uses: actions/checkout@v3.1.0
+        # https://github.com/actions/checkout/releases
+        # v4.1.1
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
         with:
           fetch-depth: 0
 
@@ -92,10 +104,14 @@ jobs:
           git checkout scratch
 
       - name: Cache Coursier cache
-        uses: coursier/cache-action@v6.4.0
+        # https://github.com/coursier/cache-action/releases
+        # v6.4.4
+        uses: coursier/cache-action@a0e7cd24be81bc84f0d7461e02bd1a96980553d7
 
       - name: Set up JDK 11
-        uses: coursier/setup-action@v1.3.0
+        # https://github.com/coursier/setup-action/releases
+        # v1.3.4
+        uses: coursier/setup-action@48280172a2c999022e42527711d6b28e4945e6f0
         with:
           jvm: temurin:1.11.0
 
@@ -118,7 +134,9 @@ jobs:
     if: github.repository == 'akka/akka-persistence-r2dbc'
     steps:
       - name: Checkout
-        uses: actions/checkout@v3.1.0
+        # https://github.com/actions/checkout/releases
+        # v4.1.1
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
         with:
           fetch-depth: 0
 
@@ -129,10 +147,14 @@ jobs:
           git checkout scratch
 
       - name: Cache Coursier cache
-        uses: coursier/cache-action@v6.4.0
+        # https://github.com/coursier/cache-action/releases
+        # v6.4.4
+        uses: coursier/cache-action@a0e7cd24be81bc84f0d7461e02bd1a96980553d7
 
       - name: Set up JDK 11
-        uses: coursier/setup-action@v1.3.0
+        # https://github.com/coursier/setup-action/releases
+        # v1.3.4
+        uses: coursier/setup-action@48280172a2c999022e42527711d6b28e4945e6f0
         with:
           jvm: temurin:1.11.0
 
@@ -153,7 +175,9 @@ jobs:
     if: github.repository == 'akka/akka-persistence-r2dbc'
     steps:
       - name: Checkout
-        uses: actions/checkout@v3.1.0
+        # https://github.com/actions/checkout/releases
+        # v4.1.1
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
         with:
           fetch-depth: 0
 
@@ -164,10 +188,14 @@ jobs:
           git checkout scratch
 
       - name: Cache Coursier cache
-        uses: coursier/cache-action@v6.4.0
+        # https://github.com/coursier/cache-action/releases
+        # v6.4.4
+        uses: coursier/cache-action@a0e7cd24be81bc84f0d7461e02bd1a96980553d7
 
       - name: Set up JDK 11
-        uses: coursier/setup-action@v1.3.0
+        # https://github.com/coursier/setup-action/releases
+        # v1.3.4
+        uses: coursier/setup-action@48280172a2c999022e42527711d6b28e4945e6f0
         with:
           jvm: temurin:1.11.0
 
@@ -189,7 +217,9 @@ jobs:
     if: github.repository == 'akka/akka-persistence-r2dbc'
     steps:
       - name: Checkout
-        uses: actions/checkout@v3.1.0
+        # https://github.com/actions/checkout/releases
+        # v4.1.1
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
         with:
           fetch-depth: 0
 
@@ -200,10 +230,14 @@ jobs:
           git checkout scratch
 
       - name: Cache Coursier cache
-        uses: coursier/cache-action@v6.4.0
+        # https://github.com/coursier/cache-action/releases
+        # v6.4.4
+        uses: coursier/cache-action@a0e7cd24be81bc84f0d7461e02bd1a96980553d7
 
       - name: Set up JDK 11
-        uses: coursier/setup-action@v1.3.0
+        # https://github.com/coursier/setup-action/releases
+        # v1.3.4
+        uses: coursier/setup-action@48280172a2c999022e42527711d6b28e4945e6f0
         with:
           jvm: temurin:1.11.0
 
@@ -218,7 +252,9 @@ jobs:
     if: github.repository == 'akka/akka-persistence-r2dbc'
     steps:
       - name: Checkout
-        uses: actions/checkout@v3.1.0
+        # https://github.com/actions/checkout/releases
+        # v4.1.1
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
         with:
           fetch-depth: 0
 
@@ -228,10 +264,14 @@ jobs:
           git fetch origin pull/${{ github.event.pull_request.number }}/merge:scratch
           git checkout scratch
       - name: Cache Coursier cache
-        uses: coursier/cache-action@v6.4.0
+        # https://github.com/coursier/cache-action/releases
+        # v6.4.4
+        uses: coursier/cache-action@a0e7cd24be81bc84f0d7461e02bd1a96980553d7
 
       - name: Set up JDK 11
-        uses: coursier/setup-action@v1.3.0
+        # https://github.com/coursier/setup-action/releases
+        # v1.3.4
+        uses: coursier/setup-action@48280172a2c999022e42527711d6b28e4945e6f0
         with:
           jvm: temurin:1.11.0
 
@@ -250,7 +290,9 @@ jobs:
     if: github.repository == 'akka/akka-persistence-r2dbc'
     steps:
       - name: Checkout
-        uses: actions/checkout@v3.1.0
+        # https://github.com/actions/checkout/releases
+        # v4.1.1
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
         with:
           fetch-depth: 0
 
@@ -261,10 +303,14 @@ jobs:
           git checkout scratch
 
       - name: Cache Coursier cache
-        uses: coursier/cache-action@v6.4.0
+        # https://github.com/coursier/cache-action/releases
+        # v6.4.4
+        uses: coursier/cache-action@a0e7cd24be81bc84f0d7461e02bd1a96980553d7
 
       - name: Set up JDK 11
-        uses: coursier/setup-action@v1.3.0
+        # https://github.com/coursier/setup-action/releases
+        # v1.3.4
+        uses: coursier/setup-action@48280172a2c999022e42527711d6b28e4945e6f0
         with:
           jvm: temurin:1.11.0
 

--- a/.github/workflows/fossa.yml
+++ b/.github/workflows/fossa.yml
@@ -15,15 +15,21 @@ jobs:
     if: github.repository == 'akka/akka-persistence-r2dbc'
     steps:
       - name: Checkout
-        uses: actions/checkout@v3.1.0
+        # https://github.com/actions/checkout/releases
+        # v4.1.1
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
         with:
           fetch-depth: 0
 
       - name: Cache Coursier cache
-        uses: coursier/cache-action@v6.4.0
+        # https://github.com/coursier/cache-action/releases
+        # v6.4.4
+        uses: coursier/cache-action@a0e7cd24be81bc84f0d7461e02bd1a96980553d7
 
       - name: Set up JDK 17
-        uses: coursier/setup-action@v1.3.0
+        # https://github.com/coursier/setup-action/releases
+        # v1.3.4
+        uses: coursier/setup-action@48280172a2c999022e42527711d6b28e4945e6f0
         with:
           jvm: temurin:1.17
 

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -24,15 +24,21 @@ jobs:
           - { scalaVersion: "2.13", jdkVersion: "1.21.0", jvmName: "temurin:1.21", extraOpts: '', testCmd: "test"}
     steps:
       - name: Checkout
-        uses: actions/checkout@v3.1.0
+        # https://github.com/actions/checkout/releases
+        # v4.1.1
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
         with:
           fetch-depth: 0
 
       - name: Cache Coursier cache
-        uses: coursier/cache-action@v6.4.0
+        # https://github.com/coursier/cache-action/releases
+        # v6.4.4
+        uses: coursier/cache-action@a0e7cd24be81bc84f0d7461e02bd1a96980553d7
 
       - name: Set up JDK ${{ matrix.jdkVersion }}
-        uses: coursier/setup-action@v1.3.4
+        # https://github.com/coursier/setup-action/releases
+        # v1.3.4
+        uses: coursier/setup-action@48280172a2c999022e42527711d6b28e4945e6f0
         with:
           jvm: ${{ matrix.jvmName }}
 
@@ -76,15 +82,21 @@ jobs:
           - { scalaVersion: "3.3",  jdkVersion: "1.17.0", jvmName: "temurin:1.17.0", extraOpts: '', testCmd: "core/test"}
     steps:
       - name: Checkout
-        uses: actions/checkout@v3.1.0
+        # https://github.com/actions/checkout/releases
+        # v4.1.1
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
         with:
           fetch-depth: 0
 
       - name: Cache Coursier cache
-        uses: coursier/cache-action@v6.4.0
+        # https://github.com/coursier/cache-action/releases
+        # v6.4.4
+        uses: coursier/cache-action@a0e7cd24be81bc84f0d7461e02bd1a96980553d7
 
       - name: Set up JDK ${{ matrix.jdkVersion }}
-        uses: coursier/setup-action@v1.3.0
+        # https://github.com/coursier/setup-action/releases
+        # v1.3.4
+        uses: coursier/setup-action@48280172a2c999022e42527711d6b28e4945e6f0
         with:
           jvm: ${{ matrix.jvmName }}
 
@@ -130,15 +142,21 @@ jobs:
           - { scalaVersion: "2.13", jdkVersion: "1.21.0", jvmName: "temurin:1.21", extraOpts: '', testCmd: "test"}
     steps:
       - name: Checkout
-        uses: actions/checkout@v3.1.0
+        # https://github.com/actions/checkout/releases
+        # v4.1.1
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
         with:
           fetch-depth: 0
 
       - name: Cache Coursier cache
-        uses: coursier/cache-action@v6.4.0
+        # https://github.com/coursier/cache-action/releases
+        # v6.4.4
+        uses: coursier/cache-action@a0e7cd24be81bc84f0d7461e02bd1a96980553d7
 
       - name: Set up JDK ${{ matrix.jdkVersion }}
-        uses: coursier/setup-action@v1.3.4
+        # https://github.com/coursier/setup-action/releases
+        # v1.3.4
+        uses: coursier/setup-action@48280172a2c999022e42527711d6b28e4945e6f0
         with:
           jvm: ${{ matrix.jvmName }}
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -16,16 +16,22 @@ jobs:
     if: github.event.repository.fork == false
     steps:
       - name: Checkout
-        uses: actions/checkout@v3.1.0
+        # https://github.com/actions/checkout/releases
+        # v4.1.1
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
         with:
           # we don't know what commit the last tag was it's safer to get entire repo so previousStableVersion resolves
           fetch-depth: 0
 
       - name: Cache Coursier cache
-        uses: coursier/cache-action@v6.4.0
+        # https://github.com/coursier/cache-action/releases
+        # v6.4.4
+        uses: coursier/cache-action@a0e7cd24be81bc84f0d7461e02bd1a96980553d7
 
       - name: Set up JDK 11
-        uses: coursier/setup-action@v1.3.0
+        # https://github.com/coursier/setup-action/releases
+        # v1.3.4
+        uses: coursier/setup-action@48280172a2c999022e42527711d6b28e4945e6f0
         with:
           jvm: temurin:1.11.0.17
 
@@ -44,13 +50,17 @@ jobs:
     if: github.event.repository.fork == false
     steps:
       - name: Checkout
-        uses: actions/checkout@v3.1.0
+        # https://github.com/actions/checkout/releases
+        # v4.1.1
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
         with:
           # we don't know what commit the last tag was it's safer to get entire repo so previousStableVersion resolves
           fetch-depth: 0
 
       - name: Set up JDK 11
-        uses: coursier/setup-action@v1.3.0
+        # https://github.com/coursier/setup-action/releases
+        # v1.3.4
+        uses: coursier/setup-action@48280172a2c999022e42527711d6b28e4945e6f0
         with:
           jvm: temurin:1.11
 


### PR DESCRIPTION
* Node.js 16 actions are deprecated
* actions/checkout, coursier/cache-action, coursier/setup-action
* using same versions as in akka-projection
