### PR TITLE
bump: R2DBC versions; explicit Netty override

### DIFF
--- a/artifact-bom/akka-persistence-r2dbc-migration/pom.xml
+++ b/artifact-bom/akka-persistence-r2dbc-migration/pom.xml
@@ -94,82 +94,82 @@
             <dependency>
                 <groupId>io.netty</groupId>
                 <artifactId>netty-buffer</artifactId>
-                <version>4.1.135.Final</version>
+                <version>4.1.136.Final</version>
             </dependency>
             <dependency>
                 <groupId>io.netty</groupId>
                 <artifactId>netty-codec</artifactId>
-                <version>4.1.135.Final</version>
+                <version>4.1.136.Final</version>
             </dependency>
             <dependency>
                 <groupId>io.netty</groupId>
                 <artifactId>netty-codec-dns</artifactId>
-                <version>4.1.135.Final</version>
+                <version>4.1.136.Final</version>
             </dependency>
             <dependency>
                 <groupId>io.netty</groupId>
                 <artifactId>netty-codec-http</artifactId>
-                <version>4.1.135.Final</version>
+                <version>4.1.136.Final</version>
             </dependency>
             <dependency>
                 <groupId>io.netty</groupId>
                 <artifactId>netty-codec-socks</artifactId>
-                <version>4.1.135.Final</version>
+                <version>4.1.136.Final</version>
             </dependency>
             <dependency>
                 <groupId>io.netty</groupId>
                 <artifactId>netty-common</artifactId>
-                <version>4.1.135.Final</version>
+                <version>4.1.136.Final</version>
             </dependency>
             <dependency>
                 <groupId>io.netty</groupId>
                 <artifactId>netty-handler</artifactId>
-                <version>4.1.135.Final</version>
+                <version>4.1.136.Final</version>
             </dependency>
             <dependency>
                 <groupId>io.netty</groupId>
                 <artifactId>netty-handler-proxy</artifactId>
-                <version>4.1.135.Final</version>
+                <version>4.1.136.Final</version>
             </dependency>
             <dependency>
                 <groupId>io.netty</groupId>
                 <artifactId>netty-resolver</artifactId>
-                <version>4.1.135.Final</version>
+                <version>4.1.136.Final</version>
             </dependency>
             <dependency>
                 <groupId>io.netty</groupId>
                 <artifactId>netty-resolver-dns</artifactId>
-                <version>4.1.135.Final</version>
+                <version>4.1.136.Final</version>
             </dependency>
             <dependency>
                 <groupId>io.netty</groupId>
                 <artifactId>netty-resolver-dns-classes-macos</artifactId>
-                <version>4.1.135.Final</version>
+                <version>4.1.136.Final</version>
             </dependency>
             <dependency>
                 <groupId>io.netty</groupId>
                 <artifactId>netty-resolver-dns-native-macos</artifactId>
-                <version>4.1.135.Final</version>
+                <version>4.1.136.Final</version>
             </dependency>
             <dependency>
                 <groupId>io.netty</groupId>
                 <artifactId>netty-transport</artifactId>
-                <version>4.1.135.Final</version>
+                <version>4.1.136.Final</version>
             </dependency>
             <dependency>
                 <groupId>io.netty</groupId>
                 <artifactId>netty-transport-classes-epoll</artifactId>
-                <version>4.1.135.Final</version>
+                <version>4.1.136.Final</version>
             </dependency>
             <dependency>
                 <groupId>io.netty</groupId>
                 <artifactId>netty-transport-native-epoll</artifactId>
-                <version>4.1.135.Final</version>
+                <version>4.1.136.Final</version>
             </dependency>
             <dependency>
                 <groupId>io.netty</groupId>
                 <artifactId>netty-transport-native-unix-common</artifactId>
-                <version>4.1.135.Final</version>
+                <version>4.1.136.Final</version>
             </dependency>
             <dependency>
                 <groupId>io.projectreactor</groupId>
