### PR TITLE
chore: Native-image support with r2dbc-postgres 1.0.5.RELEASE

### DIFF
--- a/.github/workflows/native-image-tests.yml
+++ b/.github/workflows/native-image-tests.yml
@@ -70,7 +70,7 @@ jobs:
           docker compose -f docker/docker-compose-postgres.yml up --wait
           docker exec -i postgres-db psql -U postgres -t < ddl-scripts/create_tables_postgres.sql
 
-      - name: Akka Persistence native image H2
+      - name: Akka Persistence native image Postgres
         run: |-
           cd native-image-tests/
           target/native-image/native-image-tests -Dconfig.resource=application-postgres.conf

--- a/core/src/main/resources/META-INF/native-image/io.netty/netty-handler/native-image.properties
+++ b/core/src/main/resources/META-INF/native-image/io.netty/netty-handler/native-image.properties
@@ -1,1 +1,1 @@
-Args = --initialize-at-run-time=io.netty.handler.ssl.BouncyCastleAlpnSslUtils
+Args = --initialize-at-run-time=io.netty.handler.ssl.BouncyCastleAlpnSslUtils,io.netty.handler.ssl.JdkSslServerContext

--- a/core/src/main/resources/META-INF/native-image/org.postgresql/r2dbc-postgresql/reflect-config.json
+++ b/core/src/main/resources/META-INF/native-image/org.postgresql/r2dbc-postgresql/reflect-config.json
@@ -1,0 +1,17 @@
+[{
+  "name": "io.r2dbc.postgresql.client.ReactorNettyClient$EnsureSubscribersCompleteChannelHandler",
+  "methods": [
+    {
+      "name": "channelUnregistered",
+      "parameterTypes": [
+        "io.netty.channel.ChannelHandlerContext"
+      ]
+    },
+    {
+      "name": "channelInactive",
+      "parameterTypes": [
+        "io.netty.channel.ChannelHandlerContext"
+      ]
+    }
+  ]
+}]

--- a/native-image-tests/src/main/resources/logback.xml
+++ b/native-image-tests/src/main/resources/logback.xml
@@ -6,7 +6,7 @@
         </encoder>
     </appender>
 
-    <root level="INFO">
+    <root level="DEBUG">
         <appender-ref ref="STDOUT"/>
     </root>
 


### PR DESCRIPTION
References #548 

r2dbc postgres bump transitively bumped Netty which broke native-image, also found some unsupported reflection inspection when logging native image run at debug which was fixed.