### PR TITLE
test: correct sequence number for delete single snapshot test

### DIFF
--- a/docs/src/main/paradox/snapshots.md
+++ b/docs/src/main/paradox/snapshots.md
@@ -21,7 +21,7 @@ configurations are supported.
 
 @@@ note
 Snapshots are optional, and if you know that the application doesn't store many events for each entity it is more
-efficient to not enable the snapshot plugin, because then it will not try to read snapshots when recovering the entites.
+efficient to not enable the snapshot plugin, because then it will not try to read snapshots when recovering the entities.
 @@@
 
 See also @ref:[Connection configuration](config.md#connection-configuration).


### PR DESCRIPTION
Noticed when reusing this test elsewhere: sequence number was incorrect, so it wasn't actually deleting a snapshot. Test still passed as successful if there's no matching snapshot. Rather than just set to the correct sequence number (15) also future proof by checking what it is before delete.

Also fix a typo in the snapshot store docs.