### PR TITLE
test: update flaky LatestEventTimestampQuery cache test

### DIFF
--- a/core/src/test/scala/akka/persistence/r2dbc/RetryableTests.scala
+++ b/core/src/test/scala/akka/persistence/r2dbc/RetryableTests.scala
@@ -1,0 +1,16 @@
+/*
+ * Copyright (C) 2022 - 2025 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.persistence.r2dbc
+
+import org.scalatest.Outcome
+import org.scalatest.Retries
+import org.scalatest.TestSuite
+
+trait RetryableTests extends TestSuite with Retries {
+  override def withFixture(test: NoArgTest): Outcome = {
+    if (isRetryable(test)) withRetryOnFailure { super.withFixture(test) }
+    else super.withFixture(test)
+  }
+}


### PR DESCRIPTION
Refs #681

Extend cache TTL to give more time fore cache results. Mark test as retryable.

Will trigger multiple test runs.