### PR TITLE
tests: Logback 1.5.38 does something new reflectively

### DIFF
--- a/native-image-tests/build.sbt
+++ b/native-image-tests/build.sbt
@@ -16,7 +16,7 @@ nativeImageVersion := "21.0.2"
 nativeImageOptions := Seq(
   "--no-fallback",
   "--verbose",
-  "--initialize-at-build-time=ch.qos.logback",
+  "--initialize-at-build-time=ch.qos.logback,org.slf4j",
   "-Dakka.native-image.debug=true")
 
 libraryDependencies ++= Seq(


### PR DESCRIPTION
That needs special native image handling

Failing native image tests currently