### PR TITLE
fix: stuck queries when too many events with same timestamp

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -203,7 +203,7 @@ jobs:
 
       - name: Start DB
         run: |-
-          docker-compose -f docker/docker-compose-yugabyte.yml up -d
+          docker compose -f docker/docker-compose-yugabyte.yml up -d
           # TODO: could we poll the port instead of sleep?
           sleep 10
           docker exec -i yb-tserver-n1 /home/yugabyte/bin/ysqlsh -h yb-tserver-n1 -t < ddl-scripts/create_tables_yugabyte.sql

--- a/core/src/main/mima-filters/1.2.4.backwards.excludes/rows-by-slices.excludes
+++ b/core/src/main/mima-filters/1.2.4.backwards.excludes/rows-by-slices.excludes
@@ -1,0 +1,3 @@
+# internals: fromSeqNr added to rowsBySlices
+ProblemFilters.exclude[DirectMissingMethodProblem]("akka.persistence.r2dbc.internal.BySliceQuery#Dao.rowsBySlices")
+ProblemFilters.exclude[ReversedMissingMethodProblem]("akka.persistence.r2dbc.internal.BySliceQuery#Dao.rowsBySlices")

--- a/core/src/main/scala/akka/persistence/r2dbc/internal/BySliceQuery.scala
+++ b/core/src/main/scala/akka/persistence/r2dbc/internal/BySliceQuery.scala
@@ -74,9 +74,8 @@ import org.slf4j.Logger
     }
   }
 
-  private def highestSeenSeqNr(offset: TimestampOffset): Option[Long] = {
-    if (offset.seen.isEmpty) None else Some(offset.seen.values.max)
-  }
+  private def highestSeenSeqNr(offset: TimestampOffset): Option[Long] =
+    Option.when(offset.seen.nonEmpty)(offset.seen.values.max)
 
   object Buckets {
     type EpochSeconds = Long

--- a/core/src/main/scala/akka/persistence/r2dbc/internal/postgres/PostgresDurableStateDao.scala
+++ b/core/src/main/scala/akka/persistence/r2dbc/internal/postgres/PostgresDurableStateDao.scala
@@ -653,6 +653,7 @@ private[r2dbc] class PostgresDurableStateDao(executorProvider: R2dbcExecutorProv
       minSlice: Int,
       maxSlice: Int,
       fromTimestamp: Instant,
+      fromSeqNr: Option[Long],
       toTimestamp: Option[Instant],
       behindCurrentTime: FiniteDuration,
       backtracking: Boolean): Source[SerializedStateRow, NotUsed] = {

--- a/core/src/main/scala/akka/persistence/r2dbc/internal/postgres/PostgresSnapshotDao.scala
+++ b/core/src/main/scala/akka/persistence/r2dbc/internal/postgres/PostgresSnapshotDao.scala
@@ -388,6 +388,7 @@ private[r2dbc] class PostgresSnapshotDao(executorProvider: R2dbcExecutorProvider
       minSlice: Int,
       maxSlice: Int,
       fromTimestamp: Instant,
+      fromSeqNr: Option[Long],
       toTimestamp: Option[Instant],
       behindCurrentTime: FiniteDuration,
       backtracking: Boolean): Source[SerializedSnapshotRow, NotUsed] = {

--- a/docker/docker-compose-sqlserver.yml
+++ b/docker/docker-compose-sqlserver.yml
@@ -1,7 +1,7 @@
 version: '2.2'
 services:
   sqlserver:
-    image: mcr.microsoft.com/mssql/server:2022-latest
+    image: mcr.microsoft.com/mssql/server:2022-CU13-ubuntu-22.04
     container_name: sqlserver-db
     environment:
       - MSSQL_SA_PASSWORD=<YourStrong@Passw0rd>


### PR DESCRIPTION
We've seen a case where more than 1000 events were persisted together (so have the same timestamp), and more than the default query buffer size, and then queries will be stuck on the same timestamp and never make further progress.

Since events are ordered by timestamp and sequence number, update the queries to also filter by the highest seen seq number for the latest timestamp (only for events with the same timestamp as this starting timestamp). Fixes the case where all the events are for the same persistence id. Queries will still duplicate on the events with both the same timestamp and seq number (different persistence ids), to handle events across the buffer limit. The very edge case of more events than the buffer size all with the same timestamp and the same seq number (from different persistent ids) would not be handled.

So this always ends up adding an additional filter to queries. We could look at only adding this extra conditional check when the latest timestamp is the same as the previous query (that returned results), to only handle this particular case. The backtracking filtered adjustment (updated in this PR) would need to be aware of this too.

Another alternative is to go further, and always do all the filtering on the database side. Adding conditions for all the latest seen sequence numbers, conditional per persistence id. We would then expect no duplicated events from queries. It complicates the queries even more though, with something like `db_timestamp >= :from_timestamp AND ((persistence_id NOT IN (pid1, pid2, ..., pidN) OR (persistence_id = pid1 AND seq_nr > pid1SeqNr) OR (persistence_id = pid2 AND seq_nr > pid2SeqNr) OR ... OR (persistence_id = pidN AND seq_nr > pidNSeqNr))`. But this would also guarantee progress in all cases, and the additional conditions are only for the 'seen' persistence ids that share the same latest timestamp.

Marking draft while this is under discussion.