### PR TITLE
feat: persistenceIdsAndTimestampsBySlices query to include timestamps

### DIFF
--- a/core/src/main/scala/akka/persistence/r2dbc/internal/BySliceQuery.scala
+++ b/core/src/main/scala/akka/persistence/r2dbc/internal/BySliceQuery.scala
@@ -255,6 +255,21 @@ import org.slf4j.Logger
         correlationId: Option[String]): Source[String, NotUsed] =
       throw new UnsupportedOperationException(s"persistenceIdsBySlices is not supported by ${getClass.getName}")
 
+    /**
+     * Default throws [[UnsupportedOperationException]]. Same as [[persistenceIdsBySlices]] but additionally returns the
+     * latest `db_timestamp` for each persistence id.
+     */
+    def persistenceIdsAndTimestampsBySlices(
+        entityType: String,
+        minSlice: Int,
+        maxSlice: Int,
+        fromTimestamp: Instant,
+        toTimestamp: Option[Instant],
+        limit: Int,
+        correlationId: Option[String]): Source[(String, Instant), NotUsed] =
+      throw new UnsupportedOperationException(
+        s"persistenceIdsAndTimestampsBySlices is not supported by ${getClass.getName}")
+
     protected def appendEmptyBucketIfLastIsMissing(
         buckets: IndexedSeq[Bucket],
         toTimestamp: Instant): IndexedSeq[Bucket] = {
@@ -400,6 +415,32 @@ import org.slf4j.Logger
     if (log.isDebugEnabled())
       log.debug("{} query, from time [{}] to time [{}] limit [{}].", logPrefix, fromTimestamp, toTimestamp, limit)
     dao.persistenceIdsBySlices(entityType, minSlice, maxSlice, fromTimestamp, toTimestamp, limit, correlationId)
+  }
+
+  def persistenceIdsAndTimestampsBySlices(
+      logPrefix: String,
+      correlationId: Option[String],
+      entityType: String,
+      minSlice: Int,
+      maxSlice: Int,
+      fromOffset: Offset,
+      toOffset: Offset,
+      limit: Int): Source[(String, Instant), NotUsed] = {
+    val fromTimestamp = toTimestampOffset(fromOffset).timestamp
+    val toTimestamp = toOffset match {
+      case NoOffset => None
+      case _        => Some(toTimestampOffset(toOffset).timestamp)
+    }
+    if (log.isDebugEnabled())
+      log.debug("{} query, from time [{}] to time [{}] limit [{}].", logPrefix, fromTimestamp, toTimestamp, limit)
+    dao.persistenceIdsAndTimestampsBySlices(
+      entityType,
+      minSlice,
+      maxSlice,
+      fromTimestamp,
+      toTimestamp,
+      limit,
+      correlationId)
   }
 
   def liveBySlices(

--- a/core/src/main/scala/akka/persistence/r2dbc/internal/h2/H2QueryDao.scala
+++ b/core/src/main/scala/akka/persistence/r2dbc/internal/h2/H2QueryDao.scala
@@ -63,11 +63,13 @@ private[r2dbc] class H2QueryDao(executorProvider: R2dbcExecutorProvider) extends
 
   override protected def persistenceIdsBySlicesSql(
       toDbTimestampParam: Boolean,
+      includeTimestamp: Boolean,
       minSlice: Int,
       maxSlice: Int): String = {
     val toDbTimestampCondition = if (toDbTimestampParam) "AND db_timestamp <= ?" else ""
+    val outerColumns = if (includeTimestamp) "persistence_id, db_timestamp" else "persistence_id"
     sql"""
-      SELECT persistence_id
+      SELECT $outerColumns
       FROM (
           SELECT
               persistence_id,

--- a/core/src/main/scala/akka/persistence/r2dbc/internal/postgres/PostgresQueryDao.scala
+++ b/core/src/main/scala/akka/persistence/r2dbc/internal/postgres/PostgresQueryDao.scala
@@ -245,13 +245,19 @@ private[r2dbc] class PostgresQueryDao(executorProvider: R2dbcExecutorProvider) e
     }
 
   /**
-   * the inner query has the ordering required by the distinct, the outer query applies desired order and a limit
+   * the inner query has the ordering required by the distinct, the outer query applies desired order and a limit. The
+   * outer projection includes `db_timestamp` only when `includeTimestamp` is `true`.
    */
-  protected def persistenceIdsBySlicesSql(toDbTimestampParam: Boolean, minSlice: Int, maxSlice: Int): String =
-    sqlCache.get(minSlice, s"persistenceIdsBySlicesSql-$minSlice-$maxSlice-$toDbTimestampParam") {
+  protected def persistenceIdsBySlicesSql(
+      toDbTimestampParam: Boolean,
+      includeTimestamp: Boolean,
+      minSlice: Int,
+      maxSlice: Int): String =
+    sqlCache.get(minSlice, s"persistenceIdsBySlicesSql-$minSlice-$maxSlice-$toDbTimestampParam-$includeTimestamp") {
       val toDbTimestampCondition = if (toDbTimestampParam) "AND db_timestamp <= ?" else ""
+      val outerColumns = if (includeTimestamp) "persistence_id, db_timestamp" else "persistence_id"
       sql"""
-      SELECT persistence_id FROM (
+      SELECT $outerColumns FROM (
         SELECT DISTINCT ON (persistence_id) persistence_id, db_timestamp
         FROM ${journalTable(minSlice)}
         WHERE entity_type = ?
@@ -750,7 +756,8 @@ private[r2dbc] class PostgresQueryDao(executorProvider: R2dbcExecutorProvider) e
     val result = executor.select(s"select persistenceIdsBySlices [$minSlice - $maxSlice]")(
       connection => {
         val stmt =
-          connection.createStatement(persistenceIdsBySlicesSql(toTimestamp.isDefined, minSlice, maxSlice))
+          connection.createStatement(
+            persistenceIdsBySlicesSql(toTimestamp.isDefined, includeTimestamp = false, minSlice, maxSlice))
         bindPersistenceIdsBySlicesSql(stmt, entityType, fromTimestamp, toTimestamp, limit)
       },
       row => row.get("persistence_id", classOf[String]))
@@ -759,6 +766,41 @@ private[r2dbc] class PostgresQueryDao(executorProvider: R2dbcExecutorProvider) e
       result.foreach(rows =>
         log.debug(
           "Read [{}] persistence ids by slices [{} - {}]{}",
+          rows.size,
+          minSlice,
+          maxSlice,
+          CorrelationId.toLogText(correlationId)))
+
+    Source.futureSource(result.map(Source(_))).mapMaterializedValue(_ => NotUsed)
+  }
+
+  override def persistenceIdsAndTimestampsBySlices(
+      entityType: String,
+      minSlice: Int,
+      maxSlice: Int,
+      fromTimestamp: Instant,
+      toTimestamp: Option[Instant],
+      limit: Int,
+      correlationId: Option[String]): Source[(String, Instant), NotUsed] = {
+    if (!settings.isSliceRangeWithinSameDataPartition(minSlice, maxSlice))
+      throw new IllegalArgumentException(
+        s"Slice range [$minSlice-$maxSlice] spans over more than one " +
+        s"of the [${settings.numberOfDataPartitions}] data partitions.")
+
+    val executor = executorProvider.executorFor(minSlice)
+    val result = executor.select(s"select persistenceIdsAndTimestampsBySlices [$minSlice - $maxSlice]")(
+      connection => {
+        val stmt =
+          connection.createStatement(
+            persistenceIdsBySlicesSql(toTimestamp.isDefined, includeTimestamp = true, minSlice, maxSlice))
+        bindPersistenceIdsBySlicesSql(stmt, entityType, fromTimestamp, toTimestamp, limit)
+      },
+      row => row.get("persistence_id", classOf[String]) -> row.getTimestamp("db_timestamp"))
+
+    if (log.isDebugEnabled)
+      result.foreach(rows =>
+        log.debug(
+          "Read [{}] persistence ids and timestamps by slices [{} - {}]{}",
           rows.size,
           minSlice,
           maxSlice,

--- a/core/src/main/scala/akka/persistence/r2dbc/query/javadsl/R2dbcReadJournal.scala
+++ b/core/src/main/scala/akka/persistence/r2dbc/query/javadsl/R2dbcReadJournal.scala
@@ -264,6 +264,40 @@ final class R2dbcReadJournal(delegate: scaladsl.R2dbcReadJournal)
     delegate.persistenceIdsBySlices(entityType, minSlice, maxSlice, fromOffset, toOffset, limit).asJava
 
   /**
+   * As [[persistenceIdsBySlices]], but additionally returns the latest `db_timestamp` observed for each persistence id
+   * within the slice and time window. Ordering and limit semantics are identical to [[persistenceIdsBySlices]]:
+   * descending by latest `db_timestamp`, with `persistence_id` ascending as the tiebreaker. The `limit` caps the result
+   * and is not intended for paging — see [[persistenceIdsBySlices]] for the rationale.
+   *
+   * @param entityType
+   *   The entity type name.
+   * @param minSlice
+   *   The minimum slice (inclusive).
+   * @param maxSlice
+   *   The maximum slice (inclusive). The slice range cannot span over more than one data partition.
+   * @param fromOffset
+   *   Lower bound for `db_timestamp`. Use [[Offset.noOffset]] for no lower bound.
+   * @param toOffset
+   *   Upper bound for `db_timestamp` (inclusive). Use [[Offset.noOffset]] for no upper bound.
+   * @param limit
+   *   The maximum number of persistence ids to return. Not suitable for pagination — see [[persistenceIdsBySlices]].
+   * @return
+   *   A source emitting distinct persistence ids paired with the latest `db_timestamp` observed within the window,
+   *   ordered by latest `db_timestamp` descending.
+   */
+  def persistenceIdsAndTimestampsBySlices(
+      entityType: String,
+      minSlice: Int,
+      maxSlice: Int,
+      fromOffset: Offset,
+      toOffset: Offset,
+      limit: Int): Source[Pair[String, Instant], NotUsed] =
+    delegate
+      .persistenceIdsAndTimestampsBySlices(entityType, minSlice, maxSlice, fromOffset, toOffset, limit)
+      .map { case (pid, timestamp) => Pair.create(pid, timestamp) }
+      .asJava
+
+  /**
    * Load the last event for the given `persistenceId` up to the given `toSeqNr`.
    *
    * @param persistenceId

--- a/core/src/main/scala/akka/persistence/r2dbc/query/scaladsl/R2dbcReadJournal.scala
+++ b/core/src/main/scala/akka/persistence/r2dbc/query/scaladsl/R2dbcReadJournal.scala
@@ -1036,6 +1036,49 @@ final class R2dbcReadJournal(system: ExtendedActorSystem, config: Config, cfgPat
         limit)
   }
 
+  /**
+   * As [[persistenceIdsBySlices]], but additionally returns the latest `db_timestamp` observed for each persistence id
+   * within the slice and time window. Ordering and limit semantics are identical to [[persistenceIdsBySlices]]:
+   * descending by latest `db_timestamp`, with `persistence_id` ascending as the tiebreaker. The `limit` caps the result
+   * and is not intended for paging — see [[persistenceIdsBySlices]] for the rationale.
+   *
+   * @param entityType
+   *   The entity type name.
+   * @param minSlice
+   *   The minimum slice (inclusive).
+   * @param maxSlice
+   *   The maximum slice (inclusive). The slice range cannot span over more than one data partition.
+   * @param fromOffset
+   *   Lower bound for `db_timestamp`. Use [[Offset.noOffset]] for no lower bound.
+   * @param toOffset
+   *   Upper bound for `db_timestamp` (inclusive). Use [[Offset.noOffset]] for no upper bound.
+   * @param limit
+   *   The maximum number of persistence ids to return. Not suitable for pagination — see [[persistenceIdsBySlices]].
+   * @return
+   *   A source emitting distinct persistence ids together with the latest `db_timestamp` observed within the window,
+   *   ordered by latest `db_timestamp` descending.
+   */
+  def persistenceIdsAndTimestampsBySlices(
+      entityType: String,
+      minSlice: Int,
+      maxSlice: Int,
+      fromOffset: Offset,
+      toOffset: Offset,
+      limit: Int): Source[(String, Instant), NotUsed] = {
+    val correlationId = QueryCorrelationId.get()
+    val correlationIdText = CorrelationId.toLogText(correlationId)
+    bySlice(entityType, minSlice)
+      .persistenceIdsAndTimestampsBySlices(
+        s"[$entityType] persistenceIdsAndTimestampsBySlices [$minSlice-$maxSlice]$correlationIdText: ",
+        correlationId,
+        entityType,
+        minSlice,
+        maxSlice,
+        fromOffset,
+        toOffset,
+        limit)
+  }
+
   override def currentPersistenceIds(): Source[String, NotUsed] = {
     import settings.querySettings.persistenceIdsBufferSize
     def updateState(state: PersistenceIdsQueryState, pid: String): PersistenceIdsQueryState =

--- a/core/src/test/scala/akka/persistence/r2dbc/query/PersistenceIdsBySlicesSpec.scala
+++ b/core/src/test/scala/akka/persistence/r2dbc/query/PersistenceIdsBySlicesSpec.scala
@@ -345,4 +345,134 @@ class PersistenceIdsBySlicesSpec
       result.toSet shouldBe withinPids.toSet
     }
   }
+
+  "persistenceIdsAndTimestampsBySlices" should {
+
+    pendingIfMoreThanOneDataPartition()
+    pendingIfCannotBeTestedWithDialect()
+
+    "return each persistence id paired with the latest db_timestamp" in {
+      val entityType = nextEntityType()
+      val pid = nextPid(entityType)
+      val slice = persistenceExt.sliceForPersistenceId(pid)
+      val now = InstantFactory.now()
+      val oldTime = now.minusSeconds(3600)
+      val recentTime = now.minusSeconds(60)
+
+      writeEvent(slice, pid, 1L, oldTime, "old")
+      writeEvent(slice, pid, 2L, recentTime, "recent")
+
+      val result = query
+        .persistenceIdsAndTimestampsBySlices(
+          entityType,
+          minSlice = 0,
+          maxSlice = persistenceExt.numberOfSlices - 1,
+          fromOffset = NoOffset,
+          toOffset = NoOffset,
+          limit = 100)
+        .runWith(Sink.seq)
+        .futureValue
+
+      result shouldBe Vector(pid -> recentTime)
+    }
+
+    "order results by latest db_timestamp descending, persistence_id ascending as tiebreaker" in {
+      val entityType = nextEntityType()
+      val now = InstantFactory.now()
+      val pids = (1 to 5).map(_ => nextPid(entityType)).toVector
+      // assign descending timestamps so the most recently active pid is pids(4)
+      val timestamps = pids.indices.map(i => now.minusSeconds((5 - i) * 60L))
+      pids.zip(timestamps).foreach { case (pid, ts) =>
+        writeEvent(persistenceExt.sliceForPersistenceId(pid), pid, 1L, ts, "e")
+      }
+
+      val result = query
+        .persistenceIdsAndTimestampsBySlices(
+          entityType,
+          minSlice = 0,
+          maxSlice = persistenceExt.numberOfSlices - 1,
+          fromOffset = NoOffset,
+          toOffset = NoOffset,
+          limit = 100)
+        .runWith(Sink.seq)
+        .futureValue
+
+      result shouldBe pids.zip(timestamps).reverse
+    }
+
+    "use persistence_id ascending as a tiebreaker on equal timestamps" in {
+      val entityType = nextEntityType()
+      val now = InstantFactory.now()
+      val pids = (1 to 4).map(_ => nextPid(entityType)).toVector
+      pids.foreach(pid => writeEvent(persistenceExt.sliceForPersistenceId(pid), pid, 1L, now, "e"))
+
+      val result = query
+        .persistenceIdsAndTimestampsBySlices(
+          entityType,
+          minSlice = 0,
+          maxSlice = persistenceExt.numberOfSlices - 1,
+          fromOffset = NoOffset,
+          toOffset = NoOffset,
+          limit = 100)
+        .runWith(Sink.seq)
+        .futureValue
+
+      result shouldBe pids.sorted.map(pid => pid -> now)
+    }
+
+    "return the latest timestamp within the window when an id has events both inside and outside" in {
+      val entityType = nextEntityType()
+      val pid = nextPid(entityType)
+      val slice = persistenceExt.sliceForPersistenceId(pid)
+      val now = InstantFactory.now()
+      val beforeTime = now.minusSeconds(3600)
+      val withinEarly = now.minusSeconds(800)
+      val withinLate = now.minusSeconds(400)
+      val afterTime = now.minusSeconds(10)
+
+      writeEvent(slice, pid, 1L, beforeTime, "before")
+      writeEvent(slice, pid, 2L, withinEarly, "within-early")
+      writeEvent(slice, pid, 3L, withinLate, "within-late")
+      writeEvent(slice, pid, 4L, afterTime, "after")
+
+      val fromTimestamp = now.minusSeconds(1000)
+      val toTimestamp = now.minusSeconds(120)
+      val result = query
+        .persistenceIdsAndTimestampsBySlices(
+          entityType,
+          minSlice = 0,
+          maxSlice = persistenceExt.numberOfSlices - 1,
+          fromOffset = TimestampOffset(fromTimestamp, Map.empty),
+          toOffset = TimestampOffset(toTimestamp, Map.empty),
+          limit = 100)
+        .runWith(Sink.seq)
+        .futureValue
+
+      result shouldBe Vector(pid -> withinLate)
+    }
+
+    "respect the limit, truncating from the least-recent end" in {
+      val entityType = nextEntityType()
+      val now = InstantFactory.now()
+      val pids = (1 to 5).map(_ => nextPid(entityType)).toVector
+      val timestamps = pids.indices.map(i => now.minusSeconds((5 - i) * 60L))
+      pids.zip(timestamps).foreach { case (pid, ts) =>
+        writeEvent(persistenceExt.sliceForPersistenceId(pid), pid, 1L, ts, "e")
+      }
+
+      val result = query
+        .persistenceIdsAndTimestampsBySlices(
+          entityType,
+          minSlice = 0,
+          maxSlice = persistenceExt.numberOfSlices - 1,
+          fromOffset = NoOffset,
+          toOffset = NoOffset,
+          limit = 3)
+        .runWith(Sink.seq)
+        .futureValue
+
+      // 3 most recently active, newest first
+      result shouldBe Vector(pids(4) -> timestamps(4), pids(3) -> timestamps(3), pids(2) -> timestamps(2))
+    }
+  }
 }


### PR DESCRIPTION
Having the timestamps for the latest event for these persistence IDs is very useful for creating queries when there are many IDs within a small time range. I'm currently experimenting with this for the akka console and CLI. 