### PR TITLE
Revert "Make SqlServerTimestampCodec.toInstant null-safe..."

### DIFF
--- a/core/src/main/scala/akka/persistence/r2dbc/internal/codec/TimestampCodec.scala
+++ b/core/src/main/scala/akka/persistence/r2dbc/internal/codec/TimestampCodec.scala
@@ -41,8 +41,8 @@ import akka.annotation.InternalApi
 
     private val zone = ZoneId.of("UTC")
 
-    private def toInstant(timestamp: LocalDateTime): Instant =
-      Option(timestamp).map(_.atZone(zone).toInstant).getOrElse(Instant.EPOCH)
+    private def toInstant(timestamp: LocalDateTime) =
+      timestamp.atZone(zone).toInstant
 
     override def decode(row: Row, name: String): Instant = toInstant(row.get(name, classOf[LocalDateTime]))
 


### PR DESCRIPTION
This reverts commit 1ad8f47482e2023f4bc9270f88ad0ed6d4e8af9e.

This was quite surprising. We have a flaky tests, I asked Copilot inside GH to analyse the cause of flaky tests. It suggested a patch and asked if I want it to generate a patch file. 
I understood that it would produce a .patch, but instead it apply the change directly to main and by-passed our branch protection. 

Anyway, I'm reverting it now because it was a wild-commit to main. I will probably re-send it on a PR.