### PR TITLE
feat: add setting for estimating time ranges using bucket count queries

### DIFF
--- a/core/src/main/resources/reference.conf
+++ b/core/src/main/resources/reference.conf
@@ -167,6 +167,10 @@ akka.persistence.r2dbc {
       # See also https://doc.akka.io/libraries/akka-persistence-r2dbc/current/migration-guide.html#eventsBySlicesStartingFromSnapshots
       enabled = false
     }
+
+    # Estimate time ranges to optimize slice-based query performance.
+    # Uses additional queries to count events or state changes into time buckets.
+    estimate-time-range = on
   }
 }
 // #query-settings

--- a/core/src/main/scala/akka/persistence/r2dbc/R2dbcSettings.scala
+++ b/core/src/main/scala/akka/persistence/r2dbc/R2dbcSettings.scala
@@ -493,6 +493,7 @@ final class QuerySettings(config: Config) {
   val persistenceIdsBufferSize: Int = config.getInt("persistence-ids.buffer-size")
   val deduplicateCapacity: Int = config.getInt("deduplicate-capacity")
   val startFromSnapshotEnabled: Boolean = config.getBoolean("start-from-snapshot.enabled")
+  val estimateTimeRange: Boolean = config.getBoolean("estimate-time-range")
 }
 
 /**

--- a/core/src/main/scala/akka/persistence/r2dbc/internal/BySliceQuery.scala
+++ b/core/src/main/scala/akka/persistence/r2dbc/internal/BySliceQuery.scala
@@ -138,23 +138,27 @@ import org.slf4j.Logger
     import Buckets.{ Bucket, BucketDurationSeconds, Count, EpochSeconds }
 
     def findTimeForLimit(from: Instant, atLeastCounts: Int): Option[Instant] = {
-      val fromEpochSeconds = from.toEpochMilli / 1000
-      val iter = countByBucket.iterator.dropWhile { case (key, _) => fromEpochSeconds >= key }
-
-      @tailrec def sumUntilFilled(key: EpochSeconds, sum: Count): (EpochSeconds, Count) = {
-        if (iter.isEmpty || sum >= atLeastCounts)
-          key -> sum
-        else {
-          val (nextKey, count) = iter.next()
-          sumUntilFilled(nextKey, sum + count)
-        }
-      }
-
-      val (key, sum) = sumUntilFilled(fromEpochSeconds, 0)
-      if (sum >= atLeastCounts)
-        Some(Instant.ofEpochSecond(key + BucketDurationSeconds))
-      else
+      if (isEmpty) {
         None
+      } else {
+        val fromEpochSeconds = from.toEpochMilli / 1000
+        val iter = countByBucket.iterator.dropWhile { case (key, _) => fromEpochSeconds >= key }
+
+        @tailrec def sumUntilFilled(key: EpochSeconds, sum: Count): (EpochSeconds, Count) = {
+          if (iter.isEmpty || sum >= atLeastCounts)
+            key -> sum
+          else {
+            val (nextKey, count) = iter.next()
+            sumUntilFilled(nextKey, sum + count)
+          }
+        }
+
+        val (key, sum) = sumUntilFilled(fromEpochSeconds, 0)
+        if (sum >= atLeastCounts)
+          Some(Instant.ofEpochSecond(key + BucketDurationSeconds))
+        else
+          None
+      }
     }
 
     // Key is the epoch seconds for the start of the bucket.
@@ -170,14 +174,18 @@ import org.slf4j.Logger
     }
 
     def clearUntil(time: Instant): Buckets = {
-      val epochSeconds = time.minusSeconds(BucketDurationSeconds).toEpochMilli / 1000
-      val newCountByBucket = countByBucket.dropWhile { case (key, _) => epochSeconds >= key }
-      if (newCountByBucket.size == countByBucket.size)
+      if (isEmpty) {
         this
-      else if (newCountByBucket.isEmpty)
-        new Buckets(immutable.SortedMap(countByBucket.last), createdAt = this.createdAt) // keep last
-      else
-        new Buckets(newCountByBucket, createdAt = this.createdAt)
+      } else {
+        val epochSeconds = time.minusSeconds(BucketDurationSeconds).toEpochMilli / 1000
+        val newCountByBucket = countByBucket.dropWhile { case (key, _) => epochSeconds >= key }
+        if (newCountByBucket.size == countByBucket.size)
+          this
+        else if (newCountByBucket.isEmpty)
+          new Buckets(immutable.SortedMap(countByBucket.last), createdAt = this.createdAt) // keep last
+        else
+          new Buckets(newCountByBucket, createdAt = this.createdAt)
+      }
     }
 
     def nextStartTime: Option[Instant] = {
@@ -603,7 +611,8 @@ import org.slf4j.Logger
       maxSlice: Int,
       state: QueryState): Option[Future[QueryState]] = {
     // Don't run this too frequently
-    if ((state.buckets.isEmpty || JDuration
+    if (settings.querySettings.estimateTimeRange &&
+      (state.buckets.isEmpty || JDuration
         .between(state.buckets.createdAt, InstantFactory.now())
         .compareTo(eventBucketCountInterval) > 0) &&
       // For Durable State we always refresh the bucket counts at the interval. For Event Sourced we know


### PR DESCRIPTION
To make it possible to disable the bucket count queries, to use alternative indexes for the by-slice queries.