### PR TITLE
fix: only initial backtracking up to start offset when far behind

### DIFF
--- a/core/src/main/scala/akka/persistence/r2dbc/internal/BySliceQuery.scala
+++ b/core/src/main/scala/akka/persistence/r2dbc/internal/BySliceQuery.scala
@@ -433,9 +433,12 @@ import org.slf4j.Logger
 
       def disableBacktrackingWhenFarBehindCurrentWallClockTime: Boolean = {
         val aheadOfInitial =
-          initialOffset == TimestampOffset.Zero || state.latestBacktracking.timestamp.isAfter(initialOffset.timestamp)
+          initialOffset == TimestampOffset.Zero ||
+          state.latestBacktracking.timestamp.compareTo(initialOffset.timestamp) >= 0
+
         val previousTimestamp =
           if (state.previous == TimestampOffset.Zero) state.latest.timestamp else state.previous.timestamp
+
         aheadOfInitial &&
         previousTimestamp.isBefore(clock.instant().minus(firstBacktrackingQueryWindow))
       }


### PR DESCRIPTION
Corresponding to https://github.com/akka/akka-persistence-dynamodb/pull/109