### PR TITLE
chore: bump to current versions of GH actions (Node 24)

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -21,7 +21,7 @@ jobs:
 
       - name: Checkout
         # https://github.com/actions/checkout/releases
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           # we don't know what commit the last tag was it's safer to get entire repo so previousStableVersion resolves
           fetch-depth: 0
@@ -34,7 +34,7 @@ jobs:
 
       - name: Cache Coursier cache
         # https://github.com/coursier/cache-action/releases
-        uses: coursier/cache-action@v8.1.0
+        uses: coursier/cache-action@v8.1.1
 
       - name: Set up JDK 11
         # https://github.com/coursier/setup-action/releases
@@ -60,7 +60,7 @@ jobs:
 
       - name: Checkout
         # https://github.com/actions/checkout/releases
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
 
@@ -72,7 +72,7 @@ jobs:
 
       - name: Cache Coursier cache
         # https://github.com/coursier/cache-action/releases
-        uses: coursier/cache-action@v8.1.0
+        uses: coursier/cache-action@v8.1.1
 
       - name: Set up JDK 11
         # https://github.com/coursier/setup-action/releases
@@ -100,7 +100,7 @@ jobs:
 
       - name: Checkout
         # https://github.com/actions/checkout/releases
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
 
@@ -112,7 +112,7 @@ jobs:
 
       - name: Cache Coursier cache
         # https://github.com/coursier/cache-action/releases
-        uses: coursier/cache-action@v8.1.0
+        uses: coursier/cache-action@v8.1.1
 
       - name: Set up JDK 11
         # https://github.com/coursier/setup-action/releases
@@ -143,7 +143,7 @@ jobs:
 
       - name: Checkout
         # https://github.com/actions/checkout/releases
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
 
@@ -155,7 +155,7 @@ jobs:
 
       - name: Cache Coursier cache
         # https://github.com/coursier/cache-action/releases
-        uses: coursier/cache-action@v8.1.0
+        uses: coursier/cache-action@v8.1.1
 
       - name: Set up JDK 11
         # https://github.com/coursier/setup-action/releases
@@ -184,7 +184,7 @@ jobs:
 
       - name: Checkout
         # https://github.com/actions/checkout/releases
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
 
@@ -196,7 +196,7 @@ jobs:
 
       - name: Cache Coursier cache
         # https://github.com/coursier/cache-action/releases
-        uses: coursier/cache-action@v8.1.0
+        uses: coursier/cache-action@v8.1.1
 
       - name: Set up JDK 11
         # https://github.com/coursier/setup-action/releases
@@ -226,7 +226,7 @@ jobs:
 
       - name: Checkout
         # https://github.com/actions/checkout/releases
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
 
@@ -238,7 +238,7 @@ jobs:
 
       - name: Cache Coursier cache
         # https://github.com/coursier/cache-action/releases
-        uses: coursier/cache-action@v8.1.0
+        uses: coursier/cache-action@v8.1.1
 
       - name: Set up JDK 11
         # https://github.com/coursier/setup-action/releases
@@ -261,7 +261,7 @@ jobs:
 
       - name: Checkout
         # https://github.com/actions/checkout/releases
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
 
@@ -272,7 +272,7 @@ jobs:
           git checkout scratch
       - name: Cache Coursier cache
         # https://github.com/coursier/cache-action/releases
-        uses: coursier/cache-action@v8.1.0
+        uses: coursier/cache-action@v8.1.1
 
       - name: Set up JDK 11
         # https://github.com/coursier/setup-action/releases
@@ -299,7 +299,7 @@ jobs:
 
       - name: Checkout
         # https://github.com/actions/checkout/releases
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
 
@@ -311,7 +311,7 @@ jobs:
 
       - name: Cache Coursier cache
         # https://github.com/coursier/cache-action/releases
-        uses: coursier/cache-action@v8.1.0
+        uses: coursier/cache-action@v8.1.1
 
       - name: Set up JDK 25
         # https://github.com/coursier/setup-action/releases

--- a/.github/workflows/link-validator.yml
+++ b/.github/workflows/link-validator.yml
@@ -19,7 +19,7 @@ jobs:
 
       - name: Checkout
         # https://github.com/actions/checkout/releases
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           # See https://github.com/actions/checkout/issues/299#issuecomment-677674415
           ref: ${{ github.event.pull_request.head.sha }}
@@ -30,7 +30,7 @@ jobs:
 
       - name: Cache Coursier cache
         # https://github.com/coursier/cache-action/releases
-        uses: coursier/cache-action@v8.1.0
+        uses: coursier/cache-action@v8.1.1
 
       - name: Set up JDK 25
         # https://github.com/coursier/setup-action/releases

