### PR TITLE
fix: Bucket count query start timestamp

### DIFF
--- a/core/src/main/mima-filters/1.3.0.backwards.excludes/buckets.excludes
+++ b/core/src/main/mima-filters/1.3.0.backwards.excludes/buckets.excludes
@@ -1,0 +1,3 @@
+# internals
+ProblemFilters.exclude[DirectMissingMethodProblem]("akka.persistence.r2dbc.internal.BySliceQuery#Buckets.clearUntil")
+


### PR DESCRIPTION
* it was using state.latestBacktracking.timestamp as fromTimestamp for the bucket count query, which will not progress when backtracking is disabled
* instead, use (almost) last bucket time from previous query