@@ -204,7 +204,7 @@
             <dependency>
                 <groupId>org.postgresql</groupId>
                 <artifactId>r2dbc-postgresql</artifactId>
-                <version>1.1.1.RELEASE</version>
+                <version>1.1.2.RELEASE</version>
             </dependency>
             <dependency>
                 <groupId>org.reactivestreams</groupId>
@@ -312,82 +312,82 @@
         <dependency>
             <groupId>io.netty</groupId>
             <artifactId>netty-buffer</artifactId>
-            <version>4.1.135.Final</version>
+            <version>4.1.136.Final</version>
         </dependency>
         <dependency>
             <groupId>io.netty</groupId>
             <artifactId>netty-codec</artifactId>
-            <version>4.1.135.Final</version>
+            <version>4.1.136.Final</version>
         </dependency>
         <dependency>
             <groupId>io.netty</groupId>
             <artifactId>netty-codec-dns</artifactId>
-            <version>4.1.135.Final</version>
+            <version>4.1.136.Final</version>
         </dependency>
         <dependency>
             <groupId>io.netty</groupId>
             <artifactId>netty-codec-http</artifactId>
-            <version>4.1.135.Final</version>
+            <version>4.1.136.Final</version>
         </dependency>
         <dependency>
             <groupId>io.netty</groupId>
             <artifactId>netty-codec-socks</artifactId>
-            <version>4.1.135.Final</version>
+            <version>4.1.136.Final</version>
         </dependency>
         <dependency>
             <groupId>io.netty</groupId>
             <artifactId>netty-common</artifactId>
-            <version>4.1.135.Final</version>
+            <version>4.1.136.Final</version>
         </dependency>
         <dependency>
             <groupId>io.netty</groupId>
             <artifactId>netty-handler</artifactId>
-            <version>4.1.135.Final</version>
+            <version>4.1.136.Final</version>
         </dependency>
         <dependency>
             <groupId>io.netty</groupId>
             <artifactId>netty-handler-proxy</artifactId>
-            <version>4.1.135.Final</version>
+            <version>4.1.136.Final</version>
         </dependency>
         <dependency>
             <groupId>io.netty</groupId>
             <artifactId>netty-resolver</artifactId>
-            <version>4.1.135.Final</version>
+            <version>4.1.136.Final</version>
         </dependency>
         <dependency>
             <groupId>io.netty</groupId>
             <artifactId>netty-resolver-dns</artifactId>
-            <version>4.1.135.Final</version>
+            <version>4.1.136.Final</version>
         </dependency>
         <dependency>
             <groupId>io.netty</groupId>
             <artifactId>netty-resolver-dns-classes-macos</artifactId>
-            <version>4.1.135.Final</version>
+            <version>4.1.136.Final</version>
         </dependency>
         <dependency>
             <groupId>io.netty</groupId>
             <artifactId>netty-resolver-dns-native-macos</artifactId>
-            <version>4.1.135.Final</version>
+            <version>4.1.136.Final</version>
         </dependency>
         <dependency>
             <groupId>io.netty</groupId>
             <artifactId>netty-transport</artifactId>
-            <version>4.1.135.Final</version>
+            <version>4.1.136.Final</version>
         </dependency>
         <dependency>
             <groupId>io.netty</groupId>
             <artifactId>netty-transport-classes-epoll</artifactId>
-            <version>4.1.135.Final</version>
+            <version>4.1.136.Final</version>
         </dependency>
         <dependency>
             <groupId>io.netty</groupId>
             <artifactId>netty-transport-native-epoll</artifactId>
-            <version>4.1.135.Final</version>
+            <version>4.1.136.Final</version>
         </dependency>
         <dependency>
             <groupId>io.netty</groupId>
             <artifactId>netty-transport-native-unix-common</artifactId>