--- a/.github/workflows/native-image-tests.yml
+++ b/.github/workflows/native-image-tests.yml
@@ -86,7 +86,7 @@ jobs:
           password: ${{secrets.MAIL_PASSWORD}}
           subject: "Failed: ${{ github.workflow }} / ${{ github.job }}"
           to: ${{secrets.MAIL_SEND_TO}}
-          from: Akka CI
+          from: "Akka CI <no-reply@akka.io>"
           body: |
             Job ${{ github.job }} in workflow ${{ github.workflow }} of ${{github.repository}} failed!
             https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}

--- a/.github/workflows/native-image-tests.yml
+++ b/.github/workflows/native-image-tests.yml
@@ -18,7 +18,7 @@ jobs:
 
       - name: Checkout
         # https://github.com/actions/checkout/releases
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           # we don't know what commit the last tag was it's safer to get entire repo so previousStableVersion resolves
           fetch-depth: 0
@@ -31,7 +31,7 @@ jobs:
 
       - name: Cache Coursier cache
         # https://github.com/coursier/cache-action/releases
-        uses: coursier/cache-action@v8.1.0
+        uses: coursier/cache-action@v8.1.1
 
       - name: Set up JDK 11
         # https://github.com/coursier/setup-action/releases
@@ -77,7 +77,7 @@ jobs:
 
       - name: Email on failure
         if: ${{ failure() }}
-        uses: dawidd6/action-send-mail@v12
+        uses: dawidd6/action-send-mail@v18
         with:
           server_address: smtp.gmail.com
           server_port: 465

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -20,14 +20,14 @@ jobs:
 
       - name: Checkout
         # https://github.com/actions/checkout/releases
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           # we don't know what commit the last tag was it's safer to get entire repo so previousStableVersion resolves
           fetch-depth: 0
 
       - name: Cache Coursier cache
         # https://github.com/coursier/cache-action/releases
-        uses: coursier/cache-action@v8.1.0
+        uses: coursier/cache-action@v8.1.1
 
       - name: Set up JDK 11
         # https://github.com/coursier/setup-action/releases
@@ -54,7 +54,7 @@ jobs:
 
       - name: Checkout
         # https://github.com/actions/checkout/releases
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           # we don't know what commit the last tag was it's safer to get entire repo so previousStableVersion resolves
           fetch-depth: 0

--- a/.github/workflows/scheduled.yml
+++ b/.github/workflows/scheduled.yml
@@ -31,13 +31,13 @@ jobs:
 
       - name: Checkout
         # https://github.com/actions/checkout/releases
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
 
       - name: Cache Coursier cache
         # https://github.com/coursier/cache-action/releases
-        uses: coursier/cache-action@v8.1.0
+        uses: coursier/cache-action@v8.1.1
 
       - name: Set up JDK ${{ matrix.jdkVersion }}
         # https://github.com/coursier/setup-action/releases
@@ -60,7 +60,7 @@ jobs:
 
       - name: Email on failure
         if: ${{ failure() }}
-        uses: dawidd6/action-send-mail@v12
+        uses: dawidd6/action-send-mail@v18
         with:
           server_address: smtp.gmail.com
           server_port: 465
@@ -91,13 +91,13 @@ jobs:
 
       - name: Checkout
         # https://github.com/actions/checkout/releases
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
 
       - name: Cache Coursier cache
         # https://github.com/coursier/cache-action/releases
-        uses: coursier/cache-action@v8.1.0
+        uses: coursier/cache-action@v8.1.1
 
       - name: Set up JDK ${{ matrix.jdkVersion }}
         # https://github.com/coursier/setup-action/releases
@@ -120,7 +120,7 @@ jobs:
 
       - name: Email on failure
         if: ${{ failure() }}
-        uses: dawidd6/action-send-mail@v12
+        uses: dawidd6/action-send-mail@v18
         with:
           server_address: smtp.gmail.com
           server_port: 465
@@ -151,13 +151,13 @@ jobs:
 
       - name: Checkout
         # https://github.com/actions/checkout/releases
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
 
       - name: Cache Coursier cache
         # https://github.com/coursier/cache-action/releases
-        uses: coursier/cache-action@v8.1.0
+        uses: coursier/cache-action@v8.1.1
 
       - name: Set up JDK ${{ matrix.jdkVersion }}
         # https://github.com/coursier/setup-action/releases
@@ -173,7 +173,7 @@ jobs:
 
       - name: Email on failure
         if: ${{ failure() }}
-        uses: dawidd6/action-send-mail@v12
+        uses: dawidd6/action-send-mail@v18
         with:
           server_address: smtp.gmail.com
           server_port: 465


### PR DESCRIPTION
Bump action-send-mail to a version running Node 24.

Bump even other actions to their current versions.

Change email from address to an allowed format.

- https://github.com/akka/akka-persistence-r2dbc/actions/runs/30551871356/job/90902324988