### PR TITLE
bump: Scram 3.4 (was 3.2) explicitly

### DIFF
--- a/artifact-bom/akka-persistence-r2dbc-migration/pom.xml
+++ b/artifact-bom/akka-persistence-r2dbc-migration/pom.xml
@@ -14,22 +14,22 @@
             <dependency>
                 <groupId>com.ongres.scram</groupId>
                 <artifactId>scram-client</artifactId>
-                <version>3.2</version>
+                <version>3.4</version>
             </dependency>
             <dependency>
                 <groupId>com.ongres.scram</groupId>
                 <artifactId>scram-common</artifactId>
-                <version>3.2</version>
+                <version>3.4</version>
             </dependency>
             <dependency>
                 <groupId>com.ongres.stringprep</groupId>
                 <artifactId>saslprep</artifactId>
-                <version>2.2</version>
+                <version>2.4</version>
             </dependency>
             <dependency>
                 <groupId>com.ongres.stringprep</groupId>
                 <artifactId>stringprep</artifactId>
-                <version>2.2</version>
+                <version>2.4</version>
             </dependency>
             <dependency>
                 <groupId>com.typesafe</groupId>
@@ -232,22 +232,22 @@
         <dependency>
             <groupId>com.ongres.scram</groupId>
             <artifactId>scram-client</artifactId>
-            <version>3.2</version>
+            <version>3.4</version>
         </dependency>
         <dependency>
             <groupId>com.ongres.scram</groupId>
             <artifactId>scram-common</artifactId>
-            <version>3.2</version>
+            <version>3.4</version>
         </dependency>
         <dependency>
             <groupId>com.ongres.stringprep</groupId>
             <artifactId>saslprep</artifactId>
-            <version>2.2</version>
+            <version>2.4</version>
         </dependency>
         <dependency>
             <groupId>com.ongres.stringprep</groupId>
             <artifactId>stringprep</artifactId>
-            <version>2.2</version>
+            <version>2.4</version>
         </dependency>
         <dependency>
             <groupId>com.typesafe</groupId>

--- a/artifact-bom/akka-persistence-r2dbc/pom.xml
+++ b/artifact-bom/akka-persistence-r2dbc/pom.xml
@@ -14,22 +14,22 @@
             <dependency>
                 <groupId>com.ongres.scram</groupId>
                 <artifactId>scram-client</artifactId>
-                <version>3.2</version>
+                <version>3.4</version>
             </dependency>
             <dependency>
                 <groupId>com.ongres.scram</groupId>
                 <artifactId>scram-common</artifactId>
-                <version>3.2</version>
+                <version>3.4</version>
             </dependency>
             <dependency>
                 <groupId>com.ongres.stringprep</groupId>
                 <artifactId>saslprep</artifactId>
-                <version>2.2</version>
+                <version>2.4</version>
             </dependency>
             <dependency>
                 <groupId>com.ongres.stringprep</groupId>
                 <artifactId>stringprep</artifactId>
-                <version>2.2</version>
+                <version>2.4</version>
             </dependency>
             <dependency>
                 <groupId>com.typesafe</groupId>
@@ -232,22 +232,22 @@
         <dependency>
             <groupId>com.ongres.scram</groupId>
             <artifactId>scram-client</artifactId>
-            <version>3.2</version>
+            <version>3.4</version>
         </dependency>
         <dependency>
             <groupId>com.ongres.scram</groupId>
             <artifactId>scram-common</artifactId>
-            <version>3.2</version>
+            <version>3.4</version>
         </dependency>
         <dependency>
             <groupId>com.ongres.stringprep</groupId>
             <artifactId>saslprep</artifactId>
-            <version>2.2</version>
+            <version>2.4</version>
         </dependency>
         <dependency>
             <groupId>com.ongres.stringprep</groupId>
             <artifactId>stringprep</artifactId>
-            <version>2.2</version>
+            <version>2.4</version>
         </dependency>
         <dependency>
             <groupId>com.typesafe</groupId>

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -33,6 +33,10 @@ object Dependencies {
     // FIXME: when bumping, check if the reactor-netty-core override below is still needed
     val r2dbcPostgres = "org.postgresql" % "r2dbc-postgresql" % "1.1.2.RELEASE" // ApacheV2
 
+    // Override for the transitive dependency from r2dbc-postgresql
+    // https://github.com/ongres/scram/releases
+    val scramClient = "com.ongres.scram" % "scram-client" % "3.4"
+
     // Override for the transitive dependency from r2dbc-postgresql to get Netty 4.1.135
     // https://github.com/reactor/reactor-netty/releases#release-v1.2.18
     // Won't release more in the 1.2.18 line. https://projectreactor.io/support
@@ -94,6 +98,7 @@ object Dependencies {
     r2dbcSpi,
     r2dbcPool,
     r2dbcPostgres,
+    scramClient,
     reactorNettyCore,
     h2,
     r2dbcH2,


### PR DESCRIPTION
Explicitly depend on Scram 3.4 pulled in by r2dbc-postgresql.

This gets past https://github.com/ongres/scram/security/advisories/GHSA-p9jg-fcr6-3mhf