-            <version>4.1.135.Final</version>
+            <version>4.1.136.Final</version>
         </dependency>
         <dependency>
             <groupId>io.projectreactor</groupId>
@@ -422,7 +422,7 @@
         <dependency>
             <groupId>org.postgresql</groupId>
             <artifactId>r2dbc-postgresql</artifactId>
-            <version>1.1.1.RELEASE</version>
+            <version>1.1.2.RELEASE</version>
         </dependency>
         <dependency>
             <groupId>org.reactivestreams</groupId>

--- a/artifact-bom/akka-persistence-r2dbc/pom.xml
+++ b/artifact-bom/akka-persistence-r2dbc/pom.xml
@@ -94,82 +94,82 @@
             <dependency>
                 <groupId>io.netty</groupId>
                 <artifactId>netty-buffer</artifactId>
-                <version>4.1.135.Final</version>
+                <version>4.1.136.Final</version>
             </dependency>
             <dependency>
                 <groupId>io.netty</groupId>
                 <artifactId>netty-codec</artifactId>
-                <version>4.1.135.Final</version>
+                <version>4.1.136.Final</version>
             </dependency>
             <dependency>
                 <groupId>io.netty</groupId>
                 <artifactId>netty-codec-dns</artifactId>
-                <version>4.1.135.Final</version>
+                <version>4.1.136.Final</version>
             </dependency>
             <dependency>
                 <groupId>io.netty</groupId>
                 <artifactId>netty-codec-http</artifactId>
-                <version>4.1.135.Final</version>
+                <version>4.1.136.Final</version>
             </dependency>
             <dependency>
                 <groupId>io.netty</groupId>
                 <artifactId>netty-codec-socks</artifactId>
-                <version>4.1.135.Final</version>
+                <version>4.1.136.Final</version>
             </dependency>
             <dependency>
                 <groupId>io.netty</groupId>
                 <artifactId>netty-common</artifactId>
-                <version>4.1.135.Final</version>
+                <version>4.1.136.Final</version>
             </dependency>
             <dependency>
                 <groupId>io.netty</groupId>
                 <artifactId>netty-handler</artifactId>
-                <version>4.1.135.Final</version>
+                <version>4.1.136.Final</version>
             </dependency>
             <dependency>
                 <groupId>io.netty</groupId>
                 <artifactId>netty-handler-proxy</artifactId>
-                <version>4.1.135.Final</version>
+                <version>4.1.136.Final</version>
             </dependency>
             <dependency>
                 <groupId>io.netty</groupId>
                 <artifactId>netty-resolver</artifactId>
-                <version>4.1.135.Final</version>
+                <version>4.1.136.Final</version>
             </dependency>
             <dependency>
                 <groupId>io.netty</groupId>
                 <artifactId>netty-resolver-dns</artifactId>
-                <version>4.1.135.Final</version>
+                <version>4.1.136.Final</version>
             </dependency>
             <dependency>
                 <groupId>io.netty</groupId>
                 <artifactId>netty-resolver-dns-classes-macos</artifactId>
-                <version>4.1.135.Final</version>
+                <version>4.1.136.Final</version>
             </dependency>
             <dependency>
                 <groupId>io.netty</groupId>
                 <artifactId>netty-resolver-dns-native-macos</artifactId>
-                <version>4.1.135.Final</version>
+                <version>4.1.136.Final</version>
             </dependency>
             <dependency>
                 <groupId>io.netty</groupId>
                 <artifactId>netty-transport</artifactId>
-                <version>4.1.135.Final</version>
+                <version>4.1.136.Final</version>
             </dependency>
             <dependency>
                 <groupId>io.netty</groupId>
                 <artifactId>netty-transport-classes-epoll</artifactId>
-                <version>4.1.135.Final</version>
+                <version>4.1.136.Final</version>
             </dependency>
             <dependency>
                 <groupId>io.netty</groupId>
                 <artifactId>netty-transport-native-epoll</artifactId>
