### PR TITLE
fix: filter heartbeats early in pubsub merge

### DIFF
--- a/core/src/main/scala/akka/persistence/r2dbc/internal/BySliceQuery.scala
+++ b/core/src/main/scala/akka/persistence/r2dbc/internal/BySliceQuery.scala
@@ -562,6 +562,9 @@ import org.slf4j.Logger
         None
     }
 
+    val nextHeartbeat: QueryState => Option[Envelope] =
+      if (settings.journalPublishEvents) heartbeat else _ => None
+
     val currentTimestamp =
       if (settings.useAppTimestamp) Future.successful(InstantFactory.now())
       else dao.currentDbTimestamp(minSlice)
@@ -577,7 +580,7 @@ import org.slf4j.Logger
             delayNextQuery = delayNextQuery,
             nextQuery = nextQuery,
             beforeQuery = beforeQuery(logPrefix, entityType, minSlice, maxSlice, _),
-            heartbeat = heartbeat)
+            heartbeat = nextHeartbeat)
         }
       }
       .mapMaterializedValue(_ => NotUsed)

--- a/core/src/test/scala/akka/persistence/r2dbc/query/EventsBySliceBacktrackingSpec.scala
+++ b/core/src/test/scala/akka/persistence/r2dbc/query/EventsBySliceBacktrackingSpec.scala
@@ -112,7 +112,6 @@ class EventsBySliceBacktrackingSpec
       val result: TestSubscriber.Probe[EventEnvelope[String]] =
         query
           .eventsBySlices[String](entityType, 0, persistenceExt.numberOfSlices - 1, NoOffset)
-          .filterNot(EnvelopeOrigin.fromHeartbeat)
           .runWith(sinkProbe)
           .request(100)
 
@@ -205,7 +204,6 @@ class EventsBySliceBacktrackingSpec
       def startQuery(offset: Offset): TestSubscriber.Probe[EventEnvelope[String]] =
         query
           .eventsBySlices[String](entityType, 0, persistenceExt.numberOfSlices - 1, offset)
-          .filterNot(EnvelopeOrigin.fromHeartbeat)
           .runWith(sinkProbe)
           .request(100)
 
@@ -266,7 +264,6 @@ class EventsBySliceBacktrackingSpec
       def startQuery(offset: Offset): TestSubscriber.Probe[EventEnvelope[String]] =
         query
           .eventsBySlices[String](entityType, 0, persistenceExt.numberOfSlices - 1, offset)
-          .filterNot(EnvelopeOrigin.fromHeartbeat)
           .runWith(sinkProbe)
           .request(1000)
 
@@ -328,7 +325,6 @@ class EventsBySliceBacktrackingSpec
       def startQuery(offset: Offset): TestSubscriber.Probe[EventEnvelope[String]] =
         query
           .eventsBySlices[String](entityType, 0, persistenceExt.numberOfSlices - 1, offset)
-          .filterNot(EnvelopeOrigin.fromHeartbeat)
           .runWith(sinkProbe)
           .request(1000)
 
@@ -401,7 +397,6 @@ class EventsBySliceBacktrackingSpec
       val result: TestSubscriber.Probe[EventEnvelope[String]] =
         query
           .eventsBySlices[String](entityType, 0, persistenceExt.numberOfSlices - 1, latestOffset)
-          .filterNot(EnvelopeOrigin.fromHeartbeat)
           .runWith(sinkProbe)
           .request(numberOfEvents)
 

--- a/core/src/test/scala/akka/persistence/r2dbc/query/EventsBySlicePerfSpec.scala
+++ b/core/src/test/scala/akka/persistence/r2dbc/query/EventsBySlicePerfSpec.scala
@@ -166,7 +166,6 @@ class EventsBySlicePerfSpec
         val done: Future[Done] =
           query
             .eventsBySlices[String](entityType, 0, persistenceExt.numberOfSlices - 1, NoOffset)
-            .filterNot(EnvelopeOrigin.fromHeartbeat)
             .scan(Set.empty[PidSeqNr]) { case (acc, env) =>
               val newAcc = acc + PidSeqNr(env.persistenceId, env.sequenceNr)
 

--- a/core/src/test/scala/akka/persistence/r2dbc/query/EventsBySliceSpec.scala
+++ b/core/src/test/scala/akka/persistence/r2dbc/query/EventsBySliceSpec.scala
@@ -49,8 +49,6 @@ import com.typesafe.config.ConfigFactory
 import org.scalatest.wordspec.AnyWordSpecLike
 import org.slf4j.LoggerFactory
 
-import akka.persistence.r2dbc.internal.EnvelopeOrigin
-
 object EventsBySliceSpec {
   sealed trait QueryType
   case object Live extends QueryType
@@ -141,9 +139,7 @@ class EventsBySliceSpec
         queryImpl: R2dbcReadJournal = query): Source[EventEnvelope[String], NotUsed] =
       queryType match {
         case Live =>
-          queryImpl
-            .eventsBySlices[String](entityType, minSlice, maxSlice, offset)
-            .filterNot(EnvelopeOrigin.fromHeartbeat)
+          queryImpl.eventsBySlices[String](entityType, minSlice, maxSlice, offset)
         case Current =>
           queryImpl.currentEventsBySlices[String](entityType, minSlice, maxSlice, offset)
       }

--- a/core/src/test/scala/akka/persistence/r2dbc/query/EventsBySliceStartingFromSnapshotSpec.scala
+++ b/core/src/test/scala/akka/persistence/r2dbc/query/EventsBySliceStartingFromSnapshotSpec.scala
@@ -31,8 +31,6 @@ import com.typesafe.config.Config
 import com.typesafe.config.ConfigFactory
 import org.scalatest.wordspec.AnyWordSpecLike
 
-import akka.persistence.r2dbc.internal.EnvelopeOrigin
-
 object EventsBySliceStartingFromSnapshotSpec {
   sealed trait QueryType
   case object Live extends QueryType
@@ -89,9 +87,12 @@ class EventsBySliceStartingFromSnapshotSpec
         queryImpl: R2dbcReadJournal = query): Source[EventEnvelope[String], NotUsed] =
       queryType match {
         case Live =>
-          queryImpl
-            .eventsBySlicesStartingFromSnapshots[String, String](entityType, minSlice, maxSlice, offset, snap => snap)
-            .filterNot(EnvelopeOrigin.fromHeartbeat)
+          queryImpl.eventsBySlicesStartingFromSnapshots[String, String](
+            entityType,
+            minSlice,
+            maxSlice,
+            offset,
+            snap => snap)
         case Current =>
           queryImpl.currentEventsBySlicesStartingFromSnapshots[String, String](
             entityType,


### PR DESCRIPTION
Filter heartbeats once received by the skip pubsub if too far ahead check.

Remove some extra filtering from tests again, which should fail if heartbeats are emitted.

Have left the heartbeat creation as is, including the search for appropriate persistence id, but heartbeats could also be simpler dummy envelopes now that they're not going further and to the offset store.