### PR TITLE
perf: Use select per slice for latestEventTimestamp

### DIFF
--- a/core/src/test/scala/akka/persistence/r2dbc/query/EventsBySliceSpec.scala
+++ b/core/src/test/scala/akka/persistence/r2dbc/query/EventsBySliceSpec.scala
@@ -292,24 +292,25 @@ class EventsBySliceSpec
 
         query shouldBe a[LatestEventTimestampQuery]
 
-        {
-          // test all slice ranges, with the events expected in one of the ranges
-          val numRanges = 4
-          val rangeSize = 1024 / numRanges
-          val expectedRangeIndex = slice / rangeSize
+        List(1, 4, 1024).foreach { numRanges =>
+          withClue(s"numRanges=$numRanges: ") {
+            // test all slice ranges, with the events expected in one of the ranges
+            val rangeSize = 1024 / numRanges
+            val expectedRangeIndex = slice / rangeSize
 
-          def sliceRange(rangeIndex: Int): (Int, Int) = {
-            val minSlice = rangeIndex * rangeSize
-            val maxSlice = minSlice + rangeSize - 1
-            minSlice -> maxSlice
-          }
+            def sliceRange(rangeIndex: Int): (Int, Int) = {
+              val minSlice = rangeIndex * rangeSize
+              val maxSlice = minSlice + rangeSize - 1
+              minSlice -> maxSlice
+            }
 
-          for (rangeIndex <- 0 until numRanges) {
-            val (minSlice, maxSlice) = sliceRange(rangeIndex)
-            val expectedTimestamp =
-              if (rangeIndex != expectedRangeIndex) None
-              else query.timestampOf(persistenceId, 3L).futureValue
-            query.latestEventTimestamp(entityType, minSlice, maxSlice).futureValue shouldBe expectedTimestamp
+            for (rangeIndex <- 0 until numRanges) {
+              val (minSlice, maxSlice) = sliceRange(rangeIndex)
+              val expectedTimestamp =
+                if (rangeIndex != expectedRangeIndex) None
+                else query.timestampOf(persistenceId, 3L).futureValue
+              query.latestEventTimestamp(entityType, minSlice, maxSlice).futureValue shouldBe expectedTimestamp
+            }
           }
         }
       }


### PR DESCRIPTION
* otherwise the planner is reverting to seq scans

Follow up to https://github.com/akka/akka-persistence-r2dbc/pull/667

Credit to @pvlugter for analyzing the query and suggesting the union all solution.