-                <version>4.1.135.Final</version>
+                <version>4.1.136.Final</version>
             </dependency>
             <dependency>
                 <groupId>io.netty</groupId>
                 <artifactId>netty-transport-native-unix-common</artifactId>
-                <version>4.1.135.Final</version>
+                <version>4.1.136.Final</version>
             </dependency>
             <dependency>
                 <groupId>io.projectreactor</groupId>
@@ -204,7 +204,7 @@
             <dependency>
                 <groupId>org.postgresql</groupId>
                 <artifactId>r2dbc-postgresql</artifactId>
-                <version>1.1.1.RELEASE</version>
+                <version>1.1.2.RELEASE</version>
             </dependency>
             <dependency>
                 <groupId>org.reactivestreams</groupId>
@@ -312,82 +312,82 @@
         <dependency>
             <groupId>io.netty</groupId>
             <artifactId>netty-buffer</artifactId>
-            <version>4.1.135.Final</version>
+            <version>4.1.136.Final</version>
         </dependency>
         <dependency>
             <groupId>io.netty</groupId>
             <artifactId>netty-codec</artifactId>
-            <version>4.1.135.Final</version>
+            <version>4.1.136.Final</version>
         </dependency>
         <dependency>
             <groupId>io.netty</groupId>
             <artifactId>netty-codec-dns</artifactId>
-            <version>4.1.135.Final</version>
+            <version>4.1.136.Final</version>
         </dependency>
         <dependency>
             <groupId>io.netty</groupId>
             <artifactId>netty-codec-http</artifactId>
-            <version>4.1.135.Final</version>
+            <version>4.1.136.Final</version>
         </dependency>
         <dependency>
             <groupId>io.netty</groupId>
             <artifactId>netty-codec-socks</artifactId>
-            <version>4.1.135.Final</version>
+            <version>4.1.136.Final</version>
         </dependency>
         <dependency>
             <groupId>io.netty</groupId>
             <artifactId>netty-common</artifactId>
-            <version>4.1.135.Final</version>
+            <version>4.1.136.Final</version>
         </dependency>
         <dependency>
             <groupId>io.netty</groupId>
             <artifactId>netty-handler</artifactId>
-            <version>4.1.135.Final</version>
+            <version>4.1.136.Final</version>
         </dependency>
         <dependency>
             <groupId>io.netty</groupId>
             <artifactId>netty-handler-proxy</artifactId>
-            <version>4.1.135.Final</version>
+            <version>4.1.136.Final</version>
         </dependency>
         <dependency>
             <groupId>io.netty</groupId>
             <artifactId>netty-resolver</artifactId>
-            <version>4.1.135.Final</version>
+            <version>4.1.136.Final</version>
         </dependency>
         <dependency>
             <groupId>io.netty</groupId>
             <artifactId>netty-resolver-dns</artifactId>
-            <version>4.1.135.Final</version>
+            <version>4.1.136.Final</version>
         </dependency>
         <dependency>
             <groupId>io.netty</groupId>
             <artifactId>netty-resolver-dns-classes-macos</artifactId>
-            <version>4.1.135.Final</version>
+            <version>4.1.136.Final</version>
         </dependency>
         <dependency>
             <groupId>io.netty</groupId>
             <artifactId>netty-resolver-dns-native-macos</artifactId>
-            <version>4.1.135.Final</version>
+            <version>4.1.136.Final</version>
         </dependency>
         <dependency>
             <groupId>io.netty</groupId>
             <artifactId>netty-transport</artifactId>
-            <version>4.1.135.Final</version>
+            <version>4.1.136.Final</version>
         </dependency>
         <dependency>
             <groupId>io.netty</groupId>
             <artifactId>netty-transport-classes-epoll</artifactId>
