### PR TITLE
fix: insert instead of update new state with updated revision during migration

### DIFF
--- a/core/src/main/scala/akka/persistence/r2dbc/internal/DurableStateDao.scala
+++ b/core/src/main/scala/akka/persistence/r2dbc/internal/DurableStateDao.scala
@@ -53,7 +53,9 @@ private[r2dbc] trait DurableStateDao extends BySliceQuery.Dao[DurableStateDao.Se
   def upsertState(
       state: SerializedStateRow,
       value: Any,
-      changeEvent: Option[SerializedJournalRow]): Future[Option[Instant]]
+      changeEvent: Option[SerializedJournalRow],
+      shouldInsert: (SerializedStateRow) => Future[Boolean] = state => Future.successful(state.revision == 1))
+      : Future[Option[Instant]]
 
   def deleteState(
       persistenceId: String,

--- a/core/src/main/scala/akka/persistence/r2dbc/internal/DurableStateDao.scala
+++ b/core/src/main/scala/akka/persistence/r2dbc/internal/DurableStateDao.scala
@@ -53,9 +53,7 @@ private[r2dbc] trait DurableStateDao extends BySliceQuery.Dao[DurableStateDao.Se
   def upsertState(
       state: SerializedStateRow,
       value: Any,
-      changeEvent: Option[SerializedJournalRow],
-      shouldInsert: (SerializedStateRow) => Future[Boolean] = state => Future.successful(state.revision == 1))
-      : Future[Option[Instant]]
+      changeEvent: Option[SerializedJournalRow]): Future[Option[Instant]]
 
   def deleteState(
       persistenceId: String,

--- a/core/src/main/scala/akka/persistence/r2dbc/internal/postgres/PostgresDurableStateDao.scala
+++ b/core/src/main/scala/akka/persistence/r2dbc/internal/postgres/PostgresDurableStateDao.scala
@@ -89,7 +89,7 @@ private[r2dbc] class PostgresDurableStateDao(executorProvider: R2dbcExecutorProv
   import settings.codecSettings.DurableStateImplicits._
   protected def log: Logger = PostgresDurableStateDao.log
 
-  protected val persistenceExt = Persistence(system)
+  private val persistenceExt = Persistence(system)
 
   private val sqlCache = Sql.Cache(settings.numberOfDataPartitions > 1)
 
@@ -110,7 +110,7 @@ private[r2dbc] class PostgresDurableStateDao(executorProvider: R2dbcExecutorProv
     }
   }
 
-  protected def selectStateSql(slice: Int, entityType: String): String =
+  private def selectStateSql(slice: Int, entityType: String): String =
     sqlCache.get(slice, s"selectStateSql-$entityType") {
       val stateTable = settings.getDurableStateTableWithSchema(entityType, slice)
       sql"""
@@ -222,7 +222,7 @@ private[r2dbc] class PostgresDurableStateDao(executorProvider: R2dbcExecutorProv
       createSql // no cache
   }
 
-  protected def additionalUpdateParameters(
+  private def additionalUpdateParameters(
       additionalBindings: immutable.IndexedSeq[EvaluatedAdditionalColumnBindings]): String = {
     if (additionalBindings.isEmpty) ""
     else {
@@ -238,7 +238,7 @@ private[r2dbc] class PostgresDurableStateDao(executorProvider: R2dbcExecutorProv
     }
   }
 
-  protected def hardDeleteStateSql(entityType: String, slice: Int): String = {
+  private def hardDeleteStateSql(entityType: String, slice: Int): String = {
     sqlCache.get(slice, s"hardDeleteStateSql-$entityType") {
       val stateTable = settings.getDurableStateTableWithSchema(entityType, slice)
       sql"DELETE from $stateTable WHERE persistence_id = ?"

--- a/core/src/main/scala/akka/persistence/r2dbc/internal/postgres/PostgresDurableStateDao.scala
+++ b/core/src/main/scala/akka/persistence/r2dbc/internal/postgres/PostgresDurableStateDao.scala
@@ -93,7 +93,7 @@ private[r2dbc] class PostgresDurableStateDao(executorProvider: R2dbcExecutorProv
 
   private val sqlCache = Sql.Cache(settings.numberOfDataPartitions > 1)
 
-  protected def shouldInsert: (SerializedStateRow) => Future[Boolean] = state => Future.successful(state.revision == 1)
+  protected def shouldInsert(state: SerializedStateRow): Future[Boolean] = Future.successful(state.revision == 1)
 
   // used for change events
   private lazy val journalDao: JournalDao = dialect.createJournalDao(executorProvider)

--- a/core/src/main/scala/akka/persistence/r2dbc/internal/postgres/PostgresDurableStateDao.scala
+++ b/core/src/main/scala/akka/persistence/r2dbc/internal/postgres/PostgresDurableStateDao.scala
@@ -89,7 +89,7 @@ private[r2dbc] class PostgresDurableStateDao(executorProvider: R2dbcExecutorProv
   import settings.codecSettings.DurableStateImplicits._
   protected def log: Logger = PostgresDurableStateDao.log
 
-  private val persistenceExt = Persistence(system)
+  protected val persistenceExt = Persistence(system)
 
   private val sqlCache = Sql.Cache(settings.numberOfDataPartitions > 1)
 
@@ -370,32 +370,11 @@ private[r2dbc] class PostgresDurableStateDao(executorProvider: R2dbcExecutorProv
   override def upsertState(
       state: SerializedStateRow,
       value: Any,
-      changeEvent: Option[SerializedJournalRow]): Future[Option[Instant]] = {
+      changeEvent: Option[SerializedJournalRow],
+      shouldInsert: (SerializedStateRow) => Future[Boolean]): Future[Option[Instant]] = {
     require(state.revision > 0)
     val slice = persistenceExt.sliceForPersistenceId(state.persistenceId)
     val executor = executorProvider.executorFor(slice)
-
-    def bindTags(stmt: Statement, i: Int): Statement = {
-      if (state.tags.isEmpty)
-        stmt.bindTagsNull(i)
-      else
-        stmt.bindTags(i, state.tags)
-    }
-
-    val idx = Iterator.range(0, Int.MaxValue)
-
-    def bindAdditionalColumns(
-        stmt: Statement,
-        additionalBindings: IndexedSeq[EvaluatedAdditionalColumnBindings]): Statement = {
-      additionalBindings.foreach {
-        case EvaluatedAdditionalColumnBindings(_, AdditionalColumn.BindValue(v)) =>
-          stmt.bind(idx.next(), v)
-        case EvaluatedAdditionalColumnBindings(col, AdditionalColumn.BindNull) =>
-          stmt.bindNull(idx.next(), col.fieldClass)
-        case EvaluatedAdditionalColumnBindings(_, AdditionalColumn.Skip) =>
-      }
-      stmt
-    }
 
     def change =
       new UpdatedDurableState[Any](state.persistenceId, state.revision, value, NoOffset, EmptyDbTimestamp.toEpochMilli)
@@ -403,106 +382,57 @@ private[r2dbc] class PostgresDurableStateDao(executorProvider: R2dbcExecutorProv
     val entityType = PersistenceId.extractEntityType(state.persistenceId)
 
     val result: Future[(Long, Option[Instant])] = {
-      val additionalBindings = additionalColumns.get(entityType) match {
-        case None => Vector.empty[EvaluatedAdditionalColumnBindings]
-        case Some(columns) =>
-          val slice = persistenceExt.sliceForPersistenceId(state.persistenceId)
-          val upsert = AdditionalColumn.Upsert(state.persistenceId, entityType, slice, state.revision, value)
-          columns.map(c => EvaluatedAdditionalColumnBindings(c, c.bind(upsert)))
-      }
 
-      if (state.revision == 1) {
-        def insertStatement(connection: Connection): Statement = {
-          val stmt = connection
-            .createStatement(insertStateSql(slice, entityType, additionalBindings))
-            .bind(idx.next(), slice)
-            .bind(idx.next(), entityType)
-            .bind(idx.next(), state.persistenceId)
-            .bind(idx.next(), state.revision)
-            .bind(idx.next(), state.serId)
-            .bind(idx.next(), state.serManifest)
-            .bindPayloadOption(idx.next(), state.payload)
-          bindTags(stmt, idx.next())
-          bindAdditionalColumns(stmt, additionalBindings)
+      shouldInsert(state).flatMap {
+        case true =>
+          // insert
+          def recoverDataIntegrityViolation[A](f: Future[A]): Future[A] =
+            f.recoverWith { case _: R2dbcDataIntegrityViolationException =>
+              Future.failed(
+                new IllegalStateException(
+                  s"Insert failed: durable state for persistence id [${state.persistenceId}] already exists"))
+            }
 
-          bindTimestampNow(stmt, idx.next)
-          stmt
-        }
-
-        def recoverDataIntegrityViolation[A](f: Future[A]): Future[A] =
-          f.recoverWith { case _: R2dbcDataIntegrityViolationException =>
-            Future.failed(
-              new IllegalStateException(
-                s"Insert failed: durable state for persistence id [${state.persistenceId}] already exists"))
-          }
-
-        if (!changeHandlers.contains(entityType) && changeEvent.isEmpty) {
-          val updatedRows = recoverDataIntegrityViolation(
-            executor.updateOne(s"insert [${state.persistenceId}]")(insertStatement))
-          updatedRows.map(_ -> None)
-        } else
-          executor.withConnection(s"insert [${state.persistenceId}]") { connection =>
-            for {
-              updatedRows <- recoverDataIntegrityViolation(R2dbcExecutor.updateOneInTx(insertStatement(connection)))
-              changeEventTimestamp <- writeChangeEventAndCallChangeHandler(
-                connection,
-                updatedRows,
-                entityType,
-                change,
-                changeEvent)
-            } yield (updatedRows, changeEventTimestamp)
-          }
-      } else {
-        val previousRevision = state.revision - 1
-
-        def updateStatement(connection: Connection): Statement = {
-          val stmt = connection
-            .createStatement(updateStateSql(slice, entityType, updateTags = true, additionalBindings))
-            .bind(idx.next(), state.revision)
-            .bind(idx.next(), state.serId)
-            .bind(idx.next(), state.serManifest)
-            .bindPayloadOption(idx.next(), state.payload)
-          bindTags(stmt, idx.next())
-          bindAdditionalColumns(stmt, additionalBindings)
-
-          bindTimestampNow(stmt, idx.next)
-
-          if (settings.dbTimestampMonotonicIncreasing) {
-            if (settings.durableStateAssertSingleWriter)
-              stmt
-                .bind(idx.next(), state.persistenceId)
-                .bind(idx.next(), previousRevision)
-            else
-              stmt
-                .bind(idx.next(), state.persistenceId)
-          } else {
-            stmt
-              .bind(idx.next(), state.persistenceId)
-              .bind(idx.next(), previousRevision)
-              .bind(idx.next(), state.persistenceId)
-
-            if (settings.durableStateAssertSingleWriter)
-              stmt.bind(idx.next(), previousRevision)
-            else
-              stmt
-          }
-        }
-
-        if (!changeHandlers.contains(entityType) && changeEvent.isEmpty) {
-          val updatedRows = executor.updateOne(s"update [${state.persistenceId}]")(updateStatement)
-          updatedRows.map(_ -> None)
-        } else
-          executor.withConnection(s"update [${state.persistenceId}]") { connection =>
-            for {
-              updatedRows <- R2dbcExecutor.updateOneInTx(updateStatement(connection))
-              changeEventTimestamp <- writeChangeEventAndCallChangeHandler(
-                connection,
-                updatedRows,
-                entityType,
-                change,
-                changeEvent)
-            } yield (updatedRows, changeEventTimestamp)
-          }
+          if (!changeHandlers.contains(entityType) && changeEvent.isEmpty) {
+            val insertedRows =
+              recoverDataIntegrityViolation(executor.updateOne(s"insert [${state.persistenceId}]") { connection =>
+                insertStatement(entityType, state, value, slice, connection)
+              })
+            insertedRows.map(_ -> None)
+          } else
+            executor.withConnection(s"insert [${state.persistenceId}]") { connection =>
+              for {
+                insertedRows <- recoverDataIntegrityViolation(
+                  R2dbcExecutor.updateOneInTx(insertStatement(entityType, state, value, slice, connection)))
+                changeEventTimestamp <- writeChangeEventAndCallChangeHandler(
+                  connection,
+                  insertedRows,
+                  entityType,
+                  change,
+                  changeEvent)
+              } yield (insertedRows, changeEventTimestamp)
+            }
+        case false =>
+          // update
+          val previousRevision = state.revision - 1
+          if (!changeHandlers.contains(entityType) && changeEvent.isEmpty) {
+            val updatedRows = executor.updateOne(s"update [${state.persistenceId}]") { connection =>
+              updateStatement(entityType, state, value, slice, connection, previousRevision)
+            }
+            updatedRows.map(_ -> None)
+          } else
+            executor.withConnection(s"update [${state.persistenceId}]") { connection =>
+              for {
+                updatedRows <- R2dbcExecutor.updateOneInTx(
+                  updateStatement(entityType, state, value, slice, connection, previousRevision))
+                changeEventTimestamp <- writeChangeEventAndCallChangeHandler(
+                  connection,
+                  updatedRows,
+                  entityType,
+                  change,
+                  changeEvent)
+              } yield (updatedRows, changeEventTimestamp)
+            }
       }
     }
 
@@ -963,4 +893,102 @@ private[r2dbc] class PostgresDurableStateDao(executorProvider: R2dbcExecutorProv
     result
 
   }
+
+  private def additionalBindings(
+      entityType: String,
+      state: SerializedStateRow,
+      value: Any): immutable.IndexedSeq[EvaluatedAdditionalColumnBindings] = additionalColumns.get(entityType) match {
+    case None => Vector.empty[EvaluatedAdditionalColumnBindings]
+    case Some(columns) =>
+      val slice = persistenceExt.sliceForPersistenceId(state.persistenceId)
+      val upsert = AdditionalColumn.Upsert(state.persistenceId, entityType, slice, state.revision, value)
+      columns.map(c => EvaluatedAdditionalColumnBindings(c, c.bind(upsert)))
+  }
+
+  private def bindTags(state: SerializedStateRow, stmt: Statement, i: Int): Statement = {
+    if (state.tags.isEmpty)
+      stmt.bindTagsNull(i)
+    else
+      stmt.bindTags(i, state.tags)
+  }
+
+  private def bindAdditionalColumns(
+      stmt: Statement,
+      additionalBindings: IndexedSeq[EvaluatedAdditionalColumnBindings],
+      nextIndex: () => Int): Statement = {
+    additionalBindings.foreach {
+      case EvaluatedAdditionalColumnBindings(_, AdditionalColumn.BindValue(v)) =>
+        stmt.bind(nextIndex(), v)
+      case EvaluatedAdditionalColumnBindings(col, AdditionalColumn.BindNull) =>
+        stmt.bindNull(nextIndex(), col.fieldClass)
+      case EvaluatedAdditionalColumnBindings(_, AdditionalColumn.Skip) =>
+    }
+    stmt
+  }
+
+  private def updateStatement(
+      entityType: String,
+      state: SerializedStateRow,
+      value: Any,
+      slice: Int,
+      connection: Connection,
+      previousRevision: Long): Statement = {
+    val idx = Iterator.range(0, Int.MaxValue)
+    val bindings = additionalBindings(entityType, state, value)
+    val stmt = connection
+      .createStatement(updateStateSql(slice, entityType, updateTags = true, bindings))
+      .bind(idx.next(), state.revision)
+      .bind(idx.next(), state.serId)
+      .bind(idx.next(), state.serManifest)
+      .bindPayloadOption(idx.next(), state.payload)
+    bindTags(state, stmt, idx.next())
+    bindAdditionalColumns(stmt, bindings, idx.next)
+
+    bindTimestampNow(stmt, idx.next)
+
+    if (settings.dbTimestampMonotonicIncreasing) {
+      if (settings.durableStateAssertSingleWriter)
+        stmt
+          .bind(idx.next(), state.persistenceId)
+          .bind(idx.next(), previousRevision)
+      else
+        stmt
+          .bind(idx.next(), state.persistenceId)
+    } else {
+      stmt
+        .bind(idx.next(), state.persistenceId)
+        .bind(idx.next(), previousRevision)
+        .bind(idx.next(), state.persistenceId)
+
+      if (settings.durableStateAssertSingleWriter)
+        stmt.bind(idx.next(), previousRevision)
+      else
+        stmt
+    }
+  }
+
+  private def insertStatement(
+      entityType: String,
+      state: SerializedStateRow,
+      value: Any,
+      slice: Int,
+      connection: Connection): Statement = {
+    val idx = Iterator.range(0, Int.MaxValue)
+    val bindings = additionalBindings(entityType, state, value)
+    val stmt = connection
+      .createStatement(insertStateSql(slice, entityType, bindings))
+      .bind(idx.next(), slice)
+      .bind(idx.next(), entityType)
+      .bind(idx.next(), state.persistenceId)
+      .bind(idx.next(), state.revision)
+      .bind(idx.next(), state.serId)
+      .bind(idx.next(), state.serManifest)
+      .bindPayloadOption(idx.next(), state.payload)
+    bindTags(state, stmt, idx.next())
+    bindAdditionalColumns(stmt, bindings, idx.next)
+
+    bindTimestampNow(stmt, idx.next)
+    stmt
+  }
+
 }

--- a/migration-tests/src/test/resources/application-postgres.conf
+++ b/migration-tests/src/test/resources/application-postgres.conf
@@ -46,3 +46,12 @@ jdbc-read-journal {
 
 # application specific serializers for events and snapshots
 # must also be configured and included in classpath
+
+akka.persistence.r2dbc.state {
+  additional-columns {
+    "" = ["akka.persistence.r2dbc.migration.MigrationTestColumn"]
+  }
+  change-handler {
+    "" = "akka.persistence.r2dbc.migration.MigrationChangeHandler"
+  }
+}

--- a/migration-tests/src/test/scala/akka/persistence/r2dbc/migration/MigrationChangeHandler.scala
+++ b/migration-tests/src/test/scala/akka/persistence/r2dbc/migration/MigrationChangeHandler.scala
@@ -1,0 +1,42 @@
+/*
+ * Copyright (C) 2022 - 2023 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.persistence.r2dbc.migration
+
+import scala.concurrent.ExecutionContext
+import scala.concurrent.Future
+
+import akka.Done
+import akka.actor.typed.ActorSystem
+import akka.persistence.Persistence
+import akka.persistence.query.DurableStateChange
+import akka.persistence.query.UpdatedDurableState
+import akka.persistence.r2dbc.session.scaladsl.R2dbcSession
+import akka.persistence.r2dbc.state.scaladsl.ChangeHandler
+
+class MigrationChangeHandler(system: ActorSystem[_]) extends ChangeHandler[Any] {
+
+  private val incrementSql =
+    "INSERT INTO test_counter (persistence_id, slice, counter) VALUES ($1, $2, 1) " +
+    "ON CONFLICT (persistence_id, slice) DO UPDATE SET counter = excluded.counter + 1"
+
+  private implicit val ec: ExecutionContext = system.executionContext
+
+  println(incrementSql)
+
+  override def process(session: R2dbcSession, change: DurableStateChange[Any]): Future[Done] = {
+    println("process changer")
+    change match {
+      case state: UpdatedDurableState[_] =>
+        if (state.value.asInstanceOf[String] == "s-handler") {
+          val slice = Persistence(system).sliceForPersistenceId(state.persistenceId)
+          val stmt = session
+            .createStatement(incrementSql)
+            .bind(0, state.persistenceId)
+            .bind(1, slice)
+          session.updateOne(stmt).map(_ => Done)
+        } else Future.successful(Done)
+    }
+  }
+}

--- a/migration-tests/src/test/scala/akka/persistence/r2dbc/migration/MigrationTestColumn.scala
+++ b/migration-tests/src/test/scala/akka/persistence/r2dbc/migration/MigrationTestColumn.scala
@@ -12,7 +12,6 @@ class MigrationTestColumn extends AdditionalColumn[Any, String] {
 
   override def bind(upsert: AdditionalColumn.Upsert[Any]): AdditionalColumn.Binding[String] = {
     if (upsert.value.asInstanceOf[String] == "s-column") {
-      println(s"??? ${upsert.value.asInstanceOf[String]}")
       AdditionalColumn.BindValue("my value")
     } else AdditionalColumn.Skip
   }

--- a/migration-tests/src/test/scala/akka/persistence/r2dbc/migration/MigrationTestColumn.scala
+++ b/migration-tests/src/test/scala/akka/persistence/r2dbc/migration/MigrationTestColumn.scala
@@ -1,0 +1,19 @@
+/*
+ * Copyright (C) 2022 - 2023 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.persistence.r2dbc.migration
+
+import akka.persistence.r2dbc.state.scaladsl.AdditionalColumn
+
+class MigrationTestColumn extends AdditionalColumn[Any, String] {
+
+  override val columnName: String = "test_column"
+
+  override def bind(upsert: AdditionalColumn.Upsert[Any]): AdditionalColumn.Binding[String] = {
+    if (upsert.value.asInstanceOf[String] == "s-column") {
+      println(s"??? ${upsert.value.asInstanceOf[String]}")
+      AdditionalColumn.BindValue("my value")
+    } else AdditionalColumn.Skip
+  }
+}

--- a/migration/src/main/scala/akka/persistence/r2dbc/migration/DurableStateMigrationToolDao.scala
+++ b/migration/src/main/scala/akka/persistence/r2dbc/migration/DurableStateMigrationToolDao.scala
@@ -1,0 +1,35 @@
+/*
+ * Copyright (C) 2022 - 2023 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.persistence.r2dbc.migration
+
+import scala.concurrent.ExecutionContext
+import scala.concurrent.Future
+
+import akka.Done
+import akka.annotation.InternalApi
+import akka.dispatch.ExecutionContexts
+import akka.persistence.r2dbc.internal.Dialect
+import akka.persistence.r2dbc.internal.DurableStateDao.SerializedStateRow
+import akka.persistence.r2dbc.internal.R2dbcExecutorProvider
+import akka.persistence.r2dbc.internal.postgres.PostgresDurableStateDao
+
+/**
+ * INTERNAL API
+ */
+@InternalApi private[r2dbc] class DurableStateMigrationToolDao(
+    executorProvider: R2dbcExecutorProvider,
+    dialect: Dialect)(implicit ec: ExecutionContext)
+    extends PostgresDurableStateDao(executorProvider, dialect) {
+
+  def upsertDurableState(state: SerializedStateRow, value: Any): Future[Done] = {
+
+    def shouldInsert = (state: SerializedStateRow) =>
+      readState(state.persistenceId).map {
+        case Some(_) => false
+        case None    => true
+      }
+    upsertState(state, value, None, shouldInsert).map(_ => Done)(ExecutionContexts.parasitic)
+  }
+}

--- a/migration/src/main/scala/akka/persistence/r2dbc/migration/DurableStateMigrationToolDao.scala
+++ b/migration/src/main/scala/akka/persistence/r2dbc/migration/DurableStateMigrationToolDao.scala
@@ -7,9 +7,7 @@ package akka.persistence.r2dbc.migration
 import scala.concurrent.ExecutionContext
 import scala.concurrent.Future
 
-import akka.Done
 import akka.annotation.InternalApi
-import akka.dispatch.ExecutionContexts
 import akka.persistence.r2dbc.internal.Dialect
 import akka.persistence.r2dbc.internal.DurableStateDao.SerializedStateRow
 import akka.persistence.r2dbc.internal.R2dbcExecutorProvider
@@ -28,10 +26,8 @@ import akka.persistence.r2dbc.internal.postgres.PostgresDurableStateDao
    * want to INSERT INTO if its the first revision.
    * @return
    */
-  override protected def shouldInsert: SerializedStateRow => Future[Boolean] = (state: SerializedStateRow) =>
-    readState(state.persistenceId).map {
-      case Some(_) => false
-      case None    => true
-    }
-
+  override protected def shouldInsert(state: SerializedStateRow): Future[Boolean] = readState(state.persistenceId).map {
+    case Some(_) => false
+    case None    => true
+  }
 }

--- a/migration/src/main/scala/akka/persistence/r2dbc/migration/MigrationTool.scala
+++ b/migration/src/main/scala/akka/persistence/r2dbc/migration/MigrationTool.scala
@@ -442,7 +442,7 @@ class MigrationTool(system: ActorSystem[_]) {
           revision <- {
             val serializedRow = serializedDurableStateRow(selectedDurableState)
             durableStateMigrationToolDao
-              .upsertDurableState(serializedRow, selectedDurableState.value)
+              .upsertState(serializedRow, selectedDurableState.value, None)
               .map(_ => selectedDurableState.revision)(ExecutionContexts.parasitic)
           }
           _ <- migrationDao.updateDurableStateProgress(persistenceId, revision)

--- a/migration/src/main/scala/akka/persistence/r2dbc/migration/MigrationTool.scala
+++ b/migration/src/main/scala/akka/persistence/r2dbc/migration/MigrationTool.scala
@@ -123,6 +123,12 @@ class MigrationTool(system: ActorSystem[_]) {
   private val targetPluginId = migrationConfig.getString("target.persistence-plugin-id")
   private val targetR2dbcSettings = R2dbcSettings(system.settings.config.getConfig(targetPluginId))
 
+  targetR2dbcSettings.dialectName
+  require(
+    !targetR2dbcSettings.durableStateAssertSingleWriter,
+    "While running the MigrationTool the " +
+    "`akka.persistence.r2dbc.state.assert-single-writer` configuration must be set to off.")
+
   private val serialization: Serialization = SerializationExtension(system)
 
   private val targetExecutorProvider = new R2dbcExecutorProvider(
@@ -165,6 +171,9 @@ class MigrationTool(system: ActorSystem[_]) {
       case _           => new MigrationToolDao(targetExecutorProvider)
     }
   }
+
+  private[r2dbc] val durableStateMigrationToolDao =
+    new DurableStateMigrationToolDao(targetExecutorProvider, targetR2dbcSettings.connectionFactorySettings.dialect)
 
   private lazy val createProgressTable: Future[Done] =
     migrationDao.createProgressTable()
@@ -432,20 +441,12 @@ class MigrationTool(system: ActorSystem[_]) {
         for {
           revision <- {
             val serializedRow = serializedDurableStateRow(selectedDurableState)
-            targetDurableStateDao
-              .upsertState(serializedRow, selectedDurableState.value, changeEvent = None)
+            durableStateMigrationToolDao
+              .upsertDurableState(serializedRow, selectedDurableState.value)
               .map(_ => selectedDurableState.revision)(ExecutionContexts.parasitic)
           }
           _ <- migrationDao.updateDurableStateProgress(persistenceId, revision)
         } yield 1
-    }
-  }
-
-  private lazy val checkAssertSingleWriter: Unit = {
-    if (targetR2dbcSettings.durableStateAssertSingleWriter) {
-      throw new IllegalArgumentException(
-        "When running the MigrationTool the " +
-        "`akka.persistence.r2dbc.state.assert-single-writer` configuration must be set to off.")
     }
   }
 

--- a/migration/src/main/scala/akka/persistence/r2dbc/migration/SqlServerMigrationToolDao.scala
+++ b/migration/src/main/scala/akka/persistence/r2dbc/migration/SqlServerMigrationToolDao.scala
@@ -34,7 +34,7 @@ import io.r2dbc.spi.Statement
             )"""
   }
 
-  override def baseUpsertSql(column: String): String = {
+  override def baseUpsertMigrationProgressSql(column: String): String = {
     sql"""
          UPDATE migration_progress SET
            $column = @bindColumn


### PR DESCRIPTION
Reopening of #554, follow up to https://github.com/akka/akka-persistence-r2dbc/pull/560

Open tasks:
- [x] look into adding tests for additional column and change handler