### PR TITLE
fix: link validator ignore for String$

### DIFF
--- a/scripts/link-validator.conf
+++ b/scripts/link-validator.conf
@@ -27,7 +27,7 @@ site-link-validator {
     "https://mvnrepository.com/artifact/",
     "https://repo.akka.io/",
     # created in api/akka-persistence-r2dbc/snapshot/akka/persistence/r2dbc/internal/Sql$.html
-    "https://docs.oracle.com/en/java/javase/21/docs/api/java.base/java/lang/String$.html"
+    "https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/lang/String$.html"
   ]
 
   non-https-whitelist = [


### PR DESCRIPTION
PRs have been failing link validation, on linking to `String$`. There's already an ignore for this, but docs and link validator are building with Java 17.