-            <version>4.1.135.Final</version>
+            <version>4.1.136.Final</version>
         </dependency>
         <dependency>
             <groupId>io.netty</groupId>
             <artifactId>netty-transport-native-epoll</artifactId>
-            <version>4.1.135.Final</version>
+            <version>4.1.136.Final</version>
         </dependency>
         <dependency>
             <groupId>io.netty</groupId>
             <artifactId>netty-transport-native-unix-common</artifactId>
-            <version>4.1.135.Final</version>
+            <version>4.1.136.Final</version>
         </dependency>
         <dependency>
             <groupId>io.projectreactor</groupId>
@@ -422,7 +422,7 @@
         <dependency>
             <groupId>org.postgresql</groupId>
             <artifactId>r2dbc-postgresql</artifactId>
-            <version>1.1.1.RELEASE</version>
+            <version>1.1.2.RELEASE</version>
         </dependency>
         <dependency>
             <groupId>org.reactivestreams</groupId>

--- a/build.sbt
+++ b/build.sbt
@@ -118,17 +118,21 @@ lazy val core = (project in file("core"))
 
       // match on the organization, other organizations publish artifacts named netty-* as well
       // netty-tcnative-* has its own version scheme.
-      val lagging = update.value.allModuleReports.filterNot(_.evicted).map(_.module).filter { module =>
-        module.organization == "io.netty" &&
+      val lagging = update.value.allModuleReports
+        .filterNot(_.evicted)
+        .map(_.module)
+        .filter { module =>
+          module.organization == "io.netty" &&
           !module.name.startsWith("netty-tcnative") &&
           module.revision != NettyVersion
-      }.sortWith((m1, m2) => m1.name < m2.name)
+        }
+        .sortWith((m1, m2) => m1.name < m2.name)
 
       if (lagging.nonEmpty)
         throw new MessageOnlyException(
           s"Found netty modules not matching NettyVersion [$NettyVersion]: " +
-            s"${lagging.map(m => s"${m.name}:${m.revision}").mkString(", ")}. " +
-            "Add the module to Dependencies.NettyModules so that it is overridden.")
+          s"${lagging.map(m => s"${m.name}:${m.revision}").mkString(", ")}. " +
+          "Add the module to Dependencies.NettyModules so that it is overridden.")
 
       cp
     })

--- a/build.sbt
+++ b/build.sbt
@@ -2,6 +2,8 @@ import com.typesafe.tools.mima.plugin.MimaKeys.mimaPreviousArtifacts
 import com.typesafe.tools.mima.plugin.MimaKeys.mimaReportSignatureProblems
 import sbt.Keys.parallelExecution
 import com.geirsson.CiReleasePlugin
+import Dependencies.Compile.NettyVersion
+import Dependencies.Compile.NettyModules
 
 GlobalScope / parallelExecution := false
 Global / concurrentRestrictions += Tags.limit(Tags.Test, 1)
@@ -101,10 +103,35 @@ lazy val core = (project in file("core"))
   .settings(
     name := "akka-persistence-r2dbc",
     libraryDependencies ++= Dependencies.core,
+    // explicitly overriding Netty dependencies for downstream use
+    libraryDependencies ++= NettyModules.map("io.netty" % _ % NettyVersion),
+    dependencyOverrides ++= NettyModules.map("io.netty" % _ % NettyVersion),
     AutomaticModuleName.settings("akka.persistence.r2dbc"))
   .enablePlugins(AutomateHeaderPlugin)
   .enablePlugins(ArtifactBomPlugin)
   .disablePlugins(CiReleasePlugin)
