### PR TITLE
doc: Sharding vs partitioning

### DIFF
--- a/docs/src/main/paradox/data-partition.md
+++ b/docs/src/main/paradox/data-partition.md
@@ -1,4 +1,4 @@
-# Data partitioning
+# Database sharding
 
 Using a single non-distributed database can become a bottleneck for applications that have high throughput
 requirements. To be able to spread the load over more than one database the event journal, snapshot store and
@@ -13,7 +13,8 @@ A data partition corresponds to a separate database table. For example, 4 data p
 and (768 to 1023) to data partition 3.
 
 Number of data partitions must be between 1 and 1024 and a whole number divisor of 1024 (number of slices), e.g.
-2, 4, 8, 16. The tables will have the data partition as suffix, e.g. event_journal_0, event_journal_1.
+2, 4, 8, 16. Each data partition corresponds to a database table. The tables will have the data partition as suffix,
+e.g. event_journal_0, event_journal_1.
 
 Those tables can be located in physically separate databases. Number of databases must be a whole number divisor
 of number of partitions, and less than or equal to number of partitions. For example, 8 data partitions and 2 databases

--- a/docs/src/main/paradox/index.md
+++ b/docs/src/main/paradox/index.md
@@ -15,7 +15,7 @@ The Akka Persistence R2DBC plugin allows for using SQL database with R2DBC as a 
 * [PostgreSQL JSON](postgres_json.md)
 * [Projection](projection.md)
 * [Configuration](config.md)
-* [Data partitioning](data-partition.md)
+* [Database sharding](data-partition.md)
 * [Cleanup tool](cleanup.md)
 * [Migration tool](migration.md)
 * [Migration Guide](migration-guide.md)


### PR DESCRIPTION
Trigged by some feedback I looked closer at what others say regarding sharding vs partitioning.Seems like sharding is mostly used for horizontal partitioning to distribute the data across multiple servers. While partitioning is a more generic term it mostly refers to splitting up large tables into smaller tables, but still in one database instance (*vertical scaling").

Our primary goal is horizontal scaling so we should highlight database sharding.

That said, the implementation splits the data into multiple tables (partitioning), which can then optionally be located on different database instances (sharding). The documentation still uses data partition and that it corresponds to a table. I think that is fine, but let me know if it's confusing.