### PR TITLE
fix: insert instead of update new state with updated revision during migration

### DIFF
--- a/core/src/main/scala/akka/persistence/r2dbc/internal/postgres/PostgresDurableStateDao.scala
+++ b/core/src/main/scala/akka/persistence/r2dbc/internal/postgres/PostgresDurableStateDao.scala
@@ -96,7 +96,7 @@ private[r2dbc] class PostgresDurableStateDao(executorProvider: R2dbcExecutorProv
   // used for change events
   private lazy val journalDao: JournalDao = dialect.createJournalDao(executorProvider)
 
-  protected lazy val additionalColumns: Map[String, immutable.IndexedSeq[AdditionalColumn[Any, Any]]] = {
+  private lazy val additionalColumns: Map[String, immutable.IndexedSeq[AdditionalColumn[Any, Any]]] = {
     settings.durableStateAdditionalColumnClasses.map { case (entityType, columnClasses) =>
       val instances = columnClasses.map(fqcn => AdditionalColumnFactory.create(system, fqcn))
       entityType -> instances

--- a/migration-tests/src/test/scala/akka/persistence/r2dbc/migration/MigrationToolSpec.scala
+++ b/migration-tests/src/test/scala/akka/persistence/r2dbc/migration/MigrationToolSpec.scala
@@ -417,6 +417,14 @@ class MigrationToolSpec
       assertDurableState(pid, "s-1")
     }
 
+    "migrate durable state of one persistenceId with an updated revision" in {
+      val pid = PersistenceId.ofUniqueId(nextPid())
+      persistDurableState(pid, "s-1")
+      persistDurableState(pid, "s-1")
+      migration.migrateDurableState(pid.id).futureValue shouldBe 1L
+      assertDurableState(pid, "s-1")
+    }
+
     "migrate durable state of a persistenceId several times" in {
       val pid = PersistenceId.ofUniqueId(nextPid())
       persistDurableState(pid, "s-1")

--- a/migration/src/main/scala/akka/persistence/r2dbc/migration/DurableStateMigrationToolDao.scala
+++ b/migration/src/main/scala/akka/persistence/r2dbc/migration/DurableStateMigrationToolDao.scala
@@ -1,0 +1,66 @@
+/*
+ * Copyright (C) 2022 - 2023 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.persistence.r2dbc.migration
+
+import java.time.Instant
+
+import scala.concurrent.ExecutionContext
+import scala.concurrent.Future
+
+import akka.Done
+import akka.annotation.InternalApi
+import akka.dispatch.ExecutionContexts
+import akka.persistence.r2dbc.internal.Dialect
+import akka.persistence.r2dbc.internal.DurableStateDao.SerializedStateRow
+import akka.persistence.r2dbc.internal.R2dbcExecutor
+import akka.persistence.r2dbc.internal.R2dbcExecutorProvider
+import akka.persistence.r2dbc.internal.postgres.PostgresDurableStateDao
+import akka.persistence.typed.PersistenceId
+
+/**
+ * INTERNAL API
+ */
+@InternalApi private[r2dbc] class DurableStateMigrationToolDao(
+    executorProvider: R2dbcExecutorProvider,
+    dialect: Dialect)(implicit ec: ExecutionContext)
+    extends PostgresDurableStateDao(executorProvider, dialect) {
+
+  def upsertDurableState(state: SerializedStateRow, value: Any): Future[Done] = {
+    val slice = persistenceExt.sliceForPersistenceId(state.persistenceId)
+    val r2dbcExecutor = executorProvider.executorFor(slice)
+    val entityType = PersistenceId.extractEntityType(state.persistenceId)
+    readState(state.persistenceId).flatMap {
+      case Some(existingState) => update(r2dbcExecutor, existingState, state, value, slice, entityType)
+      case None                => insert(r2dbcExecutor, state, value, slice, entityType)
+    }
+  }
+
+  private def insert(
+      r2dbcExecutor: R2dbcExecutor,
+      newRow: SerializedStateRow,
+      newValue: Any,
+      slice: Int,
+      entityType: String) = {
+    r2dbcExecutor
+      .updateOne(s"update state [${newRow.persistenceId}] for migration") { connection =>
+        insertStatement(entityType, newRow, newValue, slice, connection)
+      }
+      .map(_ => Done)(ExecutionContexts.parasitic)
+  }
+
+  private def update(
+      r2dbcExecutor: R2dbcExecutor,
+      currentState: SerializedStateRow,
+      newRow: SerializedStateRow,
+      newValue: Any,
+      slice: Int,
+      entityType: String) = {
+    r2dbcExecutor
+      .updateOne(s"update state [${newRow.persistenceId}] for migration") { connection =>
+        updateStatement(entityType, newRow, newValue, slice, connection, currentState.revision)
+      }
+      .map(_ => Done)(ExecutionContexts.parasitic)
+  }
+}

--- a/migration/src/main/scala/akka/persistence/r2dbc/migration/DurableStateMigrationToolDao.scala
+++ b/migration/src/main/scala/akka/persistence/r2dbc/migration/DurableStateMigrationToolDao.scala
@@ -44,7 +44,7 @@ import akka.persistence.typed.PersistenceId
       slice: Int,
       entityType: String) = {
     r2dbcExecutor
-      .updateOne(s"update state [${newRow.persistenceId}] for migration") { connection =>
+      .updateOne(s"insert state [${newRow.persistenceId}] for migration") { connection =>
         insertStatement(entityType, newRow, newValue, slice, connection)
       }
       .map(_ => Done)(ExecutionContexts.parasitic)

--- a/migration/src/main/scala/akka/persistence/r2dbc/migration/MigrationTool.scala
+++ b/migration/src/main/scala/akka/persistence/r2dbc/migration/MigrationTool.scala
@@ -126,7 +126,7 @@ class MigrationTool(system: ActorSystem[_]) {
   targetR2dbcSettings.dialectName
   require(
     !targetR2dbcSettings.durableStateAssertSingleWriter,
-    "When running the MigrationTool the " +
+    "While running the MigrationTool the " +
     "`akka.persistence.r2dbc.state.assert-single-writer` configuration must be set to off.")
 
   private val serialization: Serialization = SerializationExtension(system)

--- a/migration/src/main/scala/akka/persistence/r2dbc/migration/MigrationTool.scala
+++ b/migration/src/main/scala/akka/persistence/r2dbc/migration/MigrationTool.scala
@@ -123,6 +123,12 @@ class MigrationTool(system: ActorSystem[_]) {
   private val targetPluginId = migrationConfig.getString("target.persistence-plugin-id")
   private val targetR2dbcSettings = R2dbcSettings(system.settings.config.getConfig(targetPluginId))
 
+  targetR2dbcSettings.dialectName
+  require(
+    !targetR2dbcSettings.durableStateAssertSingleWriter,
+    "When running the MigrationTool the " +
+    "`akka.persistence.r2dbc.state.assert-single-writer` configuration must be set to off.")
+
   private val serialization: Serialization = SerializationExtension(system)
 
   private val targetExecutorProvider = new R2dbcExecutorProvider(
@@ -165,6 +171,9 @@ class MigrationTool(system: ActorSystem[_]) {
       case _           => new MigrationToolDao(targetExecutorProvider)
     }
   }
+
+  private[r2dbc] val durableStateMigrationToolDao =
+    new DurableStateMigrationToolDao(targetExecutorProvider, targetR2dbcSettings.connectionFactorySettings.dialect)
 
   private lazy val createProgressTable: Future[Done] =
     migrationDao.createProgressTable()
@@ -432,20 +441,12 @@ class MigrationTool(system: ActorSystem[_]) {
         for {
           revision <- {
             val serializedRow = serializedDurableStateRow(selectedDurableState)
-            targetDurableStateDao
-              .upsertState(serializedRow, selectedDurableState.value, changeEvent = None)
+            durableStateMigrationToolDao
+              .upsertDurableState(serializedRow, selectedDurableState.value)
               .map(_ => selectedDurableState.revision)(ExecutionContexts.parasitic)
           }
           _ <- migrationDao.updateDurableStateProgress(persistenceId, revision)
         } yield 1
-    }
-  }
-
-  private lazy val checkAssertSingleWriter: Unit = {
-    if (targetR2dbcSettings.durableStateAssertSingleWriter) {
-      throw new IllegalArgumentException(
-        "When running the MigrationTool the " +
-        "`akka.persistence.r2dbc.state.assert-single-writer` configuration must be set to off.")
     }
   }
 

--- a/migration/src/main/scala/akka/persistence/r2dbc/migration/SqlServerMigrationToolDao.scala
+++ b/migration/src/main/scala/akka/persistence/r2dbc/migration/SqlServerMigrationToolDao.scala
@@ -34,7 +34,7 @@ import io.r2dbc.spi.Statement
             )"""
   }
 
-  override def baseUpsertSql(column: String): String = {
+  override def baseUpsertMigrationProgressSql(column: String): String = {
     sql"""
          UPDATE migration_progress SET
            $column = @bindColumn


### PR DESCRIPTION
Fixes https://github.com/akka/akka-persistence-r2dbc/issues/552, successor of https://github.com/akka/akka-persistence-r2dbc/pull/553.

---

Before this pr, a new migrated state with an evolved revision was attempted to be `UPDATE`ed which failed as there exists no state to be upgraded.

This pr
- Applies an `INSERT` if a state is migrated that does not have an existing revision of its persistence id.
- Applies an `UPDATE` if a state is migrated that does have an existing revision of its persistence id.