+  .settings(
+    // Validate that all netty modules resolve to NettyVersion. Modules that are only requested
+    // transitively silently lag behind unless they are listed in Dependencies.NettyModules.
+    Compile / managedClasspath := {
+      val cp = (Compile / managedClasspath).value
+
+      // match on the organization, other organizations publish artifacts named netty-* as well
+      // netty-tcnative-* has its own version scheme.
+      val lagging = update.value.allModuleReports.filterNot(_.evicted).map(_.module).filter { module =>
+        module.organization == "io.netty" &&
+          !module.name.startsWith("netty-tcnative") &&
+          module.revision != NettyVersion
+      }.sortWith((m1, m2) => m1.name < m2.name)
+
+      if (lagging.nonEmpty)
+        throw new MessageOnlyException(
+          s"Found netty modules not matching NettyVersion [$NettyVersion]: " +
+            s"${lagging.map(m => s"${m.name}:${m.revision}").mkString(", ")}. " +
+            "Add the module to Dependencies.NettyModules so that it is overridden.")
+
+      cp
+    })
 
 lazy val migration = (project in file("migration"))
   .settings(common)

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -15,7 +15,7 @@ object Dependencies {
   val AkkaProjectionVersionInDocs = "current"
   val H2Version = "2.4.240"
   val R2dbcH2Version = "1.1.0.RELEASE"
-  val SqlServerR2dbcVersion = "1.0.4.RELEASE"
+  val SqlServerR2dbcVersion = "1.0.5.RELEASE"
   val SqlServerJdbcVersion = "13.2.1.jre8"
 
   // Java Platform version for JavaDoc creation

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -31,10 +31,36 @@ object Dependencies {
     val r2dbcPool = "io.r2dbc" % "r2dbc-pool" % "1.0.2.RELEASE" // ApacheV2
 
     // FIXME: when bumping, check if the reactor-netty-core override below is still needed
-    val r2dbcPostgres = "org.postgresql" % "r2dbc-postgresql" % "1.1.1.RELEASE" // ApacheV2
+    val r2dbcPostgres = "org.postgresql" % "r2dbc-postgresql" % "1.1.2.RELEASE" // ApacheV2
 
     // Override for the transitive dependency from r2dbc-postgresql to get Netty 4.1.135
+    // https://github.com/reactor/reactor-netty/releases#release-v1.2.18
+    // Won't release more in the 1.2.18 line. https://projectreactor.io/support
     val reactorNettyCore = "io.projectreactor.netty" % "reactor-netty-core" % "1.2.18"
+
+    // As Reactor Netty 1.2 won't be updated further, we explicitly update Netty 4.1.x
+    // Netty requires all its modules to be on the same version. The modules below are only requested
+    // transitively by reactor-netty, which lags behind netty releases), so each one has to be
+    // overridden explicitly, or it stays behind on an unpatched version.
+    // Note: netty-tcnative-* is versioned separately and is deliberately not listed here.
+    val NettyVersion = "4.1.136.Final"
+    val NettyModules = Seq(
+      "netty-buffer",
+      "netty-codec",
+      "netty-codec-dns",
+      "netty-codec-http",
+      "netty-codec-socks",
+      "netty-common",
+      "netty-handler",
+      "netty-handler-proxy",
+      "netty-resolver",
+      "netty-resolver-dns",
+      "netty-resolver-dns-classes-macos",
+      "netty-resolver-dns-native-macos",
+      "netty-transport",
+      "netty-transport-classes-epoll",
+      "netty-transport-native-epoll",
+      "netty-transport-native-unix-common")
 
     val h2 = "com.h2database" % "h2" % H2Version % Provided // EPL 1.0
     val r2dbcH2 = "io.r2dbc" % "r2dbc-h2" % R2dbcH2Version % Provided // ApacheV2


### PR DESCRIPTION
* bump: org.postgresql r2dbc-postgresql 1.1.2.RELEASE (was 1.1.1.RELEASE)
* bump: provided io.r2dbc r2dbc-mssql 1.0.5.RELEASE (was 1.0.4.RELEASE)
* explicit dependencies on Netty to bump its version within the 4.1 line past what Reactor Netty uses.

Added a safety net to ensure all Netty dependencies are of the version explicitly stated so that further changes keep those aligned.