### PR TITLE
Revert "bump: scala-library 2.13.16 (was 2.13.15) (#648)"

### DIFF
--- a/.scala-steward.conf
+++ b/.scala-steward.conf
@@ -9,6 +9,7 @@ updates.ignore = [
   { groupId = "org.scalameta", artifactId = "scalafmt-core" },
   { groupId = "org.scalameta", artifactId = "sbt-scalafmt" }
   { groupId = "com.typesafe.akka" },
+  { groupId = "org.scala-lang" }
 ]
 
 updatePullRequests = fals

--- a/native-image-tests/build.sbt
+++ b/native-image-tests/build.sbt
@@ -2,7 +2,7 @@ name := "native-image-tests"
 
 version := "1.0"
 
-scalaVersion := "2.13.16"
+scalaVersion := "2.13.15"
 
 resolvers += "Akka library repository".at("https://repo.akka.io/maven")
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -5,7 +5,7 @@
 import sbt._
 
 object Dependencies {
-  val Scala213 = "2.13.16"
+  val Scala213 = "2.13.15"
   val Scala3 = "3.3.4"
   val Scala2Versions = Seq(Scala213)
   val ScalaVersions = Dependencies.Scala2Versions :+ Dependencies.Scala3


### PR DESCRIPTION
This reverts commit 080467538248db24823d3d5745c5f2e976422717.

Reverts https://github.com/akka/akka-persistence-r2dbc/pull/648 for now because it enforces updates to all downstream usage, including end users. We'll probably have to bump Scala versions in a more coordinated way, from the ground up.

```
scalaInstance) expected `scalaVersion` to be "2.13.16" or later,
[error] but found "2.13.15"; upgrade scalaVersion to fix the build.
[error]
[error] to support backwards-only binary compatibility (SIP-51),
[error] the Scala 2.13 compiler cannot be older than scala-library on the
[error] dependency classpath.
```