### PR TITLE
fix: insert instead of update state with updated revision during migration

### DIFF
--- a/core/src/main/scala/akka/persistence/r2dbc/R2dbcSettings.scala
+++ b/core/src/main/scala/akka/persistence/r2dbc/R2dbcSettings.scala
@@ -73,6 +73,7 @@ object R2dbcSettings {
       configToMap(config.getConfig("state.change-handler"))
 
     val durableStateAssertSingleWriter: Boolean = config.getBoolean("state.assert-single-writer")
+    val migration: Boolean = config.hasPath("migration")
 
     val numberOfDataPartitions = config.getInt("data-partition.number-of-partitions")
     require(
@@ -173,6 +174,7 @@ object R2dbcSettings {
       snapshotsTable,
       durableStateTable,
       durableStateAssertSingleWriter,
+      migration,
       logDbCallsExceeding,
       querySettings,
       dbTimestampMonotonicIncreasing,
@@ -224,6 +226,7 @@ final class R2dbcSettings private (
     val snapshotsTable: String,
     val durableStateTable: String,
     val durableStateAssertSingleWriter: Boolean,
+    val migration: Boolean,
     val logDbCallsExceeding: FiniteDuration,
     val querySettings: QuerySettings,
     val dbTimestampMonotonicIncreasing: Boolean,
@@ -444,6 +447,7 @@ final class R2dbcSettings private (
       snapshotsTable: String = snapshotsTable,
       durableStateTable: String = durableStateTable,
       durableStateAssertSingleWriter: Boolean = durableStateAssertSingleWriter,
+      migration: Boolean = migration,
       logDbCallsExceeding: FiniteDuration = logDbCallsExceeding,
       querySettings: QuerySettings = querySettings,
       dbTimestampMonotonicIncreasing: Boolean = dbTimestampMonotonicIncreasing,
@@ -463,6 +467,7 @@ final class R2dbcSettings private (
       snapshotsTable,
       durableStateTable,
       durableStateAssertSingleWriter,
+      migration,
       logDbCallsExceeding,
       querySettings,
       dbTimestampMonotonicIncreasing,

--- a/core/src/main/scala/akka/persistence/r2dbc/internal/DurableStateDao.scala
+++ b/core/src/main/scala/akka/persistence/r2dbc/internal/DurableStateDao.scala
@@ -53,7 +53,8 @@ private[r2dbc] trait DurableStateDao extends BySliceQuery.Dao[DurableStateDao.Se
   def upsertState(
       state: SerializedStateRow,
       value: Any,
-      changeEvent: Option[SerializedJournalRow]): Future[Option[Instant]]
+      changeEvent: Option[SerializedJournalRow],
+      insertRevisionOverride: Boolean = false): Future[Option[Instant]]
 
   def deleteState(
       persistenceId: String,

--- a/migration-tests/src/test/scala/akka/persistence/r2dbc/migration/MigrationToolSpec.scala
+++ b/migration-tests/src/test/scala/akka/persistence/r2dbc/migration/MigrationToolSpec.scala
@@ -417,6 +417,14 @@ class MigrationToolSpec
       assertDurableState(pid, "s-1")
     }
 
+    "migrate durable state of one persistenceId with an updated revision" in {
+      val pid = PersistenceId.ofUniqueId(nextPid())
+      persistDurableState(pid, "s-1")
+      persistDurableState(pid, "s-1")
+      migration.migrateDurableState(pid.id).futureValue shouldBe 1L
+      assertDurableState(pid, "s-1")
+    }
+
     "migrate durable state of a persistenceId several times" in {
       val pid = PersistenceId.ofUniqueId(nextPid())
       persistDurableState(pid, "s-1")


### PR DESCRIPTION
Fixes https://github.com/akka/akka-persistence-r2dbc/issues/552

---

Very pragmatic approach to fix this issue. I first tried to add another path to make a true upsert during migration, but this caused the complexity of the `PostgresDurableStateDao` to increase even further. So I tried this version instead, and it seems to work ™️ 