### PR TITLE
chore: fixing persistenceIdsBySlicesSql for older Postgres versions

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -24,7 +24,6 @@ jobs:
           - { scalaVersion: "2.13", jdkVersion: "1.21.0", jvmName: "temurin:1.21", extraOpts: '', testCmd: "test", postgresImage: "postgres:latest"}
           - { scalaVersion: "2.13", jdkVersion: "1.25.0", jvmName: "temurin:1.25", extraOpts: '', testCmd: "test", postgresImage: "postgres:latest"}
           # also test against a fixed older Postgres version
-          - { scalaVersion: "2.13", jdkVersion: "1.21.0", jvmName: "temurin:1.21", extraOpts: '', testCmd: "test", postgresImage: "postgres:15"}
           - { scalaVersion: "2.13", jdkVersion: "1.25.0", jvmName: "temurin:1.25", extraOpts: '', testCmd: "test", postgresImage: "postgres:15"}
     steps:
       - name: Checkout Global Scripts

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -18,11 +18,14 @@ jobs:
       matrix:
         include:
           # cover relevant combinations when combined with the matrix Yugabyte tests
-          # { scalaVersion: "2.13", jdkVersion: "1.11.0", jvmName: "temurin:1.11.0", extraOpts: '-J-XX:+UnlockExperimentalVMOptions -J-XX:+UseJVMCICompiler', testCmd: "test"}
-          - { scalaVersion: "2.13", jdkVersion: "1.17.0", jvmName: "temurin:1.17.0", extraOpts: '', testCmd: "test"}
-          - { scalaVersion: "3.3",  jdkVersion: "1.17.0", jvmName: "temurin:1.17.0", extraOpts: '', testCmd: "test"}
-          - { scalaVersion: "2.13", jdkVersion: "1.21.0", jvmName: "temurin:1.21", extraOpts: '', testCmd: "test"}
-          - { scalaVersion: "2.13", jdkVersion: "1.25.0", jvmName: "temurin:1.25", extraOpts: '', testCmd: "test"}
+          # { scalaVersion: "2.13", jdkVersion: "1.11.0", jvmName: "temurin:1.11.0", extraOpts: '-J-XX:+UnlockExperimentalVMOptions -J-XX:+UseJVMCICompiler', testCmd: "test", postgresImage: "postgres:latest"}
+          - { scalaVersion: "2.13", jdkVersion: "1.17.0", jvmName: "temurin:1.17.0", extraOpts: '', testCmd: "test", postgresImage: "postgres:latest"}
+          - { scalaVersion: "3.3",  jdkVersion: "1.17.0", jvmName: "temurin:1.17.0", extraOpts: '', testCmd: "test", postgresImage: "postgres:latest"}
+          - { scalaVersion: "2.13", jdkVersion: "1.21.0", jvmName: "temurin:1.21", extraOpts: '', testCmd: "test", postgresImage: "postgres:latest"}
+          - { scalaVersion: "2.13", jdkVersion: "1.25.0", jvmName: "temurin:1.25", extraOpts: '', testCmd: "test", postgresImage: "postgres:latest"}
+          # also test against a fixed older Postgres version
+          - { scalaVersion: "2.13", jdkVersion: "1.21.0", jvmName: "temurin:1.21", extraOpts: '', testCmd: "test", postgresImage: "postgres:15"}
+          - { scalaVersion: "2.13", jdkVersion: "1.25.0", jvmName: "temurin:1.25", extraOpts: '', testCmd: "test", postgresImage: "postgres:15"}
     steps:
       - name: Checkout Global Scripts
         # This MUST be before the main checkout or else the dynver will not work
@@ -54,6 +57,8 @@ jobs:
           jvm: ${{ matrix.jvmName }}
 
       - name: Start DB
+        env:
+          POSTGRES_IMAGE: ${{ matrix.postgresImage }}
         run: |-
           docker compose -f docker/docker-compose-postgres.yml up --wait
           docker exec -i postgres-db psql -U postgres -t < ddl-scripts/create_tables_postgres.sql

--- a/core/src/main/scala/akka/persistence/r2dbc/internal/postgres/PostgresQueryDao.scala
+++ b/core/src/main/scala/akka/persistence/r2dbc/internal/postgres/PostgresQueryDao.scala
@@ -259,7 +259,7 @@ private[r2dbc] class PostgresQueryDao(executorProvider: R2dbcExecutorProvider) e
         AND db_timestamp >= ? $toDbTimestampCondition
         AND deleted = $sqlFalse
         ORDER BY persistence_id, db_timestamp DESC
-      )
+      ) AS subquery
       ORDER BY db_timestamp DESC, persistence_id ASC
       LIMIT ?;
       """

--- a/docker/docker-compose-postgres.yml
+++ b/docker/docker-compose-postgres.yml
@@ -1,7 +1,7 @@
 version: '2.2'
 services:
   postgres-db:
-    image: postgres:latest
+    image: ${POSTGRES_IMAGE:-postgres:latest}
     container_name: postgres-db
     ports:
       - 5432:5432


### PR DESCRIPTION
An older version of Postgres (e.g. 15) will throw exception for a subquery without alias:
```
io.r2dbc.postgresql.ExceptionFactory$PostgresqlBadGrammarException: subquery in FROM must have an alias
```
