### PR TITLE
perf: batch snapshot-seqNr lookups for start-from-snapshot

### DIFF
--- a/core/src/main/resources/reference.conf
+++ b/core/src/main/resources/reference.conf
@@ -202,7 +202,9 @@ akka.persistence.r2dbc {
         enabled = false
 
         # Trigger a batched lookup once this many distinct not-yet-cached persistence ids have
-        # accumulated.
+        # accumulated. Keep this well below cache-capacity: resolving a batch this large can otherwise
+        # evict entries resolved earlier in the same batch before they are consumed, forcing a
+        # redundant lookup for them.
         lookup-batch-size = 200
 
         # Upper bound on the number of buffered-but-not-yet-decided envelopes. Also triggers a batched

--- a/core/src/main/resources/reference.conf
+++ b/core/src/main/resources/reference.conf
@@ -192,19 +192,18 @@ akka.persistence.r2dbc {
       # This is the number of filtered events until a heartbeat is emitted.
       heartbeat-after = 1000
 
-      # EXPERIMENTAL, sketch/draft. When the number of distinct persistence ids handled by a single
-      # projection partition is much larger than cache-capacity, the cache above thrashes and every
-      # cache miss becomes a synchronous, unpipelined round-trip to the database that stalls the whole
-      # partition. When batching.enabled = true, cache misses are instead buffered (preserving order)
-      # and resolved with a single batched query per group of misses, without blocking the stream while
-      # waiting.
+      # When the number of distinct persistence ids handled by a single projection partition is much
+      # larger than cache-capacity, the cache above thrashes and every cache miss becomes a synchronous,
+      # unpipelined round-trip to the database that stalls the whole partition. When batching.enabled =
+      # true, cache misses are instead buffered (preserving order) and resolved with a single batched
+      # query per group of misses, without blocking the stream while waiting.
       batching {
         enabled = false
 
         # Trigger a batched lookup once this many distinct not-yet-cached persistence ids have
-        # accumulated. Keep this well below cache-capacity: resolving a batch this large can otherwise
-        # evict entries resolved earlier in the same batch before they are consumed, forcing a
-        # redundant lookup for them.
+        # accumulated. Keep this well below cache-capacity: resolving a batch this large can push the
+        # cache to evict entries faster than the batch itself is consumed (each resolution counts as a
+        # cache use), reducing the hit rate for later events.
         lookup-batch-size = 200
 
         # Upper bound on the number of buffered-but-not-yet-decided envelopes. Also triggers a batched

--- a/core/src/main/resources/reference.conf
+++ b/core/src/main/resources/reference.conf
@@ -191,6 +191,28 @@ akka.persistence.r2dbc {
       # fictive heartbeat events for progress observations and offset storage downstreams.
       # This is the number of filtered events until a heartbeat is emitted.
       heartbeat-after = 1000
+
+      # EXPERIMENTAL, sketch/draft. When the number of distinct persistence ids handled by a single
+      # projection partition is much larger than cache-capacity, the cache above thrashes and every
+      # cache miss becomes a synchronous, unpipelined round-trip to the database that stalls the whole
+      # partition. When batching.enabled = true, cache misses are instead buffered (preserving order)
+      # and resolved with a single batched query per group of misses, without blocking the stream while
+      # waiting.
+      batching {
+        enabled = false
+
+        # Trigger a batched lookup once this many distinct not-yet-cached persistence ids have
+        # accumulated.
+        lookup-batch-size = 200
+
+        # Upper bound on the number of buffered-but-not-yet-decided envelopes. Also triggers a batched
+        # lookup early if reached before lookup-batch-size, to bound memory use.
+        max-buffered-envelopes = 2000
+
+        # If fewer than lookup-batch-size distinct ids have accumulated within this long, trigger a
+        # (smaller) batched lookup anyway rather than waiting indefinitely.
+        batch-linger = 50 ms
+      }
     }
 
     # Cache TTL for latestEventTimestamp queries. Setting this to a positive duration enables caching of

--- a/core/src/main/scala/akka/persistence/r2dbc/R2dbcSettings.scala
+++ b/core/src/main/scala/akka/persistence/r2dbc/R2dbcSettings.scala
@@ -579,6 +579,13 @@ final class QuerySettings(config: Config) {
   val startFromSnapshotEnabled: Boolean = config.getBoolean("start-from-snapshot.enabled")
   val startFromSnapshotCacheCapacity: Int = config.getInt("start-from-snapshot.cache-capacity")
   val startFromSnapshotHeartbeatAfter: Int = config.getInt("start-from-snapshot.heartbeat-after")
+  // EXPERIMENTAL, sketch/draft, see BatchingStartingFromSnapshotStage
+  val startFromSnapshotBatchingEnabled: Boolean = config.getBoolean("start-from-snapshot.batching.enabled")
+  val startFromSnapshotLookupBatchSize: Int = config.getInt("start-from-snapshot.batching.lookup-batch-size")
+  val startFromSnapshotMaxBufferedEnvelopes: Int =
+    config.getInt("start-from-snapshot.batching.max-buffered-envelopes")
+  val startFromSnapshotBatchLinger: FiniteDuration =
+    config.getDuration("start-from-snapshot.batching.batch-linger").toScala
   val cacheLatestEventTimestamp: Option[FiniteDuration] = config.optDuration("cache-latest-event-timestamp")
   val estimateTimeRange: Boolean = config.getBoolean("estimate-time-range")
 }

--- a/core/src/main/scala/akka/persistence/r2dbc/R2dbcSettings.scala
+++ b/core/src/main/scala/akka/persistence/r2dbc/R2dbcSettings.scala
@@ -579,7 +579,7 @@ final class QuerySettings(config: Config) {
   val startFromSnapshotEnabled: Boolean = config.getBoolean("start-from-snapshot.enabled")
   val startFromSnapshotCacheCapacity: Int = config.getInt("start-from-snapshot.cache-capacity")
   val startFromSnapshotHeartbeatAfter: Int = config.getInt("start-from-snapshot.heartbeat-after")
-  // EXPERIMENTAL, sketch/draft, see BatchingStartingFromSnapshotStage
+  // see BatchingStartingFromSnapshotStage
   val startFromSnapshotBatchingEnabled: Boolean = config.getBoolean("start-from-snapshot.batching.enabled")
   val startFromSnapshotLookupBatchSize: Int = config.getInt("start-from-snapshot.batching.lookup-batch-size")
   val startFromSnapshotMaxBufferedEnvelopes: Int =

--- a/core/src/main/scala/akka/persistence/r2dbc/internal/BatchingStartingFromSnapshotStage.scala
+++ b/core/src/main/scala/akka/persistence/r2dbc/internal/BatchingStartingFromSnapshotStage.scala
@@ -64,10 +64,6 @@ import akka.util.RecencyList
  * Loading the actual snapshot payload for entities whose boundary event is reached is left serialized as before — that
  * only happens once per entity (not once per cache eviction) so it isn't the dominant cost, but it is a natural next
  * step to pipeline the same way if it turns out to matter.
- *
- * Known gaps:
- *   - memory bound of the envelope buffer under pathological miss patterns not validated
- *   - snapshot-load step not pipelined (see above)
  */
 @InternalApi private[r2dbc] object BatchingStartingFromSnapshotStage {
   private case class SnapshotState(seqNr: Long, emitted: Boolean)

--- a/core/src/main/scala/akka/persistence/r2dbc/internal/BatchingStartingFromSnapshotStage.scala
+++ b/core/src/main/scala/akka/persistence/r2dbc/internal/BatchingStartingFromSnapshotStage.scala
@@ -29,41 +29,20 @@ import akka.util.RecencyList
 
 /**
  * Alternative to `StartingFromSnapshotStage` for workloads where a projection partition handles many more distinct
- * persistence ids than `cache-capacity`. In that situation the original stage's cache-miss rate approaches 1, and it
- * degrades into one fully serialized, blocking DB round-trip per event, because it does not pull the next upstream
- * element until the current lookup's callback has completed. Total pipeline throughput then becomes bound by round-trip
- * latency instead of DB or write capacity.
+ * persistence ids than `cache-capacity`. There, the original stage's cache-miss rate approaches 1, and it becomes fully
+ * serialized and round-trip-latency bound: it never pulls the next event until the current lookup completes.
  *
- * This stage keeps the same LRU cache, but resolves a batch of cache misses with a single round-trip instead of one
- * round-trip per miss. All envelopes — cache hits included — pass through a single ordered `pendingQueue` and are only
- * ever decided (push / ignore / load snapshot) strictly from its head, one at a time:
- *   - every envelope is enqueued in arrival order, and if its persistence id isn't cached its id is added to a
- *     pending-lookup set
- *   - upstream keeps being pulled (bounded by `maxBufferedEnvelopes`) to keep the queue filling
- *   - once `lookupBatchSize` distinct new ids have accumulated (anywhere in the queue, not just at the head),
- *     `maxBufferedEnvelopes` is reached, a linger timer expires, or upstream finishes, a *single* batched lookup
- *     (`SnapshotDao.sequenceNumbersOfSnapshots`) resolves the whole pending set in one round-trip
- *   - the queue is then advanced from the head for as long as each head's persistence id is resolved; advancing stops
- *     the moment the head's id isn't resolved yet (nothing later in the queue can be emitted before it without
- *     reordering) or a snapshot payload load is in flight for the current head
+ * This stage resolves cache misses in batches (`SnapshotDao.sequenceNumbersOfSnapshots`) instead of one round-trip per
+ * event, and keeps pulling upstream while a batch is in flight. All envelopes pass through a single ordered queue and
+ * are only ever decided from its head, so a cache hit can never be emitted ahead of an earlier, still unresolved
+ * envelope.
  *
- * Every envelope, hit or miss, must pass through the same head-of-queue gate: deciding a cache-hit envelope out of
- * order, ahead of an earlier envelope still waiting on a lookup or a snapshot load, would reorder the stream.
+ * A persistence id's cache entry is pinned against LRU eviction for as long as an envelope that depends on it, has not
+ * yet been decided, including while its snapshot payload is being loaded. See `loadCorrespondingSnapshot` for why the
+ * payload-load case needs the same protection.
  *
- * A persistence id that is resolved in the cache but still referenced by an envelope sitting in `pendingQueue` (stuck
- * behind an earlier, not-yet-resolved head) is pinned and exempt from LRU eviction until it is dequeued. Without this,
- * the entry could be evicted between being resolved and being dequeued, leaving that envelope permanently unresolved
- * and stalling the stage. The same applies while a snapshot payload load is in flight: the envelope that triggered it
- * has already been dequeued (and unpinned) by the time the load starts, but its persistence id must still not be
- * evicted for the load's duration - a batch lookup for a different id can run concurrently with the load (nothing gates
- * `triggerBatch` on `awaitingSnapshotLoad`), and if that eviction happened, a redelivery of the same id would see a
- * cache miss and start a redundant lookup racing the load, non-deterministically clobbering the `emitted` flag the load
- * is about to set and opening the door to a duplicate snapshot-envelope emission on a later redelivery.
- * `loadCorrespondingSnapshot` pins the id explicitly for exactly this reason.
- *
- * Loading the actual snapshot payload for entities whose boundary event is reached is left serialized as before — that
- * only happens once per entity (not once per cache eviction) so it isn't the dominant cost, but it is a natural next
- * step to pipeline the same way if it turns out to matter.
+ * Loading the snapshot payload itself stays serialized. That happens once per entity, not once per cache eviction, so
+ * it is not the dominant cost.
  */
 @InternalApi private[r2dbc] object BatchingStartingFromSnapshotStage {
   private case class SnapshotState(seqNr: Long, emitted: Boolean)
@@ -106,11 +85,11 @@ import akka.util.RecencyList
       // hit can never jump ahead of an earlier envelope that is still waiting on a lookup or a snapshot load.
       private val pendingQueue = mutable.Queue.empty[EventEnvelope[Event]]
       // reference count, per persistence id, of envelopes currently in pendingQueue; used to pin cache entries
-      // that a not-yet-dequeued envelope depends on so eviction can't invalidate a resolution before it's consumed
+      // that a not-yet-dequeued envelope depends on so eviction cannot invalidate a resolution before it is consumed
       private val pinCount = mutable.Map.empty[String, Int]
-      // ids seen in pendingQueue that aren't cached yet and aren't already covered by an in-flight batch
+      // ids seen in pendingQueue that are not cached yet and are not already covered by an in-flight batch
       private val pendingLookupIds = mutable.LinkedHashSet.empty[String]
-      // ids covered by the batch currently in flight, so a re-arriving envelope for the same id doesn't trigger
+      // ids covered by the batch currently in flight, so a re-arriving envelope for the same id does not trigger
       // a redundant duplicate lookup
       private val idsInFlight = mutable.Set.empty[String]
       private var batchInFlight = false
@@ -148,9 +127,7 @@ import akka.util.RecencyList
               snapshotState -= pid
               continueEviction = recency.size > cacheCapacity
             case None =>
-              // every cached entry is pinned (referenced by an envelope still sitting in pendingQueue behind a
-              // not-yet-resolved head) - can't evict without risking losing a resolution before it's consumed.
-              // Temporarily over cacheCapacity; bounded by maxBufferedEnvelopes.
+              // every cached entry is pinned; stay temporarily over cacheCapacity rather than evict one in use
               continueEviction = false
           }
         }
@@ -217,10 +194,8 @@ import akka.util.RecencyList
 
       private def loadCorrespondingSnapshot(env: EventEnvelope[Event]): Unit = {
         awaitingSnapshotLoad = true
-        // pin explicitly: this envelope was already dequeued (and unpinned) by advance() before this is called,
-        // but the cache entry it depends on must not be evicted while the load - a second async operation not
-        // otherwise tracked by the queue - is in flight, or a concurrent batch resolving a different id could
-        // evict it and a redelivery for this id would then race a redundant lookup against this load
+        // re-pin: advance() already unpinned this id when it dequeued the envelope, but a concurrent batch for
+        // another id could otherwise evict it mid-load and race a redundant lookup against this load
         pin(env.persistenceId)
         loadSnapshot(env.persistenceId)
           .map(result => (env, result))(ExecutionContext.parasitic)
@@ -268,9 +243,7 @@ import akka.util.RecencyList
         }
       }
 
-      // advances strictly from the head: an envelope can only be decided once every envelope ahead of it
-      // has already been decided, so a resolved (cache hit) id can never jump ahead of an earlier envelope
-      // that is still waiting on a lookup or a snapshot load
+      // enforces the head-of-queue ordering invariant described in the class doc
       private def advance(): Unit = {
         var continue = true
         while (continue && pendingQueue.nonEmpty && !awaitingSnapshotLoad) {

--- a/core/src/main/scala/akka/persistence/r2dbc/internal/BatchingStartingFromSnapshotStage.scala
+++ b/core/src/main/scala/akka/persistence/r2dbc/internal/BatchingStartingFromSnapshotStage.scala
@@ -28,13 +28,11 @@ import akka.stream.stage.TimerGraphStageLogic
 import akka.util.RecencyList
 
 /**
- * SKETCH / PROTOTYPE — not wired into `R2dbcReadJournal` yet.
- *
- * Alternative to `StartingFromSnapshotStage` addressing the observed Westpac issue: with a cache-miss rate close to 1
- * (many more distinct persistence ids per projection partition than `cache-capacity`), the original stage degrades into
- * one fully serialized, blocking DB round-trip per event, because it does not pull the next upstream element until the
- * current lookup's callback has completed. Total pipeline throughput then becomes bound by round-trip latency instead
- * of DB or write capacity.
+ * Alternative to `StartingFromSnapshotStage` for workloads where a projection partition handles many more distinct
+ * persistence ids than `cache-capacity`. In that situation the original stage's cache-miss rate approaches 1, and it
+ * degrades into one fully serialized, blocking DB round-trip per event, because it does not pull the next upstream
+ * element until the current lookup's callback has completed. Total pipeline throughput then becomes bound by round-trip
+ * latency instead of DB or write capacity.
  *
  * This stage keeps the same LRU cache, but resolves a batch of cache misses with a single round-trip instead of one
  * round-trip per miss. All envelopes — cache hits included — pass through a single ordered `pendingQueue` and are only
@@ -49,19 +47,20 @@ import akka.util.RecencyList
  *     the moment the head's id isn't resolved yet (nothing later in the queue can be emitted before it without
  *     reordering) or a snapshot payload load is in flight for the current head
  *
- * An earlier version of this stage had a fast path that decided cache-hit envelopes immediately, bypassing the queue.
- * That reordered the stream whenever a cache hit arrived while an async snapshot-payload load for an *earlier* envelope
- * was still in flight (caught by EventsBySliceStartingFromSnapshotSpec against real Postgres with batching enabled —
- * the first delivered envelope was a later plain event instead of the pending snapshot). Every envelope, hit or miss,
- * must now pass through the same head-of-queue gate.
+ * Every envelope, hit or miss, must pass through the same head-of-queue gate: deciding a cache-hit envelope out of
+ * order, ahead of an earlier envelope still waiting on a lookup or a snapshot load, would reorder the stream.
+ *
+ * A persistence id that is resolved in the cache but still referenced by an envelope sitting in `pendingQueue` (stuck
+ * behind an earlier, not-yet-resolved head) is pinned and exempt from LRU eviction until it is dequeued. Without this,
+ * the entry could be evicted between being resolved and being dequeued, leaving that envelope permanently unresolved
+ * and stalling the stage.
  *
  * Loading the actual snapshot payload for entities whose boundary event is reached is left serialized as before — that
  * only happens once per entity (not once per cache eviction) so it isn't the dominant cost, but it is a natural next
  * step to pipeline the same way if it turns out to matter.
  *
- * Known gaps to close before this can replace the original stage:
+ * Known gaps:
  *   - no automated tests yet (should reuse/extend StartingFromSnapshotStageSpec)
- *   - config wiring for lookupBatchSize / maxBufferedEnvelopes / batchLinger not added to reference.conf
  *   - memory bound of the envelope buffer under pathological miss patterns not validated
  *   - snapshot-load step not pipelined (see above)
  */
@@ -71,7 +70,7 @@ import akka.util.RecencyList
 }
 
 /**
- * SKETCH / PROTOTYPE — see class doc.
+ * See class doc.
  */
 @InternalApi private[r2dbc] class BatchingStartingFromSnapshotStage[Event](
     cacheCapacity: Int,
@@ -105,8 +104,14 @@ import akka.util.RecencyList
       // ALL not-yet-decided envelopes, in arrival order. Only ever advanced from the head, so that a cache
       // hit can never jump ahead of an earlier envelope that is still waiting on a lookup or a snapshot load.
       private val pendingQueue = mutable.Queue.empty[EventEnvelope[Event]]
-      // ids seen in pendingQueue that aren't cached yet and aren't part of an in-flight batch
+      // reference count, per persistence id, of envelopes currently in pendingQueue; used to pin cache entries
+      // that a not-yet-dequeued envelope depends on so eviction can't invalidate a resolution before it's consumed
+      private val pinCount = mutable.Map.empty[String, Int]
+      // ids seen in pendingQueue that aren't cached yet and aren't already covered by an in-flight batch
       private val pendingLookupIds = mutable.LinkedHashSet.empty[String]
+      // ids covered by the batch currently in flight, so a re-arriving envelope for the same id doesn't trigger
+      // a redundant duplicate lookup
+      private val idsInFlight = mutable.Set.empty[String]
       private var batchInFlight = false
 
       // envelopes that have been decided (should be pushed) but are waiting for downstream demand
@@ -119,13 +124,35 @@ import akka.util.RecencyList
       private var filterCount = 0L
       private var latestTimestamp = Instant.EPOCH
 
+      private def pin(persistenceId: String): Unit =
+        pinCount.update(persistenceId, pinCount.getOrElse(persistenceId, 0) + 1)
+
+      private def unpin(persistenceId: String): Unit =
+        pinCount.get(persistenceId) match {
+          case Some(1) => pinCount -= persistenceId
+          case Some(n) => pinCount.update(persistenceId, n - 1)
+          case None    => ()
+        }
+
+      private def isPinned(persistenceId: String): Boolean = pinCount.contains(persistenceId)
+
       private def updateState(persistenceId: String, seqNr: Long, emitted: Boolean): Unit = {
         snapshotState = snapshotState.updated(persistenceId, SnapshotState(seqNr, emitted))
         recency.update(persistenceId)
-        if (recency.size > cacheCapacity)
-          recency.removeLeastRecent().foreach { pid =>
-            snapshotState -= pid
+        var continueEviction = recency.size > cacheCapacity
+        while (continueEviction) {
+          recency.leastToMostRecent.find(pid => !isPinned(pid)) match {
+            case Some(pid) =>
+              recency.remove(pid)
+              snapshotState -= pid
+              continueEviction = recency.size > cacheCapacity
+            case None =>
+              // every cached entry is pinned (referenced by an envelope still sitting in pendingQueue behind a
+              // not-yet-resolved head) - can't evict without risking losing a resolution before it's consumed.
+              // Temporarily over cacheCapacity; bounded by maxBufferedEnvelopes.
+              continueEviction = false
           }
+        }
       }
 
       private def emit(env: EventEnvelope[Event]): Unit = {
@@ -195,6 +222,7 @@ import akka.util.RecencyList
       private val batchCallback = getAsyncCallback[Try[(Set[String], Map[String, Long])]] {
         case Success((ids, results)) =>
           batchInFlight = false
+          idsInFlight --= ids
           ids.foreach { pid =>
             results.get(pid) match {
               case Some(seqNr) => updateState(pid, seqNr, emitted = false)
@@ -215,6 +243,7 @@ import akka.util.RecencyList
         if (pendingLookupIds.nonEmpty && !batchInFlight) {
           val ids = pendingLookupIds.toSet
           pendingLookupIds.clear()
+          idsInFlight ++= ids
           batchInFlight = true
           sequenceNumbersOfSnapshots(ids)
             .map(results => (ids, results))(ExecutionContext.parasitic)
@@ -240,6 +269,7 @@ import akka.util.RecencyList
           snapshotState.get(pendingQueue.head.persistenceId) match {
             case Some(s) =>
               val env = pendingQueue.dequeue()
+              unpin(env.persistenceId)
               handleResolved(env, s) // may set awaitingSnapshotLoad = true, loop condition then stops us
             case None =>
               // head not resolved yet - nothing after it can be emitted without reordering
@@ -260,7 +290,8 @@ import akka.util.RecencyList
       override def onPush(): Unit = {
         val env = grab(in)
         pendingQueue.enqueue(env)
-        if (!snapshotState.contains(env.persistenceId)) {
+        pin(env.persistenceId)
+        if (!snapshotState.contains(env.persistenceId) && !idsInFlight.contains(env.persistenceId)) {
           pendingLookupIds += env.persistenceId
           maybeTriggerBatch()
         }
@@ -271,8 +302,9 @@ import akka.util.RecencyList
       override def onPull(): Unit = {
         if (readyQueue.nonEmpty)
           push(out, readyQueue.dequeue())
-        else
-          pullIfRoom()
+        // keep pulling upstream regardless, so refilling the buffer overlaps with downstream draining it
+        // instead of the two phases alternating
+        pullIfRoom()
         completeIfDone()
       }
 
@@ -281,6 +313,7 @@ import akka.util.RecencyList
         // flush whatever is pending rather than waiting for lookupBatchSize / the linger timer
         if (pendingLookupIds.nonEmpty && !batchInFlight)
           triggerBatch()
+        advance()
         completeIfDone()
       }
 

--- a/core/src/main/scala/akka/persistence/r2dbc/internal/BatchingStartingFromSnapshotStage.scala
+++ b/core/src/main/scala/akka/persistence/r2dbc/internal/BatchingStartingFromSnapshotStage.scala
@@ -36,15 +36,24 @@ import akka.util.RecencyList
  * current lookup's callback has completed. Total pipeline throughput then becomes bound by round-trip latency instead
  * of DB or write capacity.
  *
- * This stage keeps the same LRU cache, but on a cache miss it does not immediately block:
- *   - the event is buffered (in original order) and the persistence id is added to a pending-lookup set
- *   - upstream keeps being pulled (bounded by `maxBufferedEnvelopes`) to keep accumulating misses
- *   - once `lookupBatchSize` distinct new ids have accumulated, `maxBufferedEnvelopes` is reached, a linger timer
- *     expires, or upstream finishes, a *single* batched lookup (`SnapshotDao.sequenceNumbersOfSnapshots`) resolves the
- *     whole pending set in one round-trip (or, worst case with the trait's default fallback, one round-trip per id but
- *     *concurrently* rather than serialized)
- *   - buffered envelopes are then drained, in order, through the same per-envelope decision logic as the original stage
- *     (push / ignore / load the matching snapshot)
+ * This stage keeps the same LRU cache, but resolves a batch of cache misses with a single round-trip instead of one
+ * round-trip per miss. All envelopes — cache hits included — pass through a single ordered `pendingQueue` and are only
+ * ever decided (push / ignore / load snapshot) strictly from its head, one at a time:
+ *   - every envelope is enqueued in arrival order, and if its persistence id isn't cached its id is added to a
+ *     pending-lookup set
+ *   - upstream keeps being pulled (bounded by `maxBufferedEnvelopes`) to keep the queue filling
+ *   - once `lookupBatchSize` distinct new ids have accumulated (anywhere in the queue, not just at the head),
+ *     `maxBufferedEnvelopes` is reached, a linger timer expires, or upstream finishes, a *single* batched lookup
+ *     (`SnapshotDao.sequenceNumbersOfSnapshots`) resolves the whole pending set in one round-trip
+ *   - the queue is then advanced from the head for as long as each head's persistence id is resolved; advancing stops
+ *     the moment the head's id isn't resolved yet (nothing later in the queue can be emitted before it without
+ *     reordering) or a snapshot payload load is in flight for the current head
+ *
+ * An earlier version of this stage had a fast path that decided cache-hit envelopes immediately, bypassing the queue.
+ * That reordered the stream whenever a cache hit arrived while an async snapshot-payload load for an *earlier* envelope
+ * was still in flight (caught by EventsBySliceStartingFromSnapshotSpec against real Postgres with batching enabled —
+ * the first delivered envelope was a later plain event instead of the pending snapshot). Every envelope, hit or miss,
+ * must now pass through the same head-of-queue gate.
  *
  * Loading the actual snapshot payload for entities whose boundary event is reached is left serialized as before — that
  * only happens once per entity (not once per cache eviction) so it isn't the dominant cost, but it is a natural next
@@ -93,9 +102,10 @@ import akka.util.RecencyList
       private var snapshotState = Map.empty[String, SnapshotState]
       private val recency = RecencyList.emptyWithNanoClock[String]
 
-      // envelopes whose persistence id isn't resolved yet, in arrival order
-      private val lookupBuffer = mutable.Queue.empty[EventEnvelope[Event]]
-      // ids not yet part of an in-flight batch, accumulating towards the next one
+      // ALL not-yet-decided envelopes, in arrival order. Only ever advanced from the head, so that a cache
+      // hit can never jump ahead of an earlier envelope that is still waiting on a lookup or a snapshot load.
+      private val pendingQueue = mutable.Queue.empty[EventEnvelope[Event]]
+      // ids seen in pendingQueue that aren't cached yet and aren't part of an in-flight batch
       private val pendingLookupIds = mutable.LinkedHashSet.empty[String]
       private var batchInFlight = false
 
@@ -133,8 +143,8 @@ import akka.util.RecencyList
           emit(createHeartbeat(latestTimestamp))
       }
 
-      // same per-envelope decision as StartingFromSnapshotStage.onPush's cached branch,
-      // used both for cache hits and for buffered envelopes once their id has been resolved
+      // decision for one envelope whose persistence id is already resolved; only ever called for the
+      // current head of pendingQueue (already dequeued by the caller)
       private def handleResolved(env: EventEnvelope[Event], s: SnapshotState): Unit = {
         val eventIsAfterSnapshot = env.sequenceNr > s.seqNr
         if (eventIsAfterSnapshot) {
@@ -159,13 +169,17 @@ import akka.util.RecencyList
             updateState(snap.persistenceId, snap.seqNr, emitted = false)
             ignoreOne(env)
           }
-          drainLookupBuffer()
+          advance()
+          pullIfRoom()
+          completeIfDone()
 
         case Success((env, None)) =>
           awaitingSnapshotLoad = false
           updateState(env.persistenceId, 0L, emitted = true)
           emit(env)
-          drainLookupBuffer()
+          advance()
+          pullIfRoom()
+          completeIfDone()
 
         case Failure(exc) =>
           failStage(exc)
@@ -187,7 +201,7 @@ import akka.util.RecencyList
               case None        => updateState(pid, 0L, emitted = true) // no snapshot for this id
             }
           }
-          drainLookupBuffer()
+          advance()
           maybeTriggerBatch()
           pullIfRoom()
           completeIfDone()
@@ -210,44 +224,48 @@ import akka.util.RecencyList
 
       private def maybeTriggerBatch(): Unit = {
         if (!batchInFlight && pendingLookupIds.nonEmpty) {
-          if (pendingLookupIds.size >= lookupBatchSize || lookupBuffer.size >= maxBufferedEnvelopes)
+          if (pendingLookupIds.size >= lookupBatchSize || pendingQueue.size >= maxBufferedEnvelopes)
             triggerBatch()
           else if (!isTimerActive(BatchLingerTimerKey))
             scheduleOnce(BatchLingerTimerKey, batchLinger)
         }
       }
 
-      // drains envelopes that are ready to be resolved, in order; stops at the first envelope whose id
-      // isn't resolved yet (belongs to the next generation) or while a snapshot load is in flight
-      private def drainLookupBuffer(): Unit = {
-        while (lookupBuffer.nonEmpty && !awaitingSnapshotLoad && snapshotState.contains(
-            lookupBuffer.head.persistenceId)) {
-          val env = lookupBuffer.dequeue()
-          handleResolved(env, snapshotState(env.persistenceId))
+      // advances strictly from the head: an envelope can only be decided once every envelope ahead of it
+      // has already been decided, so a resolved (cache hit) id can never jump ahead of an earlier envelope
+      // that is still waiting on a lookup or a snapshot load
+      private def advance(): Unit = {
+        var continue = true
+        while (continue && pendingQueue.nonEmpty && !awaitingSnapshotLoad) {
+          snapshotState.get(pendingQueue.head.persistenceId) match {
+            case Some(s) =>
+              val env = pendingQueue.dequeue()
+              handleResolved(env, s) // may set awaitingSnapshotLoad = true, loop condition then stops us
+            case None =>
+              // head not resolved yet - nothing after it can be emitted without reordering
+              continue = false
+          }
         }
       }
 
       private def pullIfRoom(): Unit =
-        if (!upstreamFinished && !hasBeenPulled(in) && (lookupBuffer.size + readyQueue.size) < maxBufferedEnvelopes)
+        if (!upstreamFinished && !hasBeenPulled(in) && (pendingQueue.size + readyQueue.size) < maxBufferedEnvelopes)
           pull(in)
 
       private def completeIfDone(): Unit =
-        if (upstreamFinished && lookupBuffer.isEmpty && pendingLookupIds.isEmpty && !batchInFlight &&
+        if (upstreamFinished && pendingQueue.isEmpty && pendingLookupIds.isEmpty && !batchInFlight &&
           !awaitingSnapshotLoad && readyQueue.isEmpty)
           completeStage()
 
       override def onPush(): Unit = {
         val env = grab(in)
-        snapshotState.get(env.persistenceId) match {
-          case Some(s) =>
-            handleResolved(env, s)
-            pullIfRoom()
-          case None =>
-            lookupBuffer.enqueue(env)
-            pendingLookupIds += env.persistenceId
-            maybeTriggerBatch()
-            pullIfRoom()
+        pendingQueue.enqueue(env)
+        if (!snapshotState.contains(env.persistenceId)) {
+          pendingLookupIds += env.persistenceId
+          maybeTriggerBatch()
         }
+        advance()
+        pullIfRoom()
       }
 
       override def onPull(): Unit = {

--- a/core/src/main/scala/akka/persistence/r2dbc/internal/BatchingStartingFromSnapshotStage.scala
+++ b/core/src/main/scala/akka/persistence/r2dbc/internal/BatchingStartingFromSnapshotStage.scala
@@ -236,7 +236,8 @@ import akka.util.RecencyList
 
       private def maybeTriggerBatch(): Unit = {
         if (!batchInFlight && pendingLookupIds.nonEmpty) {
-          if (pendingLookupIds.size >= lookupBatchSize || pendingQueue.size >= maxBufferedEnvelopes)
+          // once upstream is finished no further ids can arrive, so there is nothing left to linger for
+          if (upstreamFinished || pendingLookupIds.size >= lookupBatchSize || pendingQueue.size >= maxBufferedEnvelopes)
             triggerBatch()
           else if (!isTimerActive(BatchLingerTimerKey))
             scheduleOnce(BatchLingerTimerKey, batchLinger)
@@ -291,9 +292,7 @@ import akka.util.RecencyList
 
       override def onUpstreamFinish(): Unit = {
         upstreamFinished = true
-        // flush whatever is pending rather than waiting for lookupBatchSize / the linger timer
-        if (pendingLookupIds.nonEmpty && !batchInFlight)
-          triggerBatch()
+        maybeTriggerBatch()
         advance()
         completeIfDone()
       }

--- a/core/src/main/scala/akka/persistence/r2dbc/internal/BatchingStartingFromSnapshotStage.scala
+++ b/core/src/main/scala/akka/persistence/r2dbc/internal/BatchingStartingFromSnapshotStage.scala
@@ -53,14 +53,19 @@ import akka.util.RecencyList
  * A persistence id that is resolved in the cache but still referenced by an envelope sitting in `pendingQueue` (stuck
  * behind an earlier, not-yet-resolved head) is pinned and exempt from LRU eviction until it is dequeued. Without this,
  * the entry could be evicted between being resolved and being dequeued, leaving that envelope permanently unresolved
- * and stalling the stage.
+ * and stalling the stage. The same applies while a snapshot payload load is in flight: the envelope that triggered it
+ * has already been dequeued (and unpinned) by the time the load starts, but its persistence id must still not be
+ * evicted for the load's duration - a batch lookup for a different id can run concurrently with the load (nothing gates
+ * `triggerBatch` on `awaitingSnapshotLoad`), and if that eviction happened, a redelivery of the same id would see a
+ * cache miss and start a redundant lookup racing the load, non-deterministically clobbering the `emitted` flag the load
+ * is about to set and opening the door to a duplicate snapshot-envelope emission on a later redelivery.
+ * `loadCorrespondingSnapshot` pins the id explicitly for exactly this reason.
  *
  * Loading the actual snapshot payload for entities whose boundary event is reached is left serialized as before — that
  * only happens once per entity (not once per cache eviction) so it isn't the dominant cost, but it is a natural next
  * step to pipeline the same way if it turns out to matter.
  *
  * Known gaps:
- *   - no automated tests yet (should reuse/extend StartingFromSnapshotStageSpec)
  *   - memory bound of the envelope buffer under pathological miss patterns not validated
  *   - snapshot-load step not pipelined (see above)
  */
@@ -186,6 +191,7 @@ import akka.util.RecencyList
       private val loadSnapshotCallback = getAsyncCallback[Try[(EventEnvelope[Event], Option[SerializedSnapshotRow])]] {
         case Success((env, Some(snap))) =>
           awaitingSnapshotLoad = false
+          unpin(env.persistenceId)
           if (env.sequenceNr == snap.seqNr) {
             updateState(snap.persistenceId, snap.seqNr, emitted = true)
             emit(createEnvelope(snap, env.offset.asInstanceOf[TimestampOffset]))
@@ -202,6 +208,7 @@ import akka.util.RecencyList
 
         case Success((env, None)) =>
           awaitingSnapshotLoad = false
+          unpin(env.persistenceId)
           updateState(env.persistenceId, 0L, emitted = true)
           emit(env)
           advance()
@@ -214,6 +221,11 @@ import akka.util.RecencyList
 
       private def loadCorrespondingSnapshot(env: EventEnvelope[Event]): Unit = {
         awaitingSnapshotLoad = true
+        // pin explicitly: this envelope was already dequeued (and unpinned) by advance() before this is called,
+        // but the cache entry it depends on must not be evicted while the load - a second async operation not
+        // otherwise tracked by the queue - is in flight, or a concurrent batch resolving a different id could
+        // evict it and a redelivery for this id would then race a redundant lookup against this load
+        pin(env.persistenceId)
         loadSnapshot(env.persistenceId)
           .map(result => (env, result))(ExecutionContext.parasitic)
           .onComplete(loadSnapshotCallback.invoke)

--- a/core/src/main/scala/akka/persistence/r2dbc/internal/BatchingStartingFromSnapshotStage.scala
+++ b/core/src/main/scala/akka/persistence/r2dbc/internal/BatchingStartingFromSnapshotStage.scala
@@ -1,0 +1,278 @@
+/*
+ * Copyright (C) 2022 - 2025 Lightbend Inc. <https://akka.io>
+ */
+
+package akka.persistence.r2dbc.internal
+
+import java.time.Instant
+import scala.collection.mutable
+import scala.concurrent.ExecutionContext
+import scala.concurrent.Future
+import scala.concurrent.duration.FiniteDuration
+import scala.util.Failure
+import scala.util.Success
+import scala.util.Try
+
+import akka.annotation.InternalApi
+import akka.persistence.query.TimestampOffset
+import akka.persistence.query.typed.EventEnvelope
+import akka.persistence.r2dbc.internal.SnapshotDao.SerializedSnapshotRow
+import akka.stream.Attributes
+import akka.stream.FlowShape
+import akka.stream.Inlet
+import akka.stream.Outlet
+import akka.stream.stage.GraphStage
+import akka.stream.stage.InHandler
+import akka.stream.stage.OutHandler
+import akka.stream.stage.TimerGraphStageLogic
+import akka.util.RecencyList
+
+/**
+ * SKETCH / PROTOTYPE — not wired into `R2dbcReadJournal` yet.
+ *
+ * Alternative to `StartingFromSnapshotStage` addressing the observed Westpac issue: with a cache-miss rate close to 1
+ * (many more distinct persistence ids per projection partition than `cache-capacity`), the original stage degrades into
+ * one fully serialized, blocking DB round-trip per event, because it does not pull the next upstream element until the
+ * current lookup's callback has completed. Total pipeline throughput then becomes bound by round-trip latency instead
+ * of DB or write capacity.
+ *
+ * This stage keeps the same LRU cache, but on a cache miss it does not immediately block:
+ *   - the event is buffered (in original order) and the persistence id is added to a pending-lookup set
+ *   - upstream keeps being pulled (bounded by `maxBufferedEnvelopes`) to keep accumulating misses
+ *   - once `lookupBatchSize` distinct new ids have accumulated, `maxBufferedEnvelopes` is reached, a linger timer
+ *     expires, or upstream finishes, a *single* batched lookup (`SnapshotDao.sequenceNumbersOfSnapshots`) resolves the
+ *     whole pending set in one round-trip (or, worst case with the trait's default fallback, one round-trip per id but
+ *     *concurrently* rather than serialized)
+ *   - buffered envelopes are then drained, in order, through the same per-envelope decision logic as the original stage
+ *     (push / ignore / load the matching snapshot)
+ *
+ * Loading the actual snapshot payload for entities whose boundary event is reached is left serialized as before — that
+ * only happens once per entity (not once per cache eviction) so it isn't the dominant cost, but it is a natural next
+ * step to pipeline the same way if it turns out to matter.
+ *
+ * Known gaps to close before this can replace the original stage:
+ *   - no automated tests yet (should reuse/extend StartingFromSnapshotStageSpec)
+ *   - config wiring for lookupBatchSize / maxBufferedEnvelopes / batchLinger not added to reference.conf
+ *   - memory bound of the envelope buffer under pathological miss patterns not validated
+ *   - snapshot-load step not pipelined (see above)
+ */
+@InternalApi private[r2dbc] object BatchingStartingFromSnapshotStage {
+  private case class SnapshotState(seqNr: Long, emitted: Boolean)
+  private case object BatchLingerTimerKey
+}
+
+/**
+ * SKETCH / PROTOTYPE — see class doc.
+ */
+@InternalApi private[r2dbc] class BatchingStartingFromSnapshotStage[Event](
+    cacheCapacity: Int,
+    lookupBatchSize: Int,
+    maxBufferedEnvelopes: Int,
+    batchLinger: FiniteDuration,
+    sequenceNumbersOfSnapshots: Set[String] => Future[Map[String, Long]],
+    loadSnapshot: String => Future[Option[SnapshotDao.SerializedSnapshotRow]],
+    createEnvelope: (SerializedSnapshotRow, TimestampOffset) => EventEnvelope[Event],
+    heartbeatAfter: Int,
+    createHeartbeat: Instant => EventEnvelope[Event])
+    extends GraphStage[FlowShape[EventEnvelope[Event], EventEnvelope[Event]]] {
+  import BatchingStartingFromSnapshotStage._
+
+  require(lookupBatchSize > 0, "lookupBatchSize must be > 0")
+  require(maxBufferedEnvelopes >= lookupBatchSize, "maxBufferedEnvelopes must be >= lookupBatchSize")
+
+  val in: Inlet[EventEnvelope[Event]] = Inlet("in")
+  val out: Outlet[EventEnvelope[Event]] = Outlet("out")
+
+  override val shape: FlowShape[EventEnvelope[Event], EventEnvelope[Event]] =
+    FlowShape(in, out)
+
+  override def createLogic(inheritedAttributes: Attributes) =
+    new TimerGraphStageLogic(shape) with InHandler with OutHandler { self =>
+      private implicit def ec: ExecutionContext = materializer.executionContext
+
+      private var snapshotState = Map.empty[String, SnapshotState]
+      private val recency = RecencyList.emptyWithNanoClock[String]
+
+      // envelopes whose persistence id isn't resolved yet, in arrival order
+      private val lookupBuffer = mutable.Queue.empty[EventEnvelope[Event]]
+      // ids not yet part of an in-flight batch, accumulating towards the next one
+      private val pendingLookupIds = mutable.LinkedHashSet.empty[String]
+      private var batchInFlight = false
+
+      // envelopes that have been decided (should be pushed) but are waiting for downstream demand
+      private val readyQueue = mutable.Queue.empty[EventEnvelope[Event]]
+
+      private var awaitingSnapshotLoad = false
+      private var upstreamFinished = false
+
+      // for emitting heartbeat events
+      private var filterCount = 0L
+      private var latestTimestamp = Instant.EPOCH
+
+      private def updateState(persistenceId: String, seqNr: Long, emitted: Boolean): Unit = {
+        snapshotState = snapshotState.updated(persistenceId, SnapshotState(seqNr, emitted))
+        recency.update(persistenceId)
+        if (recency.size > cacheCapacity)
+          recency.removeLeastRecent().foreach { pid =>
+            snapshotState -= pid
+          }
+      }
+
+      private def emit(env: EventEnvelope[Event]): Unit = {
+        filterCount = 0L
+        if (isAvailable(out)) push(out, env)
+        else readyQueue.enqueue(env)
+      }
+
+      private def ignoreOne(env: EventEnvelope[Event]): Unit = {
+        val timestamp = env.offset.asInstanceOf[TimestampOffset].timestamp
+        if (timestamp.isAfter(latestTimestamp))
+          latestTimestamp = timestamp
+        filterCount += 1
+        if (filterCount >= heartbeatAfter)
+          emit(createHeartbeat(latestTimestamp))
+      }
+
+      // same per-envelope decision as StartingFromSnapshotStage.onPush's cached branch,
+      // used both for cache hits and for buffered envelopes once their id has been resolved
+      private def handleResolved(env: EventEnvelope[Event], s: SnapshotState): Unit = {
+        val eventIsAfterSnapshot = env.sequenceNr > s.seqNr
+        if (eventIsAfterSnapshot) {
+          emit(env)
+        } else if (!s.emitted && env.sequenceNr == s.seqNr) {
+          loadCorrespondingSnapshot(env)
+        } else {
+          ignoreOne(env)
+        }
+      }
+
+      private val loadSnapshotCallback = getAsyncCallback[Try[(EventEnvelope[Event], Option[SerializedSnapshotRow])]] {
+        case Success((env, Some(snap))) =>
+          awaitingSnapshotLoad = false
+          if (env.sequenceNr == snap.seqNr) {
+            updateState(snap.persistenceId, snap.seqNr, emitted = true)
+            emit(createEnvelope(snap, env.offset.asInstanceOf[TimestampOffset]))
+          } else if (env.sequenceNr > snap.seqNr) {
+            updateState(snap.persistenceId, snap.seqNr, emitted = false)
+            emit(env)
+          } else {
+            updateState(snap.persistenceId, snap.seqNr, emitted = false)
+            ignoreOne(env)
+          }
+          drainLookupBuffer()
+
+        case Success((env, None)) =>
+          awaitingSnapshotLoad = false
+          updateState(env.persistenceId, 0L, emitted = true)
+          emit(env)
+          drainLookupBuffer()
+
+        case Failure(exc) =>
+          failStage(exc)
+      }
+
+      private def loadCorrespondingSnapshot(env: EventEnvelope[Event]): Unit = {
+        awaitingSnapshotLoad = true
+        loadSnapshot(env.persistenceId)
+          .map(result => (env, result))(ExecutionContext.parasitic)
+          .onComplete(loadSnapshotCallback.invoke)
+      }
+
+      private val batchCallback = getAsyncCallback[Try[(Set[String], Map[String, Long])]] {
+        case Success((ids, results)) =>
+          batchInFlight = false
+          ids.foreach { pid =>
+            results.get(pid) match {
+              case Some(seqNr) => updateState(pid, seqNr, emitted = false)
+              case None        => updateState(pid, 0L, emitted = true) // no snapshot for this id
+            }
+          }
+          drainLookupBuffer()
+          maybeTriggerBatch()
+          pullIfRoom()
+          completeIfDone()
+
+        case Failure(exc) =>
+          failStage(exc)
+      }
+
+      private def triggerBatch(): Unit = {
+        cancelTimer(BatchLingerTimerKey)
+        if (pendingLookupIds.nonEmpty && !batchInFlight) {
+          val ids = pendingLookupIds.toSet
+          pendingLookupIds.clear()
+          batchInFlight = true
+          sequenceNumbersOfSnapshots(ids)
+            .map(results => (ids, results))(ExecutionContext.parasitic)
+            .onComplete(batchCallback.invoke)
+        }
+      }
+
+      private def maybeTriggerBatch(): Unit = {
+        if (!batchInFlight && pendingLookupIds.nonEmpty) {
+          if (pendingLookupIds.size >= lookupBatchSize || lookupBuffer.size >= maxBufferedEnvelopes)
+            triggerBatch()
+          else if (!isTimerActive(BatchLingerTimerKey))
+            scheduleOnce(BatchLingerTimerKey, batchLinger)
+        }
+      }
+
+      // drains envelopes that are ready to be resolved, in order; stops at the first envelope whose id
+      // isn't resolved yet (belongs to the next generation) or while a snapshot load is in flight
+      private def drainLookupBuffer(): Unit = {
+        while (lookupBuffer.nonEmpty && !awaitingSnapshotLoad && snapshotState.contains(
+            lookupBuffer.head.persistenceId)) {
+          val env = lookupBuffer.dequeue()
+          handleResolved(env, snapshotState(env.persistenceId))
+        }
+      }
+
+      private def pullIfRoom(): Unit =
+        if (!upstreamFinished && !hasBeenPulled(in) && (lookupBuffer.size + readyQueue.size) < maxBufferedEnvelopes)
+          pull(in)
+
+      private def completeIfDone(): Unit =
+        if (upstreamFinished && lookupBuffer.isEmpty && pendingLookupIds.isEmpty && !batchInFlight &&
+          !awaitingSnapshotLoad && readyQueue.isEmpty)
+          completeStage()
+
+      override def onPush(): Unit = {
+        val env = grab(in)
+        snapshotState.get(env.persistenceId) match {
+          case Some(s) =>
+            handleResolved(env, s)
+            pullIfRoom()
+          case None =>
+            lookupBuffer.enqueue(env)
+            pendingLookupIds += env.persistenceId
+            maybeTriggerBatch()
+            pullIfRoom()
+        }
+      }
+
+      override def onPull(): Unit = {
+        if (readyQueue.nonEmpty)
+          push(out, readyQueue.dequeue())
+        else
+          pullIfRoom()
+        completeIfDone()
+      }
+
+      override def onUpstreamFinish(): Unit = {
+        upstreamFinished = true
+        // flush whatever is pending rather than waiting for lookupBatchSize / the linger timer
+        if (pendingLookupIds.nonEmpty && !batchInFlight)
+          triggerBatch()
+        completeIfDone()
+      }
+
+      override protected def onTimer(timerKey: Any): Unit = timerKey match {
+        case BatchLingerTimerKey => triggerBatch()
+        case _                   => ()
+      }
+
+      setHandler(in, this)
+      setHandler(out, this)
+    }
+
+}

--- a/core/src/main/scala/akka/persistence/r2dbc/internal/SnapshotDao.scala
+++ b/core/src/main/scala/akka/persistence/r2dbc/internal/SnapshotDao.scala
@@ -6,6 +6,7 @@ package akka.persistence.r2dbc.internal
 
 import java.time.Instant
 
+import scala.concurrent.ExecutionContext
 import scala.concurrent.Future
 
 import akka.annotation.InternalApi
@@ -49,5 +50,22 @@ private[r2dbc] trait SnapshotDao {
   def store(serializedRow: SerializedSnapshotRow): Future[Unit]
   def delete(persistenceId: String, criteria: SnapshotSelectionCriteria): Future[Unit]
   def sequenceNumberOfSnapshot(persistenceId: String): Future[Option[Long]]
+
+  /**
+   * SKETCH / PROTOTYPE, see BatchingStartingFromSnapshotStage.
+   *
+   * Batched variant of `sequenceNumberOfSnapshot`, used by the start-from-snapshot filtering stage to resolve many
+   * persistence ids with a single round-trip instead of one round-trip per persistence id. Default implementation falls
+   * back to concurrent single-id lookups so existing dialects (H2, SQL Server) keep working without changes; dialects
+   * that support an efficient `= ANY(...)`/`IN (...)` batched query should override this.
+   *
+   * Only returns entries for persistence ids that actually have a snapshot; ids without one are absent from the result
+   * map.
+   */
+  def sequenceNumbersOfSnapshots(persistenceIds: Set[String])(implicit
+      ec: ExecutionContext): Future[Map[String, Long]] =
+    Future
+      .traverse(persistenceIds)(pid => sequenceNumberOfSnapshot(pid).map(pid -> _))
+      .map(_.collect { case (pid, Some(seqNr)) => pid -> seqNr }.toMap)
 
 }

--- a/core/src/main/scala/akka/persistence/r2dbc/internal/SnapshotDao.scala
+++ b/core/src/main/scala/akka/persistence/r2dbc/internal/SnapshotDao.scala
@@ -46,6 +46,11 @@ private[r2dbc] object SnapshotDao {
 private[r2dbc] trait SnapshotDao {
   import SnapshotDao._
 
+  // Every implementation is backed by an R2dbcExecutorProvider with its own dedicated ec (e.g. H2's blocking-io
+  // dispatcher), so this must come from the implementation rather than be left to whatever ec happens to be
+  // implicit at each call site.
+  protected implicit def ec: ExecutionContext
+
   def load(persistenceId: String, criteria: SnapshotSelectionCriteria): Future[Option[SerializedSnapshotRow]]
   def store(serializedRow: SerializedSnapshotRow): Future[Unit]
   def delete(persistenceId: String, criteria: SnapshotSelectionCriteria): Future[Unit]
@@ -60,8 +65,7 @@ private[r2dbc] trait SnapshotDao {
    * Only returns entries for persistence ids that actually have a snapshot; ids without one are absent from the result
    * map.
    */
-  def sequenceNumbersOfSnapshots(persistenceIds: Set[String])(implicit
-      ec: ExecutionContext): Future[Map[String, Long]] =
+  def sequenceNumbersOfSnapshots(persistenceIds: Set[String]): Future[Map[String, Long]] =
     sequenceNumbersOfSnapshotsConcurrently(persistenceIds)
 
   /**
@@ -69,8 +73,7 @@ private[r2dbc] trait SnapshotDao {
    * round-trip. Exposed so a dialect that overrides `sequenceNumbersOfSnapshots` further down the class hierarchy (for
    * example a subclass of a dialect that does support batching) can opt back into this instead.
    */
-  protected def sequenceNumbersOfSnapshotsConcurrently(persistenceIds: Set[String])(implicit
-      ec: ExecutionContext): Future[Map[String, Long]] =
+  protected def sequenceNumbersOfSnapshotsConcurrently(persistenceIds: Set[String]): Future[Map[String, Long]] =
     Future
       .traverse(persistenceIds)(pid => sequenceNumberOfSnapshot(pid).map(pid -> _))
       .map(_.collect { case (pid, Some(seqNr)) => pid -> seqNr }.toMap)

--- a/core/src/main/scala/akka/persistence/r2dbc/internal/SnapshotDao.scala
+++ b/core/src/main/scala/akka/persistence/r2dbc/internal/SnapshotDao.scala
@@ -51,6 +51,11 @@ private[r2dbc] trait SnapshotDao {
   // implicit at each call site.
   protected implicit def ec: ExecutionContext
 
+  // Upper bound on concurrent requests fired by sequenceNumbersOfSnapshotsConcurrently. That fallback is one
+  // round-trip per persistence id, so left unbounded a single lookup batch (up to `lookup-batch-size` ids) can
+  // flood the connection pool and starve unrelated journal/query traffic sharing it.
+  protected def maxConcurrentSequenceNumberLookups: Int
+
   def load(persistenceId: String, criteria: SnapshotSelectionCriteria): Future[Option[SerializedSnapshotRow]]
   def store(serializedRow: SerializedSnapshotRow): Future[Unit]
   def delete(persistenceId: String, criteria: SnapshotSelectionCriteria): Future[Unit]
@@ -70,12 +75,21 @@ private[r2dbc] trait SnapshotDao {
 
   /**
    * Fallback for dialects without an efficient batched lookup: resolves each persistence id concurrently with its own
-   * round-trip. Exposed so a dialect that overrides `sequenceNumbersOfSnapshots` further down the class hierarchy (for
-   * example a subclass of a dialect that does support batching) can opt back into this instead.
+   * round-trip, `maxConcurrentSequenceNumberLookups` at a time. Exposed so a dialect that overrides
+   * `sequenceNumbersOfSnapshots` further down the class hierarchy (for example a subclass of a dialect that does
+   * support batching) can opt back into this instead.
    */
-  protected def sequenceNumbersOfSnapshotsConcurrently(persistenceIds: Set[String]): Future[Map[String, Long]] =
-    Future
-      .traverse(persistenceIds)(pid => sequenceNumberOfSnapshot(pid).map(pid -> _))
-      .map(_.collect { case (pid, Some(seqNr)) => pid -> seqNr }.toMap)
+  protected def sequenceNumbersOfSnapshotsConcurrently(persistenceIds: Set[String]): Future[Map[String, Long]] = {
+    def resolveChunk(chunk: Set[String]): Future[Map[String, Long]] =
+      Future
+        .traverse(chunk)(pid => sequenceNumberOfSnapshot(pid).map(pid -> _))
+        .map(_.collect { case (pid, Some(seqNr)) => pid -> seqNr }.toMap)
+
+    persistenceIds
+      .grouped(math.max(1, maxConcurrentSequenceNumberLookups))
+      .foldLeft(Future.successful(Map.empty[String, Long])) { (acc, chunk) =>
+        acc.flatMap(resolved => resolveChunk(chunk).map(resolved ++ _))
+      }
+  }
 
 }

--- a/core/src/main/scala/akka/persistence/r2dbc/internal/SnapshotDao.scala
+++ b/core/src/main/scala/akka/persistence/r2dbc/internal/SnapshotDao.scala
@@ -52,17 +52,24 @@ private[r2dbc] trait SnapshotDao {
   def sequenceNumberOfSnapshot(persistenceId: String): Future[Option[Long]]
 
   /**
-   * SKETCH / PROTOTYPE, see BatchingStartingFromSnapshotStage.
-   *
    * Batched variant of `sequenceNumberOfSnapshot`, used by the start-from-snapshot filtering stage to resolve many
-   * persistence ids with a single round-trip instead of one round-trip per persistence id. Default implementation falls
-   * back to concurrent single-id lookups so existing dialects (H2, SQL Server) keep working without changes; dialects
-   * that support an efficient `= ANY(...)`/`IN (...)` batched query should override this.
+   * persistence ids with a single round-trip instead of one round-trip per persistence id. Default implementation
+   * delegates to [[sequenceNumbersOfSnapshotsConcurrently]]; dialects that support an efficient `= ANY(...)`/`IN (...)`
+   * batched query should override this instead.
    *
    * Only returns entries for persistence ids that actually have a snapshot; ids without one are absent from the result
    * map.
    */
   def sequenceNumbersOfSnapshots(persistenceIds: Set[String])(implicit
+      ec: ExecutionContext): Future[Map[String, Long]] =
+    sequenceNumbersOfSnapshotsConcurrently(persistenceIds)
+
+  /**
+   * Fallback for dialects without an efficient batched lookup: resolves each persistence id concurrently with its own
+   * round-trip. Exposed so a dialect that overrides `sequenceNumbersOfSnapshots` further down the class hierarchy (for
+   * example a subclass of a dialect that does support batching) can opt back into this instead.
+   */
+  protected def sequenceNumbersOfSnapshotsConcurrently(persistenceIds: Set[String])(implicit
       ec: ExecutionContext): Future[Map[String, Long]] =
     Future
       .traverse(persistenceIds)(pid => sequenceNumberOfSnapshot(pid).map(pid -> _))

--- a/core/src/main/scala/akka/persistence/r2dbc/internal/h2/H2SnapshotDao.scala
+++ b/core/src/main/scala/akka/persistence/r2dbc/internal/h2/H2SnapshotDao.scala
@@ -28,7 +28,7 @@ private[r2dbc] final class H2SnapshotDao(executorProvider: R2dbcExecutorProvider
 
   private val sqlCache = Sql.Cache(settings.numberOfDataPartitions > 1)
 
-  // The `= ANY(?)` batched query in PostgresSnapshotDao isn't verified to work against H2's r2dbc driver, so opt
+  // The `= ANY(?)` batched query in PostgresSnapshotDao is not verified to work against H2's r2dbc driver, so opt
   // back into the safe per-id fallback rather than inheriting the Postgres override.
   override def sequenceNumbersOfSnapshots(persistenceIds: Set[String])(implicit
       ec: ExecutionContext): Future[Map[String, Long]] =

--- a/core/src/main/scala/akka/persistence/r2dbc/internal/h2/H2SnapshotDao.scala
+++ b/core/src/main/scala/akka/persistence/r2dbc/internal/h2/H2SnapshotDao.scala
@@ -4,6 +4,9 @@
 
 package akka.persistence.r2dbc.internal.h2
 
+import scala.concurrent.ExecutionContext
+import scala.concurrent.Future
+
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 
@@ -24,6 +27,12 @@ private[r2dbc] final class H2SnapshotDao(executorProvider: R2dbcExecutorProvider
   override protected lazy val log: Logger = LoggerFactory.getLogger(classOf[H2SnapshotDao])
 
   private val sqlCache = Sql.Cache(settings.numberOfDataPartitions > 1)
+
+  // The `= ANY(?)` batched query in PostgresSnapshotDao isn't verified to work against H2's r2dbc driver, so opt
+  // back into the safe per-id fallback rather than inheriting the Postgres override.
+  override def sequenceNumbersOfSnapshots(persistenceIds: Set[String])(implicit
+      ec: ExecutionContext): Future[Map[String, Long]] =
+    sequenceNumbersOfSnapshotsConcurrently(persistenceIds)
 
   override protected def upsertSql(slice: Int): String =
     sqlCache.get(slice, "upsertSql") {

--- a/core/src/main/scala/akka/persistence/r2dbc/internal/h2/H2SnapshotDao.scala
+++ b/core/src/main/scala/akka/persistence/r2dbc/internal/h2/H2SnapshotDao.scala
@@ -4,7 +4,6 @@
 
 package akka.persistence.r2dbc.internal.h2
 
-import scala.concurrent.ExecutionContext
 import scala.concurrent.Future
 
 import org.slf4j.Logger
@@ -30,8 +29,7 @@ private[r2dbc] final class H2SnapshotDao(executorProvider: R2dbcExecutorProvider
 
   // The `= ANY(?)` batched query in PostgresSnapshotDao is not verified to work against H2's r2dbc driver, so opt
   // back into the safe per-id fallback rather than inheriting the Postgres override.
-  override def sequenceNumbersOfSnapshots(persistenceIds: Set[String])(implicit
-      ec: ExecutionContext): Future[Map[String, Long]] =
+  override def sequenceNumbersOfSnapshots(persistenceIds: Set[String]): Future[Map[String, Long]] =
     sequenceNumbersOfSnapshotsConcurrently(persistenceIds)
 
   override protected def upsertSql(slice: Int): String =

--- a/core/src/main/scala/akka/persistence/r2dbc/internal/postgres/PostgresSnapshotDao.scala
+++ b/core/src/main/scala/akka/persistence/r2dbc/internal/postgres/PostgresSnapshotDao.scala
@@ -147,7 +147,6 @@ private[r2dbc] class PostgresSnapshotDao(executorProvider: R2dbcExecutorProvider
     }
   }
 
-  // SKETCH / PROTOTYPE, see BatchingStartingFromSnapshotStage.
   protected def selectSeqNrsSql(slice: Int): String = {
     sqlCache.get(slice, "selectSeqNrsSql") {
       sql"""
@@ -269,7 +268,6 @@ private[r2dbc] class PostgresSnapshotDao(executorProvider: R2dbcExecutorProvider
         _.get[java.lang.Long]("seq_nr", classOf[java.lang.Long]))
   }
 
-  // SKETCH / PROTOTYPE, see BatchingStartingFromSnapshotStage.
   // Groups the requested ids by data-partition (by table name, see comment below) and issues one `= ANY(?)`
   // query per group instead of one query per id. With the default single data-partition setup this is a single
   // round-trip for the whole batch.

--- a/core/src/main/scala/akka/persistence/r2dbc/internal/postgres/PostgresSnapshotDao.scala
+++ b/core/src/main/scala/akka/persistence/r2dbc/internal/postgres/PostgresSnapshotDao.scala
@@ -46,6 +46,9 @@ private[r2dbc] class PostgresSnapshotDao(executorProvider: R2dbcExecutorProvider
   protected val settings: R2dbcSettings = executorProvider.settings
   protected val system: ActorSystem[_] = executorProvider.system
   implicit protected val ec: ExecutionContext = executorProvider.ec
+  // half the pool, so a lookup batch can't starve unrelated journal/query traffic sharing it
+  protected val maxConcurrentSequenceNumberLookups: Int =
+    math.max(1, settings.connectionFactorySettings.poolSettings.maxSize / 2)
   import settings.codecSettings.SnapshotImplicits._
 
   import SnapshotDao._

--- a/core/src/main/scala/akka/persistence/r2dbc/internal/postgres/PostgresSnapshotDao.scala
+++ b/core/src/main/scala/akka/persistence/r2dbc/internal/postgres/PostgresSnapshotDao.scala
@@ -147,6 +147,16 @@ private[r2dbc] class PostgresSnapshotDao(executorProvider: R2dbcExecutorProvider
     }
   }
 
+  // SKETCH / PROTOTYPE, see BatchingStartingFromSnapshotStage.
+  protected def selectSeqNrsSql(slice: Int): String = {
+    sqlCache.get(slice, "selectSeqNrsSql") {
+      sql"""
+        SELECT persistence_id, seq_nr
+        FROM ${snapshotTable(slice)}
+        WHERE persistence_id = ANY(?)"""
+    }
+  }
+
   private def deleteSql(slice: Int, criteria: SnapshotSelectionCriteria): String = {
     // not caching, too many combinations
 
@@ -257,6 +267,37 @@ private[r2dbc] class PostgresSnapshotDao(executorProvider: R2dbcExecutorProvider
         _.createStatement(selectSeqNrSql(slice))
           .bind(0, persistenceId),
         _.get[java.lang.Long]("seq_nr", classOf[java.lang.Long]))
+  }
+
+  // SKETCH / PROTOTYPE, see BatchingStartingFromSnapshotStage.
+  // Groups the requested ids by which (data-partition) executor and table they belong to, and issues one
+  // `= ANY(?)` query per group instead of one query per id. With the default single data-partition setup this is
+  // a single round-trip for the whole batch.
+  override def sequenceNumbersOfSnapshots(persistenceIds: Set[String])(implicit
+      ec: ExecutionContext): Future[Map[String, Long]] = {
+    if (persistenceIds.isEmpty) {
+      Future.successful(Map.empty)
+    } else {
+      val bySliceGroup =
+        persistenceIds.groupBy(pid => persistenceExt.sliceForPersistenceId(pid))
+      val byExecutorAndTable =
+        bySliceGroup.groupBy { case (slice, _) => (executorProvider.executorFor(slice), snapshotTable(slice)) }
+
+      Future
+        .traverse(byExecutorAndTable.toVector) { case ((executor, table), sliceGroups) =>
+          val ids = sliceGroups.values.flatten.toArray
+          val representativeSlice = sliceGroups.keys.head
+          executor
+            .select(s"sequenceNumbersOfSnapshots [${ids.length} ids] [$table]")(
+              _.createStatement(selectSeqNrsSql(representativeSlice))
+                .bind(0, ids),
+              row =>
+                row.get("persistence_id", classOf[String]) -> row
+                  .get[java.lang.Long]("seq_nr", classOf[java.lang.Long])
+                  .longValue)
+        }
+        .map(_.flatten.toMap)
+    }
   }
 
   protected def bindUpsertSql(statement: Statement, serializedRow: SerializedSnapshotRow): Statement = {

--- a/core/src/main/scala/akka/persistence/r2dbc/internal/postgres/PostgresSnapshotDao.scala
+++ b/core/src/main/scala/akka/persistence/r2dbc/internal/postgres/PostgresSnapshotDao.scala
@@ -268,9 +268,7 @@ private[r2dbc] class PostgresSnapshotDao(executorProvider: R2dbcExecutorProvider
         _.get[java.lang.Long]("seq_nr", classOf[java.lang.Long]))
   }
 
-  // Groups the requested ids by data-partition (by table name, see comment below) and issues one `= ANY(?)`
-  // query per group instead of one query per id. With the default single data-partition setup this is a single
-  // round-trip for the whole batch.
+  // One `= ANY(?)` query per data-partition instead of one query per id.
   override def sequenceNumbersOfSnapshots(persistenceIds: Set[String])(implicit
       ec: ExecutionContext): Future[Map[String, Long]] = {
     if (persistenceIds.isEmpty) {
@@ -278,13 +276,8 @@ private[r2dbc] class PostgresSnapshotDao(executorProvider: R2dbcExecutorProvider
     } else {
       val bySliceGroup =
         persistenceIds.groupBy(pid => persistenceExt.sliceForPersistenceId(pid))
-      // Group by table name, not by `executorFor(slice)`: that method caches one R2dbcExecutor instance per
-      // individual slice (IntMap keyed by slice, see R2dbcExecutorProvider.executorFor), not per data-partition,
-      // so two different but same-partition slices never return the same object reference - grouping by that
-      // would fragment the batch back down to near one group per distinct slice. Table name is a pure function
-      // of `dataPartition(slice)`, the actual partition boundary, so it's a stable and correct grouping key
-      // (same table name implies same partition implies same connection). With the default single-partition
-      // setup this always yields exactly one group, i.e. one round-trip for the whole batch.
+      // group by table name, not by `executorFor(slice)`: that caches one executor per slice, not per
+      // partition, so it would fragment the batch. Table name is a pure function of the partition.
       val byTable = bySliceGroup.groupBy { case (slice, _) => snapshotTable(slice) }
 
       Future

--- a/core/src/main/scala/akka/persistence/r2dbc/internal/postgres/PostgresSnapshotDao.scala
+++ b/core/src/main/scala/akka/persistence/r2dbc/internal/postgres/PostgresSnapshotDao.scala
@@ -270,9 +270,9 @@ private[r2dbc] class PostgresSnapshotDao(executorProvider: R2dbcExecutorProvider
   }
 
   // SKETCH / PROTOTYPE, see BatchingStartingFromSnapshotStage.
-  // Groups the requested ids by which (data-partition) executor and table they belong to, and issues one
-  // `= ANY(?)` query per group instead of one query per id. With the default single data-partition setup this is
-  // a single round-trip for the whole batch.
+  // Groups the requested ids by data-partition (by table name, see comment below) and issues one `= ANY(?)`
+  // query per group instead of one query per id. With the default single data-partition setup this is a single
+  // round-trip for the whole batch.
   override def sequenceNumbersOfSnapshots(persistenceIds: Set[String])(implicit
       ec: ExecutionContext): Future[Map[String, Long]] = {
     if (persistenceIds.isEmpty) {
@@ -280,13 +280,20 @@ private[r2dbc] class PostgresSnapshotDao(executorProvider: R2dbcExecutorProvider
     } else {
       val bySliceGroup =
         persistenceIds.groupBy(pid => persistenceExt.sliceForPersistenceId(pid))
-      val byExecutorAndTable =
-        bySliceGroup.groupBy { case (slice, _) => (executorProvider.executorFor(slice), snapshotTable(slice)) }
+      // Group by table name, not by `executorFor(slice)`: that method caches one R2dbcExecutor instance per
+      // individual slice (IntMap keyed by slice, see R2dbcExecutorProvider.executorFor), not per data-partition,
+      // so two different but same-partition slices never return the same object reference - grouping by that
+      // would fragment the batch back down to near one group per distinct slice. Table name is a pure function
+      // of `dataPartition(slice)`, the actual partition boundary, so it's a stable and correct grouping key
+      // (same table name implies same partition implies same connection). With the default single-partition
+      // setup this always yields exactly one group, i.e. one round-trip for the whole batch.
+      val byTable = bySliceGroup.groupBy { case (slice, _) => snapshotTable(slice) }
 
       Future
-        .traverse(byExecutorAndTable.toVector) { case ((executor, table), sliceGroups) =>
+        .traverse(byTable.toVector) { case (table, sliceGroups) =>
           val ids = sliceGroups.values.flatten.toArray
           val representativeSlice = sliceGroups.keys.head
+          val executor = executorProvider.executorFor(representativeSlice)
           executor
             .select(s"sequenceNumbersOfSnapshots [${ids.length} ids] [$table]")(
               _.createStatement(selectSeqNrsSql(representativeSlice))

--- a/core/src/main/scala/akka/persistence/r2dbc/internal/postgres/PostgresSnapshotDao.scala
+++ b/core/src/main/scala/akka/persistence/r2dbc/internal/postgres/PostgresSnapshotDao.scala
@@ -269,8 +269,7 @@ private[r2dbc] class PostgresSnapshotDao(executorProvider: R2dbcExecutorProvider
   }
 
   // One `= ANY(?)` query per data-partition instead of one query per id.
-  override def sequenceNumbersOfSnapshots(persistenceIds: Set[String])(implicit
-      ec: ExecutionContext): Future[Map[String, Long]] = {
+  override def sequenceNumbersOfSnapshots(persistenceIds: Set[String]): Future[Map[String, Long]] = {
     if (persistenceIds.isEmpty) {
       Future.successful(Map.empty)
     } else {

--- a/core/src/main/scala/akka/persistence/r2dbc/internal/sqlserver/SqlServerSnapshotDao.scala
+++ b/core/src/main/scala/akka/persistence/r2dbc/internal/sqlserver/SqlServerSnapshotDao.scala
@@ -4,7 +4,6 @@
 
 package akka.persistence.r2dbc.internal.sqlserver
 
-import scala.concurrent.ExecutionContext
 import scala.concurrent.Future
 
 import io.r2dbc.spi.Statement
@@ -45,8 +44,7 @@ private[r2dbc] class SqlServerSnapshotDao(executorProvider: R2dbcExecutorProvide
 
   // `= ANY(?)` (inherited from PostgresSnapshotDao) is not valid T-SQL and SQL Server has no array bind parameter
   // type, so opt back into the safe per-id fallback rather than inheriting the Postgres override.
-  override def sequenceNumbersOfSnapshots(persistenceIds: Set[String])(implicit
-      ec: ExecutionContext): Future[Map[String, Long]] =
+  override def sequenceNumbersOfSnapshots(persistenceIds: Set[String]): Future[Map[String, Long]] =
     sequenceNumbersOfSnapshotsConcurrently(persistenceIds)
 
   override def selectSql(slice: Int, criteria: SnapshotSelectionCriteria): String = {

--- a/core/src/main/scala/akka/persistence/r2dbc/internal/sqlserver/SqlServerSnapshotDao.scala
+++ b/core/src/main/scala/akka/persistence/r2dbc/internal/sqlserver/SqlServerSnapshotDao.scala
@@ -4,6 +4,9 @@
 
 package akka.persistence.r2dbc.internal.sqlserver
 
+import scala.concurrent.ExecutionContext
+import scala.concurrent.Future
+
 import io.r2dbc.spi.Statement
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
@@ -39,6 +42,12 @@ private[r2dbc] class SqlServerSnapshotDao(executorProvider: R2dbcExecutorProvide
   override def log: Logger = SqlServerSnapshotDao.log
 
   private val sqlCache = Sql.Cache(settings.numberOfDataPartitions > 1)
+
+  // `= ANY(?)` (inherited from PostgresSnapshotDao) isn't valid T-SQL and SQL Server has no array bind parameter
+  // type, so opt back into the safe per-id fallback rather than inheriting the Postgres override.
+  override def sequenceNumbersOfSnapshots(persistenceIds: Set[String])(implicit
+      ec: ExecutionContext): Future[Map[String, Long]] =
+    sequenceNumbersOfSnapshotsConcurrently(persistenceIds)
 
   override def selectSql(slice: Int, criteria: SnapshotSelectionCriteria): String = {
     def createSql = {

--- a/core/src/main/scala/akka/persistence/r2dbc/internal/sqlserver/SqlServerSnapshotDao.scala
+++ b/core/src/main/scala/akka/persistence/r2dbc/internal/sqlserver/SqlServerSnapshotDao.scala
@@ -43,7 +43,7 @@ private[r2dbc] class SqlServerSnapshotDao(executorProvider: R2dbcExecutorProvide
 
   private val sqlCache = Sql.Cache(settings.numberOfDataPartitions > 1)
 
-  // `= ANY(?)` (inherited from PostgresSnapshotDao) isn't valid T-SQL and SQL Server has no array bind parameter
+  // `= ANY(?)` (inherited from PostgresSnapshotDao) is not valid T-SQL and SQL Server has no array bind parameter
   // type, so opt back into the safe per-id fallback rather than inheriting the Postgres override.
   override def sequenceNumbersOfSnapshots(persistenceIds: Set[String])(implicit
       ec: ExecutionContext): Future[Map[String, Long]] =

--- a/core/src/main/scala/akka/persistence/r2dbc/query/scaladsl/R2dbcReadJournal.scala
+++ b/core/src/main/scala/akka/persistence/r2dbc/query/scaladsl/R2dbcReadJournal.scala
@@ -55,6 +55,7 @@ import akka.persistence.r2dbc.internal.JournalDao.SerializedJournalRow
 import akka.persistence.r2dbc.internal.PubSub
 import akka.persistence.r2dbc.internal.R2dbcExecutorProvider
 import akka.persistence.r2dbc.internal.SnapshotDao.SerializedSnapshotRow
+import akka.persistence.r2dbc.internal.BatchingStartingFromSnapshotStage
 import akka.persistence.r2dbc.internal.StartingFromSnapshotStage
 import akka.persistence.typed.PersistenceId
 import akka.serialization.SerializationExtension
@@ -372,16 +373,7 @@ final class R2dbcReadJournal(system: ExtendedActorSystem, config: Config, cfgPat
           offset)
 
     eventSource
-      .via(
-        Flow.fromGraph(
-          new StartingFromSnapshotStage[Event](
-            cacheCapacity = settings.querySettings.startFromSnapshotCacheCapacity,
-            sequenceNumberOfSnapshot = persistenceId => snapshotDao.sequenceNumberOfSnapshot(persistenceId),
-            loadSnapshot = persistenceId => snapshotDao.load(persistenceId, SnapshotSelectionCriteria.Latest),
-            createEnvelope =
-              (snapshotRow, offset) => createEnvelopeFromSnapshot(snapshotRow, offset, transformSnapshot),
-            heartbeatAfter = settings.querySettings.startFromSnapshotHeartbeatAfter,
-            createHeartbeat = timestamp => createEventEnvelopeHeartbeat(entityType, minSlice, timestamp))))
+      .via(startingFromSnapshotFlow(entityType, minSlice, transformSnapshot))
   }
 
   /**
@@ -424,16 +416,41 @@ final class R2dbcReadJournal(system: ExtendedActorSystem, config: Config, cfgPat
         dbSource
 
     eventSource
-      .via(
-        Flow.fromGraph(
-          new StartingFromSnapshotStage[Event](
-            cacheCapacity = settings.querySettings.startFromSnapshotCacheCapacity,
-            sequenceNumberOfSnapshot = persistenceId => snapshotDao.sequenceNumberOfSnapshot(persistenceId),
-            loadSnapshot = persistenceId => snapshotDao.load(persistenceId, SnapshotSelectionCriteria.Latest),
-            createEnvelope =
-              (snapshotRow, offset) => createEnvelopeFromSnapshot(snapshotRow, offset, transformSnapshot),
-            heartbeatAfter = settings.querySettings.startFromSnapshotHeartbeatAfter,
-            createHeartbeat = timestamp => createEventEnvelopeHeartbeat(entityType, minSlice, timestamp))))
+      .via(startingFromSnapshotFlow(entityType, minSlice, transformSnapshot))
+  }
+
+  /**
+   * SKETCH / DRAFT: picks between the original `StartingFromSnapshotStage` and the experimental
+   * `BatchingStartingFromSnapshotStage` (`start-from-snapshot.batching.enabled`), which batches cache-miss lookups
+   * instead of doing one blocking, unpipelined round-trip per event. See BatchingStartingFromSnapshotStage's doc
+   * comment for details and known gaps.
+   */
+  private def startingFromSnapshotFlow[Snapshot, Event](
+      entityType: String,
+      minSlice: Int,
+      transformSnapshot: Snapshot => Event): Flow[EventEnvelope[Event], EventEnvelope[Event], NotUsed] = {
+    val querySettings = settings.querySettings
+    if (querySettings.startFromSnapshotBatchingEnabled)
+      Flow.fromGraph(
+        new BatchingStartingFromSnapshotStage[Event](
+          cacheCapacity = querySettings.startFromSnapshotCacheCapacity,
+          lookupBatchSize = querySettings.startFromSnapshotLookupBatchSize,
+          maxBufferedEnvelopes = querySettings.startFromSnapshotMaxBufferedEnvelopes,
+          batchLinger = querySettings.startFromSnapshotBatchLinger,
+          sequenceNumbersOfSnapshots = persistenceIds => snapshotDao.sequenceNumbersOfSnapshots(persistenceIds),
+          loadSnapshot = persistenceId => snapshotDao.load(persistenceId, SnapshotSelectionCriteria.Latest),
+          createEnvelope = (snapshotRow, offset) => createEnvelopeFromSnapshot(snapshotRow, offset, transformSnapshot),
+          heartbeatAfter = querySettings.startFromSnapshotHeartbeatAfter,
+          createHeartbeat = timestamp => createEventEnvelopeHeartbeat(entityType, minSlice, timestamp)))
+    else
+      Flow.fromGraph(
+        new StartingFromSnapshotStage[Event](
+          cacheCapacity = querySettings.startFromSnapshotCacheCapacity,
+          sequenceNumberOfSnapshot = persistenceId => snapshotDao.sequenceNumberOfSnapshot(persistenceId),
+          loadSnapshot = persistenceId => snapshotDao.load(persistenceId, SnapshotSelectionCriteria.Latest),
+          createEnvelope = (snapshotRow, offset) => createEnvelopeFromSnapshot(snapshotRow, offset, transformSnapshot),
+          heartbeatAfter = querySettings.startFromSnapshotHeartbeatAfter,
+          createHeartbeat = timestamp => createEventEnvelopeHeartbeat(entityType, minSlice, timestamp)))
   }
 
   private def checkStartFromSnapshotEnabled(methodName: String): Unit =

--- a/core/src/main/scala/akka/persistence/r2dbc/query/scaladsl/R2dbcReadJournal.scala
+++ b/core/src/main/scala/akka/persistence/r2dbc/query/scaladsl/R2dbcReadJournal.scala
@@ -422,7 +422,7 @@ final class R2dbcReadJournal(system: ExtendedActorSystem, config: Config, cfgPat
   /**
    * Picks between the original `StartingFromSnapshotStage` and `BatchingStartingFromSnapshotStage`
    * (`start-from-snapshot.batching.enabled`), which batches cache-miss lookups instead of doing one blocking,
-   * unpipelined round-trip per event. See BatchingStartingFromSnapshotStage's doc comment for details and known gaps.
+   * unpipelined round-trip per event. See BatchingStartingFromSnapshotStage's doc comment for details.
    */
   private def startingFromSnapshotFlow[Snapshot, Event](
       entityType: String,

--- a/core/src/main/scala/akka/persistence/r2dbc/query/scaladsl/R2dbcReadJournal.scala
+++ b/core/src/main/scala/akka/persistence/r2dbc/query/scaladsl/R2dbcReadJournal.scala
@@ -47,6 +47,7 @@ import akka.persistence.query.typed.scaladsl.LatestEventTimestampQuery
 import akka.persistence.query.typed.scaladsl.LoadEventQuery
 import akka.persistence.query.{ EventEnvelope => ClassicEventEnvelope }
 import akka.persistence.r2dbc.R2dbcSettings
+import akka.persistence.r2dbc.internal.BatchingStartingFromSnapshotStage
 import akka.persistence.r2dbc.internal.BySliceQuery
 import akka.persistence.r2dbc.internal.ContinuousQuery
 import akka.persistence.r2dbc.internal.CorrelationId
@@ -55,7 +56,6 @@ import akka.persistence.r2dbc.internal.JournalDao.SerializedJournalRow
 import akka.persistence.r2dbc.internal.PubSub
 import akka.persistence.r2dbc.internal.R2dbcExecutorProvider
 import akka.persistence.r2dbc.internal.SnapshotDao.SerializedSnapshotRow
-import akka.persistence.r2dbc.internal.BatchingStartingFromSnapshotStage
 import akka.persistence.r2dbc.internal.StartingFromSnapshotStage
 import akka.persistence.typed.PersistenceId
 import akka.serialization.SerializationExtension

--- a/core/src/main/scala/akka/persistence/r2dbc/query/scaladsl/R2dbcReadJournal.scala
+++ b/core/src/main/scala/akka/persistence/r2dbc/query/scaladsl/R2dbcReadJournal.scala
@@ -420,10 +420,9 @@ final class R2dbcReadJournal(system: ExtendedActorSystem, config: Config, cfgPat
   }
 
   /**
-   * SKETCH / DRAFT: picks between the original `StartingFromSnapshotStage` and the experimental
-   * `BatchingStartingFromSnapshotStage` (`start-from-snapshot.batching.enabled`), which batches cache-miss lookups
-   * instead of doing one blocking, unpipelined round-trip per event. See BatchingStartingFromSnapshotStage's doc
-   * comment for details and known gaps.
+   * Picks between the original `StartingFromSnapshotStage` and `BatchingStartingFromSnapshotStage`
+   * (`start-from-snapshot.batching.enabled`), which batches cache-miss lookups instead of doing one blocking,
+   * unpipelined round-trip per event. See BatchingStartingFromSnapshotStage's doc comment for details and known gaps.
    */
   private def startingFromSnapshotFlow[Snapshot, Event](
       entityType: String,

--- a/core/src/test/scala/akka/persistence/r2dbc/internal/BatchingStartingFromSnapshotStageSpec.scala
+++ b/core/src/test/scala/akka/persistence/r2dbc/internal/BatchingStartingFromSnapshotStageSpec.scala
@@ -32,11 +32,12 @@ import akka.stream.scaladsl.Source
 import akka.stream.testkit.scaladsl.TestSink
 
 /**
- * Unit-level tests for the two correctness issues found (and fixed) in review: a resolved cache entry getting evicted
- * while still referenced by a queued envelope (deadlocks the stage), and a cache-hit envelope being decided while an
- * earlier envelope's snapshot payload load is still in flight (reorders the stream). Both are exercised here with fully
- * controlled, hand-completed `Promise`s so the exact interleaving that triggers them is deterministic, rather than
- * relying on timing against a real database.
+ * Unit-level tests for `BatchingStartingFromSnapshotStage`'s ordering, cache-eviction, and buffering invariants: a
+ * resolved cache entry evicted while still referenced by a queued envelope, a cache-hit envelope decided while an
+ * earlier envelope's snapshot payload load is still in flight, a cache entry evicted while its own payload load is in
+ * flight, and the buffered-envelope count under a pattern of distinct, never-repeating persistence ids. These use fully
+ * controlled, hand-completed `Promise`s so the exact interleaving that exercises each case is deterministic, rather
+ * than relying on timing against a real database.
  */
 class BatchingStartingFromSnapshotStageSpec extends ScalaTestWithActorTestKit with AnyWordSpecLike with LogCapturing {
   private val entityType = "TestEntity"
@@ -160,7 +161,7 @@ class BatchingStartingFromSnapshotStageSpec extends ScalaTestWithActorTestKit wi
 
       val e0 = createEnvelope(pidA, 1, "a1") // resolves and is dequeued before the eviction pressure below
       val e1 = createEnvelope(pidB, 1, "b1") // sits ahead of e2 in the queue, unresolved, blocking advance()
-      val e2 = createEnvelope(pidA, 2, "a2") // depends on pidA's cache entry surviving until it's dequeued
+      val e2 = createEnvelope(pidA, 2, "a2") // depends on pidA's cache entry surviving until it is dequeued
 
       val probe = Source(Vector(e0, e1, e2))
         .via(
@@ -243,13 +244,9 @@ class BatchingStartingFromSnapshotStageSpec extends ScalaTestWithActorTestKit wi
     }
 
     "not let an id's cache entry be evicted while its snapshot payload load is in flight" in {
-      // cacheCapacity = 1 so resolving pidB creates eviction pressure that would (bug) hit pidA's entry while
-      // pidA's own snapshot payload load is in flight and unprotected by pinning - the load only pins ids
-      // referenced by envelopes still sitting in the queue, but the envelope that triggered the load has
-      // already been dequeued by the time the load starts. Uses Source.queue instead of a plain Vector source:
-      // the stage pulls eagerly, so a plain source would let later envelopes race ahead and re-pin pidA before
-      // the test gets a chance to evict it - offering elements one at a time under explicit test control avoids
-      // that.
+      // cacheCapacity = 1 so resolving pidB creates eviction pressure on pidA's entry while pidA's own load is
+      // in flight. Uses Source.queue, not a plain source: the stage pulls eagerly, so a plain source would let
+      // later envelopes race ahead and re-pin pidA before the test gets a chance to evict it.
       val snapAEnvelope = createEnvelope(pidA, 5, "snap-a5")
 
       val batchCalls = new LinkedBlockingQueue[(Set[String], Promise[Map[String, Long]])]()
@@ -304,19 +301,15 @@ class BatchingStartingFromSnapshotStageSpec extends ScalaTestWithActorTestKit wi
       val (bIds, bPromise) = poll(batchCalls)
       bIds shouldBe Set(pidB.id)
       bPromise.success(Map.empty)
-      // eB can't be decided yet - awaitingSnapshotLoad still blocks advance() until pidA's load completes below.
-      // `success()` doesn't block until the stage has actually processed it (that happens asynchronously on the
-      // stream's own dispatcher), so without waiting here, offer(e2) below could race ahead of the eviction
-      // check this is meant to trigger. expectNoMessage doubles as that synchronization point.
+      // eB cannot be decided yet - awaitingSnapshotLoad blocks it. success() does not block until the stage has
+      // processed it, so this wait is needed or offer(e2) below could race ahead of the eviction it should see.
       probe.expectNoMessage(100.millis)
 
       // only now, after pidA may have been evicted, does a redelivery for it arrive
       offer(e2)
 
-      // without the pinning-during-load fix, pidA was evicted above and this re-triggers a redundant lookup
-      // for it while the original load is still in flight; capture it now but resolve it only after the
-      // original load below, so it's the *last* writer to pidA's cache entry - the interleaving that actually
-      // corrupts the `emitted` flag (if the load's update wins here, the outcome would be correct by luck)
+      // captured now, but resolved only after the load below, so it is the last writer to pidA's entry - the
+      // interleaving that actually corrupts `emitted` (if the load wins instead, the outcome is correct by luck)
       val redundantBatch = batchCalls.poll(300, java.util.concurrent.TimeUnit.MILLISECONDS)
 
       // complete the original load - decides e1 (and unblocks eB and e2, queued behind it)
@@ -330,7 +323,7 @@ class BatchingStartingFromSnapshotStageSpec extends ScalaTestWithActorTestKit wi
         val (ids, p) = redundantBatch
         ids shouldBe Set(pidA.id)
         p.success(Map(pidA.id -> 5L)) // same seqNr as before - simulates the DB state being unchanged
-        // again, success() doesn't block until the stage has processed it - synchronize before offer(e3) below
+        // again, success() does not block until the stage has processed it - synchronize before offer(e3) below
         probe.expectNoMessage(100.millis)
       }
 
@@ -370,10 +363,9 @@ class BatchingStartingFromSnapshotStageSpec extends ScalaTestWithActorTestKit wi
 
       probe.request(10000)
 
-      // bufferSize = 1 with OverflowStrategy.backpressure means offer() only completes once the stage has
-      // actually pulled room for it, so this directly measures how many envelopes the stage was willing to
-      // buffer before it stopped pulling. The +1 is the queue's own single-element buffer, filled once and
-      // never drained by the stage - not slack in the stage's own bound.
+      // bufferSize 1 with backpressure means offer() only completes once the stage has pulled room for it, so
+      // this measures how many envelopes the stage buffers before it stops. The +1 below is the queue's own
+      // single-element buffer, not slack in the stage's bound.
       var offered = 0
       var blocked = false
       while (!blocked && offered < maxBuffered * 3) {

--- a/core/src/test/scala/akka/persistence/r2dbc/internal/BatchingStartingFromSnapshotStageSpec.scala
+++ b/core/src/test/scala/akka/persistence/r2dbc/internal/BatchingStartingFromSnapshotStageSpec.scala
@@ -9,6 +9,7 @@ import java.util.concurrent.LinkedBlockingQueue
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicInteger
 
+import scala.concurrent.Await
 import scala.concurrent.Future
 import scala.concurrent.Promise
 import scala.concurrent.duration._
@@ -24,7 +25,9 @@ import akka.persistence.query.TimestampOffset
 import akka.persistence.query.typed.EventEnvelope
 import akka.persistence.r2dbc.internal.SnapshotDao.SerializedSnapshotRow
 import akka.persistence.typed.PersistenceId
+import akka.stream.OverflowStrategy
 import akka.stream.scaladsl.Flow
+import akka.stream.scaladsl.Keep
 import akka.stream.scaladsl.Source
 import akka.stream.testkit.scaladsl.TestSink
 
@@ -237,6 +240,107 @@ class BatchingStartingFromSnapshotStageSpec extends ScalaTestWithActorTestKit wi
       probe.expectNext(snapAEnvelope)
       probe.expectNext(e2)
       probe.expectComplete()
+    }
+
+    "not let an id's cache entry be evicted while its snapshot payload load is in flight" in {
+      // cacheCapacity = 1 so resolving pidB creates eviction pressure that would (bug) hit pidA's entry while
+      // pidA's own snapshot payload load is in flight and unprotected by pinning - the load only pins ids
+      // referenced by envelopes still sitting in the queue, but the envelope that triggered the load has
+      // already been dequeued by the time the load starts. Uses Source.queue instead of a plain Vector source:
+      // the stage pulls eagerly, so a plain source would let later envelopes race ahead and re-pin pidA before
+      // the test gets a chance to evict it - offering elements one at a time under explicit test control avoids
+      // that.
+      val snapAEnvelope = createEnvelope(pidA, 5, "snap-a5")
+
+      val batchCalls = new LinkedBlockingQueue[(Set[String], Promise[Map[String, Long]])]()
+      def sequenceNumbersOfSnapshots(ids: Set[String]): Future[Map[String, Long]] = {
+        val p = Promise[Map[String, Long]]()
+        batchCalls.put(ids -> p)
+        p.future
+      }
+
+      val loadCalls = new LinkedBlockingQueue[(String, Promise[Option[SerializedSnapshotRow]])]()
+      def loadSnapshot(persistenceId: String): Future[Option[SerializedSnapshotRow]] = {
+        val p = Promise[Option[SerializedSnapshotRow]]()
+        loadCalls.put(persistenceId -> p)
+        p.future
+      }
+
+      val e1 = createEnvelope(pidA, 5, "a5") // triggers pidA's snapshot load
+      val eB = createEnvelope(pidB, 1, "b1") // unrelated id; resolving it creates the eviction pressure
+      val e2 = createEnvelope(pidA, 5, "a5-redelivered") // arrives only after pidA has (bug) been evicted
+      val e3 = createEnvelope(pidA, 5, "a5-redelivered-again") // a further, later redelivery of the same event
+
+      val (queue, probe) = Source
+        .queue[EventEnvelope[Any]](16, OverflowStrategy.fail)
+        .via(
+          stage(
+            cacheCapacity = 1,
+            lookupBatchSize = 1,
+            sequenceNumbersOfSnapshots,
+            loadSnapshot,
+            (_, _) => snapAEnvelope,
+            maxBufferedEnvelopes = 16))
+        .toMat(TestSink())(Keep.both)
+        .run()
+
+      def offer(env: EventEnvelope[Any]): Unit = Await.result(queue.offer(env), 5.seconds)
+
+      probe.request(10)
+
+      // e1: pidA is uncached, resolves to snapshot seqNr 5 (== e1's own seqNr), which triggers the load
+      offer(e1)
+      val (aIds, aPromise) = poll(batchCalls)
+      aIds shouldBe Set(pidA.id)
+      aPromise.success(Map(pidA.id -> 5L))
+      val (loadPid1, loadPromise1) = poll(loadCalls)
+      loadPid1 shouldBe pidA.id
+      // do not complete this load yet - pidA is now unpinned (e1 was its only queue reference) while the
+      // load stays in flight
+
+      // eB: unrelated id, resolves with no snapshot - at cacheCapacity 1 this creates eviction pressure, and
+      // pidA (unpinned, untouched since its load started) is the only eviction candidate
+      offer(eB)
+      val (bIds, bPromise) = poll(batchCalls)
+      bIds shouldBe Set(pidB.id)
+      bPromise.success(Map.empty)
+      // eB can't be decided yet - awaitingSnapshotLoad still blocks advance() until pidA's load completes below.
+      // `success()` doesn't block until the stage has actually processed it (that happens asynchronously on the
+      // stream's own dispatcher), so without waiting here, offer(e2) below could race ahead of the eviction
+      // check this is meant to trigger. expectNoMessage doubles as that synchronization point.
+      probe.expectNoMessage(100.millis)
+
+      // only now, after pidA may have been evicted, does a redelivery for it arrive
+      offer(e2)
+
+      // without the pinning-during-load fix, pidA was evicted above and this re-triggers a redundant lookup
+      // for it while the original load is still in flight; capture it now but resolve it only after the
+      // original load below, so it's the *last* writer to pidA's cache entry - the interleaving that actually
+      // corrupts the `emitted` flag (if the load's update wins here, the outcome would be correct by luck)
+      val redundantBatch = batchCalls.poll(300, java.util.concurrent.TimeUnit.MILLISECONDS)
+
+      // complete the original load - decides e1 (and unblocks eB and e2, queued behind it)
+      loadPromise1.success(Some(createSerializedSnapshotRow(pidA, 5L)))
+      probe.expectNext(snapAEnvelope)
+      probe.expectNext(eB)
+      // e2 is a redelivery of the same seqNr as the already-emitted snapshot - must be ignored, not re-loaded
+      probe.expectNoMessage(200.millis)
+
+      if (redundantBatch != null) {
+        val (ids, p) = redundantBatch
+        ids shouldBe Set(pidA.id)
+        p.success(Map(pidA.id -> 5L)) // same seqNr as before - simulates the DB state being unchanged
+        // again, success() doesn't block until the stage has processed it - synchronize before offer(e3) below
+        probe.expectNoMessage(100.millis)
+      }
+
+      // e3: a further redelivery: if the redundant batch above clobbered pidA's emitted flag back to false,
+      // this triggers a second, duplicate snapshot load (and would eventually emit snapAEnvelope twice)
+      offer(e3)
+      val secondLoad = loadCalls.poll(300, java.util.concurrent.TimeUnit.MILLISECONDS)
+      secondLoad shouldBe null
+
+      probe.cancel()
     }
   }
 }

--- a/core/src/test/scala/akka/persistence/r2dbc/internal/BatchingStartingFromSnapshotStageSpec.scala
+++ b/core/src/test/scala/akka/persistence/r2dbc/internal/BatchingStartingFromSnapshotStageSpec.scala
@@ -342,5 +342,62 @@ class BatchingStartingFromSnapshotStageSpec extends ScalaTestWithActorTestKit wi
 
       probe.cancel()
     }
+
+    "bound the number of buffered envelopes to maxBufferedEnvelopes even when every persistence id is distinct and nothing ever resolves" in {
+      // adversarial case for the envelope buffer: every envelope is for a different, never-repeating persistence
+      // id, and no lookup is ever completed, so nothing is ever decided and nothing ever drains - the buffer can
+      // only stop growing because upstream demand stops, not because anything gets consumed
+      val maxBuffered = 200
+      val lookupBatchSize = 50
+
+      val requestedIds = new LinkedBlockingQueue[Set[String]]()
+      def sequenceNumbersOfSnapshots(ids: Set[String]): Future[Map[String, Long]] = {
+        requestedIds.put(ids)
+        Promise[Map[String, Long]]().future // never completes
+      }
+
+      val (queue, probe) = Source
+        .queue[EventEnvelope[Any]](1, OverflowStrategy.backpressure)
+        .via(stage(
+          cacheCapacity = 10,
+          lookupBatchSize = lookupBatchSize,
+          sequenceNumbersOfSnapshots,
+          neverLoadsSnapshot,
+          (_, _) => throw new IllegalStateException("no snapshot expected"),
+          maxBufferedEnvelopes = maxBuffered))
+        .toMat(TestSink())(Keep.both)
+        .run()
+
+      probe.request(10000)
+
+      // bufferSize = 1 with OverflowStrategy.backpressure means offer() only completes once the stage has
+      // actually pulled room for it, so this directly measures how many envelopes the stage was willing to
+      // buffer before it stopped pulling. The +1 is the queue's own single-element buffer, filled once and
+      // never drained by the stage - not slack in the stage's own bound.
+      var offered = 0
+      var blocked = false
+      while (!blocked && offered < maxBuffered * 3) {
+        val env = createEnvelope(PersistenceId(entityType, s"distinct-$offered"), 1, "e")
+        try {
+          Await.result(queue.offer(env), 300.millis)
+          offered += 1
+        } catch {
+          case _: java.util.concurrent.TimeoutException => blocked = true
+        }
+      }
+
+      blocked shouldBe true
+      offered shouldBe maxBuffered + 1
+
+      var totalRequestedIds = Set.empty[String]
+      var batch = requestedIds.poll(100, java.util.concurrent.TimeUnit.MILLISECONDS)
+      while (batch != null) {
+        totalRequestedIds ++= batch
+        batch = requestedIds.poll(100, java.util.concurrent.TimeUnit.MILLISECONDS)
+      }
+      totalRequestedIds.size should be <= maxBuffered
+
+      probe.cancel()
+    }
   }
 }

--- a/core/src/test/scala/akka/persistence/r2dbc/internal/BatchingStartingFromSnapshotStageSpec.scala
+++ b/core/src/test/scala/akka/persistence/r2dbc/internal/BatchingStartingFromSnapshotStageSpec.scala
@@ -1,0 +1,242 @@
+/*
+ * Copyright (C) 2022 - 2025 Lightbend Inc. <https://akka.io>
+ */
+
+package akka.persistence.r2dbc.internal
+
+import java.time.Instant
+import java.util.concurrent.LinkedBlockingQueue
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicInteger
+
+import scala.concurrent.Future
+import scala.concurrent.Promise
+import scala.concurrent.duration._
+
+import org.scalatest.wordspec.AnyWordSpecLike
+
+import akka.NotUsed
+import akka.actor.testkit.typed.scaladsl.LogCapturing
+import akka.actor.testkit.typed.scaladsl.ScalaTestWithActorTestKit
+import akka.actor.typed.ActorSystem
+import akka.persistence.Persistence
+import akka.persistence.query.TimestampOffset
+import akka.persistence.query.typed.EventEnvelope
+import akka.persistence.r2dbc.internal.SnapshotDao.SerializedSnapshotRow
+import akka.persistence.typed.PersistenceId
+import akka.stream.scaladsl.Flow
+import akka.stream.scaladsl.Source
+import akka.stream.testkit.scaladsl.TestSink
+
+/**
+ * Unit-level tests for the two correctness issues found (and fixed) in review: a resolved cache entry getting evicted
+ * while still referenced by a queued envelope (deadlocks the stage), and a cache-hit envelope being decided while an
+ * earlier envelope's snapshot payload load is still in flight (reorders the stream). Both are exercised here with fully
+ * controlled, hand-completed `Promise`s so the exact interleaving that triggers them is deterministic, rather than
+ * relying on timing against a real database.
+ */
+class BatchingStartingFromSnapshotStageSpec extends ScalaTestWithActorTestKit with AnyWordSpecLike with LogCapturing {
+  private val entityType = "TestEntity"
+  private val persistence = Persistence(system)
+  private implicit val sys: ActorSystem[_] = system
+
+  private val pidA = PersistenceId(entityType, "a")
+  private val pidB = PersistenceId(entityType, "b")
+
+  private def createEnvelope(pid: PersistenceId, seqNr: Long, evt: String): EventEnvelope[Any] = {
+    val now = Instant.now()
+    EventEnvelope(
+      TimestampOffset(now, Map(pid.id -> seqNr)),
+      pid.id,
+      seqNr,
+      evt,
+      now.toEpochMilli,
+      pid.entityTypeHint,
+      persistence.sliceForPersistenceId(pid.id),
+      filtered = false,
+      "",
+      tags = Set.empty)
+  }
+
+  private def createSerializedSnapshotRow(pid: PersistenceId, seqNr: Long): SerializedSnapshotRow =
+    SerializedSnapshotRow(
+      persistence.sliceForPersistenceId(pid.id),
+      entityType,
+      pid.id,
+      seqNr,
+      Instant.now(),
+      Instant.now().toEpochMilli,
+      Array.empty,
+      0,
+      "",
+      Set.empty,
+      None)
+
+  private def createHeartbeat(timestamp: Instant): EventEnvelope[Any] =
+    new EventEnvelope(
+      TimestampOffset(timestamp, Map.empty),
+      "heartbeat-pid",
+      1L,
+      eventOption = None,
+      timestamp.toEpochMilli,
+      _eventMetadata = None,
+      entityType,
+      0,
+      filtered = true,
+      source = EnvelopeOrigin.SourceHeartbeat,
+      Set.empty)
+
+  private def stage(
+      cacheCapacity: Int,
+      lookupBatchSize: Int,
+      sequenceNumbersOfSnapshots: Set[String] => Future[Map[String, Long]],
+      loadSnapshot: String => Future[Option[SerializedSnapshotRow]],
+      createEnvelopeFromSnapshot: (SerializedSnapshotRow, TimestampOffset) => EventEnvelope[Any],
+      maxBufferedEnvelopes: Int = 100,
+      batchLinger: FiniteDuration = 1.hour): Flow[EventEnvelope[Any], EventEnvelope[Any], NotUsed] =
+    Flow.fromGraph(
+      new BatchingStartingFromSnapshotStage[Any](
+        cacheCapacity,
+        lookupBatchSize,
+        maxBufferedEnvelopes,
+        batchLinger,
+        sequenceNumbersOfSnapshots,
+        loadSnapshot,
+        createEnvelopeFromSnapshot,
+        heartbeatAfter = 1000,
+        createHeartbeat))
+
+  // no dialect actually returns a snapshot for this pid; used where a lookup only needs to resolve, not load
+  private def neverLoadsSnapshot(persistenceId: String): Future[Option[SerializedSnapshotRow]] =
+    Future.successful(None)
+
+  private def poll[A](queue: LinkedBlockingQueue[A]): A = {
+    val v = queue.poll(5, TimeUnit.SECONDS)
+    if (v == null) throw new AssertionError("expected a lookup call within 5 seconds but none arrived")
+    v
+  }
+
+  "BatchingStartingFromSnapshotStage" must {
+
+    "batch multiple distinct cache misses into a single lookup call" in {
+      val lookupCalls = new AtomicInteger(0)
+      def sequenceNumbersOfSnapshots(ids: Set[String]): Future[Map[String, Long]] = {
+        lookupCalls.incrementAndGet()
+        Future.successful(Map.empty) // no snapshots, both events pass straight through
+      }
+
+      val e1 = createEnvelope(pidA, 1, "a1")
+      val e2 = createEnvelope(pidB, 1, "b1")
+
+      val probe = Source(Vector(e1, e2))
+        .via(
+          stage(
+            cacheCapacity = 10,
+            lookupBatchSize = 2,
+            sequenceNumbersOfSnapshots,
+            neverLoadsSnapshot,
+            (_, _) => throw new IllegalStateException("no snapshot expected")))
+        .runWith(TestSink())
+
+      probe.request(10)
+      probe.expectNext(e1)
+      probe.expectNext(e2)
+      probe.expectComplete()
+
+      lookupCalls.get() shouldBe 1
+    }
+
+    "not stall when a resolved entry pinned by a still-queued envelope would otherwise be evicted" in {
+      // cacheCapacity = 1 so the second lookup's resolution creates immediate eviction pressure on the first
+      val batchCalls = new LinkedBlockingQueue[(Set[String], Promise[Map[String, Long]])]()
+      def sequenceNumbersOfSnapshots(ids: Set[String]): Future[Map[String, Long]] = {
+        val p = Promise[Map[String, Long]]()
+        batchCalls.put(ids -> p)
+        p.future
+      }
+
+      val e0 = createEnvelope(pidA, 1, "a1") // resolves and is dequeued before the eviction pressure below
+      val e1 = createEnvelope(pidB, 1, "b1") // sits ahead of e2 in the queue, unresolved, blocking advance()
+      val e2 = createEnvelope(pidA, 2, "a2") // depends on pidA's cache entry surviving until it's dequeued
+
+      val probe = Source(Vector(e0, e1, e2))
+        .via(
+          stage(
+            cacheCapacity = 1,
+            lookupBatchSize = 1,
+            sequenceNumbersOfSnapshots,
+            neverLoadsSnapshot,
+            (_, _) => throw new IllegalStateException("no snapshot expected")))
+        .runWith(TestSink())
+
+      probe.request(10)
+
+      val (ids0, p0) = poll(batchCalls)
+      ids0 shouldBe Set(pidA.id)
+      p0.success(Map.empty)
+      probe.expectNext(e0)
+
+      // without the eviction-pinning fix this hangs forever: resolving pidB pushes the (capacity 1) cache over
+      // the edge, evicting pidA's just-resolved entry while e2 - which still needs it - sits queued behind e1
+      val (ids1, p1) = poll(batchCalls)
+      ids1 shouldBe Set(pidB.id)
+      p1.success(Map.empty)
+
+      probe.expectNext(e1)
+      probe.expectNext(e2)
+      probe.expectComplete()
+    }
+
+    "not decide a cache-hit envelope while an earlier envelope's snapshot load is still in flight" in {
+      val snapAEnvelope = createEnvelope(pidA, 5, "snap-a5")
+
+      val batchCalls = new LinkedBlockingQueue[(Set[String], Promise[Map[String, Long]])]()
+      def sequenceNumbersOfSnapshots(ids: Set[String]): Future[Map[String, Long]] = {
+        val p = Promise[Map[String, Long]]()
+        batchCalls.put(ids -> p)
+        p.future
+      }
+
+      val loadCalls = new LinkedBlockingQueue[(String, Promise[Option[SerializedSnapshotRow]])]()
+      def loadSnapshot(persistenceId: String): Future[Option[SerializedSnapshotRow]] = {
+        val p = Promise[Option[SerializedSnapshotRow]]()
+        loadCalls.put(persistenceId -> p)
+        p.future
+      }
+
+      // e1's persistence id has a snapshot at the same seqNr as the event itself, so resolving it triggers a
+      // snapshot payload load rather than an immediate decision; e2's persistence id has no snapshot, so it is
+      // immediately decidable once resolved - but must still wait behind e1 in the queue.
+      val e1 = createEnvelope(pidA, 5, "a5")
+      val e2 = createEnvelope(pidB, 1, "b1")
+
+      val probe = Source(Vector(e1, e2))
+        .via(
+          stage(
+            cacheCapacity = 10,
+            lookupBatchSize = 2,
+            sequenceNumbersOfSnapshots,
+            loadSnapshot,
+            (_, _) => snapAEnvelope))
+        .runWith(TestSink())
+
+      probe.request(10)
+
+      val (ids, p) = poll(batchCalls)
+      ids shouldBe Set(pidA.id, pidB.id)
+      p.success(Map(pidA.id -> 5L)) // pidB has no snapshot, pidA's snapshot is exactly at e1's seqNr
+
+      // pidB is fully resolved at this point, but must not be emitted ahead of pidA, which is still waiting on
+      // its snapshot payload load
+      probe.expectNoMessage(200.millis)
+
+      val (loadPid, loadPromise) = poll(loadCalls)
+      loadPid shouldBe pidA.id
+      loadPromise.success(Some(createSerializedSnapshotRow(pidA, 5L)))
+
+      probe.expectNext(snapAEnvelope)
+      probe.expectNext(e2)
+      probe.expectComplete()
+    }
+  }
+}

--- a/core/src/test/scala/akka/persistence/r2dbc/internal/SnapshotDaoSpec.scala
+++ b/core/src/test/scala/akka/persistence/r2dbc/internal/SnapshotDaoSpec.scala
@@ -1,0 +1,99 @@
+/*
+ * Copyright (C) 2022 - 2025 Lightbend Inc. <https://akka.io>
+ */
+
+package akka.persistence.r2dbc.internal
+
+import java.util.concurrent.LinkedBlockingQueue
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicInteger
+
+import scala.concurrent.Await
+import scala.concurrent.ExecutionContext
+import scala.concurrent.Future
+import scala.concurrent.Promise
+import scala.concurrent.duration._
+
+import akka.persistence.SnapshotSelectionCriteria
+import akka.persistence.r2dbc.internal.SnapshotDao.SerializedSnapshotRow
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+
+class SnapshotDaoSpec extends AnyWordSpec with Matchers {
+
+  // only sequenceNumberOfSnapshot and maxConcurrentSequenceNumberLookups are exercised by
+  // sequenceNumbersOfSnapshotsConcurrently, the default `sequenceNumbersOfSnapshots` implementation under test here
+  private class TestDao(maxConcurrent: Int) extends SnapshotDao {
+    protected implicit def ec: ExecutionContext = ExecutionContext.global
+    protected def maxConcurrentSequenceNumberLookups: Int = maxConcurrent
+
+    private val active = new AtomicInteger(0)
+    val maxObservedConcurrency = new AtomicInteger(0)
+    val invoked = new LinkedBlockingQueue[(String, Promise[Option[Long]])]()
+
+    override def sequenceNumberOfSnapshot(persistenceId: String): Future[Option[Long]] = {
+      maxObservedConcurrency.updateAndGet(prev => math.max(prev, active.incrementAndGet()))
+      val promise = Promise[Option[Long]]()
+      promise.future.onComplete(_ => active.decrementAndGet())(ExecutionContext.parasitic)
+      invoked.put(persistenceId -> promise)
+      promise.future
+    }
+
+    override def load(
+        persistenceId: String,
+        criteria: SnapshotSelectionCriteria): Future[Option[SerializedSnapshotRow]] =
+      throw new UnsupportedOperationException
+    override def store(serializedRow: SerializedSnapshotRow): Future[Unit] = throw new UnsupportedOperationException
+    override def delete(persistenceId: String, criteria: SnapshotSelectionCriteria): Future[Unit] =
+      throw new UnsupportedOperationException
+
+    // takes the next `n` invocations off the queue without completing them
+    def takeNext(n: Int): Seq[(String, Promise[Option[Long]])] =
+      (1 to n).map(_ => invoked.poll(3, TimeUnit.SECONDS))
+
+    // completes the next `n` not-yet-completed invocations, one at a time, in the order sequenceNumberOfSnapshot
+    // was called for them. Interleaving poll-then-complete (rather than pre-taking a whole wave) lets a chunk
+    // whose size doesn't evenly divide `n` progress correctly.
+    def completeNext(n: Int)(result: String => Option[Long]): Unit =
+      takeNext(n).foreach { case (persistenceId, promise) => promise.success(result(persistenceId)) }
+
+    def assertNothingInvokedWithin(duration: FiniteDuration): Unit =
+      invoked.poll(duration.toMillis, TimeUnit.MILLISECONDS) shouldBe null
+  }
+
+  "SnapshotDao.sequenceNumbersOfSnapshots default implementation" should {
+    "resolve all persistence ids, keeping only the ones with a snapshot" in {
+      val dao = new TestDao(maxConcurrent = 2)
+      val ids = (1 to 5).map(i => s"pid-$i").toSet
+      val resultFuture = dao.sequenceNumbersOfSnapshots(ids)
+
+      // every id gets a snapshot except pid-3
+      ids.toList.foreach(_ => dao.completeNext(1)(persistenceId => if (persistenceId == "pid-3") None else Some(7L)))
+
+      val result = Await.result(resultFuture, 3.seconds)
+      result shouldBe (ids - "pid-3").map(_ -> 7L).toMap
+    }
+
+    "never have more than maxConcurrentSequenceNumberLookups lookups in flight at once" in {
+      val dao = new TestDao(maxConcurrent = 3)
+      val ids = (1 to 7).map(i => s"pid-$i").toSet
+      val resultFuture = dao.sequenceNumbersOfSnapshots(ids)
+
+      // wave 1: exactly maxConcurrent in flight, nothing more until they complete
+      val wave1 = dao.takeNext(3)
+      dao.assertNothingInvokedWithin(200.millis)
+      wave1.foreach { case (_, promise) => promise.success(Some(1L)) }
+
+      // wave 2: same check
+      val wave2 = dao.takeNext(3)
+      dao.assertNothingInvokedWithin(200.millis)
+      wave2.foreach { case (_, promise) => promise.success(Some(1L)) }
+
+      // wave 3: the trailing, smaller-than-maxConcurrent chunk
+      dao.takeNext(1).foreach { case (_, promise) => promise.success(Some(1L)) }
+
+      Await.result(resultFuture, 3.seconds) shouldBe ids.map(_ -> 1L).toMap
+      dao.maxObservedConcurrency.get() shouldBe 3
+    }
+  }
+}

--- a/core/src/test/scala/akka/persistence/r2dbc/query/BatchingEventsBySliceStartingFromSnapshotSpec.scala
+++ b/core/src/test/scala/akka/persistence/r2dbc/query/BatchingEventsBySliceStartingFromSnapshotSpec.scala
@@ -1,0 +1,12 @@
+/*
+ * Copyright (C) 2022 - 2025 Lightbend Inc. <https://akka.io>
+ */
+
+package akka.persistence.r2dbc.query
+
+/**
+ * Runs the full EventsBySliceStartingFromSnapshotSpec suite again with `start-from-snapshot.batching.enabled = true`,
+ * so PostgresSnapshotDao's batched `= ANY(?)` sequence-number lookup is exercised against a real database in CI.
+ */
+class BatchingEventsBySliceStartingFromSnapshotSpec
+    extends EventsBySliceStartingFromSnapshotSpec(EventsBySliceStartingFromSnapshotSpec.batchingConfig)

--- a/core/src/test/scala/akka/persistence/r2dbc/query/BatchingSnapshotLookupBenchmark.scala
+++ b/core/src/test/scala/akka/persistence/r2dbc/query/BatchingSnapshotLookupBenchmark.scala
@@ -67,8 +67,8 @@ object BatchingSnapshotLookupBenchmark extends TestData {
   def main(args: Array[String]): Unit = {
     val numberOfPersistenceIds = args.headOption.map(_.toInt).getOrElse(8000)
 
-    val baselineSystem =
-      ActorSystem[Nothing](Behaviors.empty, "BatchingSnapshotLookupBenchmark-baseline", baselineConfig)
+    val baselineSystem: ActorSystem[Nothing] =
+      ActorSystem[Nothing](Behaviors.empty[Nothing], "BatchingSnapshotLookupBenchmark-baseline", baselineConfig)
     implicit val ec: ExecutionContext = baselineSystem.executionContext
 
     val settings = R2dbcSettings(baselineConfig.getConfig("akka.persistence.r2dbc"))
@@ -127,7 +127,9 @@ object BatchingSnapshotLookupBenchmark extends TestData {
         "",
         "bench-writer",
         Set.empty,
-        None)
+        None,
+        eventValue = None,
+        eventMetadata = None)
       for {
         _ <- snapshotDao.store(snapshotRow)
         _ <- journalDao.writeEvents(Seq(eventRow))
@@ -165,8 +167,8 @@ object BatchingSnapshotLookupBenchmark extends TestData {
 
     val baselineElapsed = runQuery(baselineSystem, "batching disabled (baseline)")
 
-    val batchedSystem =
-      ActorSystem[Nothing](Behaviors.empty, "BatchingSnapshotLookupBenchmark-batched", batchedConfig)
+    val batchedSystem: ActorSystem[Nothing] =
+      ActorSystem[Nothing](Behaviors.empty[Nothing], "BatchingSnapshotLookupBenchmark-batched", batchedConfig)
     val batchedElapsed =
       try runQuery(batchedSystem, "batching enabled")
       finally {

--- a/core/src/test/scala/akka/persistence/r2dbc/query/BatchingSnapshotLookupBenchmark.scala
+++ b/core/src/test/scala/akka/persistence/r2dbc/query/BatchingSnapshotLookupBenchmark.scala
@@ -1,0 +1,185 @@
+/*
+ * Copyright (C) 2022 - 2025 Lightbend Inc. <https://akka.io>
+ */
+
+package akka.persistence.r2dbc.query
+
+import java.time.Instant
+
+import scala.concurrent.Await
+import scala.concurrent.ExecutionContext
+import scala.concurrent.Future
+import scala.concurrent.duration._
+
+import com.typesafe.config.Config
+import com.typesafe.config.ConfigFactory
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
+
+import akka.actor.typed.ActorSystem
+import akka.actor.typed.scaladsl.Behaviors
+import akka.persistence.Persistence
+import akka.persistence.query.NoOffset
+import akka.persistence.query.PersistenceQuery
+import akka.persistence.r2dbc.R2dbcSettings
+import akka.persistence.r2dbc.TestConfig
+import akka.persistence.r2dbc.TestData
+import akka.persistence.r2dbc.internal.JournalDao.SerializedJournalRow
+import akka.persistence.r2dbc.internal.R2dbcExecutorProvider
+import akka.persistence.r2dbc.internal.SnapshotDao.SerializedSnapshotRow
+import akka.persistence.r2dbc.query.scaladsl.R2dbcReadJournal
+import akka.serialization.SerializationExtension
+import akka.stream.scaladsl.Sink
+
+/**
+ * Manual benchmark validating, against real Postgres and a dataset shaped like the reported production workload - many
+ * more distinct persistence ids in one partition than cache-capacity, so the snapshot-filtering stage sees a near-100%
+ * cache-miss rate - that `batching.enabled` actually reduces wall-clock time for `eventsBySlicesStartingFromSnapshots`,
+ * not just round-trip *count* in isolation.
+ *
+ * Each persistence id gets exactly one snapshot (seqNr 1) and one trailing event (seqNr 2). Since the event is always
+ * after the snapshot, deciding it never needs to load the snapshot payload - only the sequence-number lookup - which
+ * isolates the cost this change targets from every other cost in the pipeline.
+ *
+ * A plain `main`, not a test spec, so `sbt test` never runs it. Requires a running local Postgres matching
+ * `docker/docker-compose-postgres.yml`. Run explicitly with: sbt "core/Test/runMain
+ * akka.persistence.r2dbc.query.BatchingSnapshotLookupBenchmark" optionally followed by the number of persistence ids to
+ * seed (default 8000).
+ */
+object BatchingSnapshotLookupBenchmark extends TestData {
+  private val log: Logger = LoggerFactory.getLogger(getClass)
+  private val seedConcurrency = 200
+
+  private val baselineConfig: Config =
+    ConfigFactory
+      .parseString("""
+      akka.persistence.r2dbc.query.start-from-snapshot.enabled = true
+      akka.persistence.r2dbc.query.start-from-snapshot.batching.enabled = false
+      akka.persistence.r2dbc.journal.publish-events = off
+      """)
+      .withFallback(TestConfig.config)
+
+  private val batchedConfig: Config =
+    ConfigFactory
+      .parseString("akka.persistence.r2dbc.query.start-from-snapshot.batching.enabled = true")
+      .withFallback(baselineConfig)
+
+  def main(args: Array[String]): Unit = {
+    val numberOfPersistenceIds = args.headOption.map(_.toInt).getOrElse(8000)
+
+    val baselineSystem =
+      ActorSystem[Nothing](Behaviors.empty, "BatchingSnapshotLookupBenchmark-baseline", baselineConfig)
+    implicit val ec: ExecutionContext = baselineSystem.executionContext
+
+    val settings = R2dbcSettings(baselineConfig.getConfig("akka.persistence.r2dbc"))
+    val executorProvider = new R2dbcExecutorProvider(
+      baselineSystem,
+      settings.connectionFactorySettings.dialect.daoExecutionContext(settings, baselineSystem),
+      settings,
+      "akka.persistence.r2dbc.connection-factory",
+      log)
+    val persistenceExt = Persistence(baselineSystem)
+    val dialect = settings.connectionFactorySettings.dialect
+    val journalDao = dialect.createJournalDao(executorProvider)
+    val snapshotDao = dialect.createSnapshotDao(executorProvider)
+
+    log.info("Clearing journal/snapshot tables...")
+    settings.allJournalTablesWithSchema.foreach { case (table, minSlice) =>
+      Await.result(
+        executorProvider.executorFor(minSlice).updateOne("delete")(_.createStatement(s"delete from $table")),
+        10.seconds)
+    }
+    settings.allSnapshotTablesWithSchema.foreach { case (table, minSlice) =>
+      Await.result(
+        executorProvider.executorFor(minSlice).updateOne("delete")(_.createStatement(s"delete from $table")),
+        10.seconds)
+    }
+
+    val entityType = nextEntityType()
+    val stringSerializer = SerializationExtension(baselineSystem).serializerFor(classOf[String])
+    val baseTime = Instant.now().minusSeconds(3600)
+
+    def seedOne(i: Int): Future[Unit] = {
+      val pid = nextPid(entityType)
+      val slice = persistenceExt.sliceForPersistenceId(pid)
+      val timestamp = baseTime.plusMillis(i.toLong)
+      val snapshotRow = SerializedSnapshotRow(
+        slice,
+        entityType,
+        pid,
+        1L,
+        timestamp,
+        timestamp.toEpochMilli,
+        stringSerializer.toBinary(s"snap-$pid"),
+        stringSerializer.identifier,
+        "",
+        Set.empty,
+        None)
+      val eventRow = SerializedJournalRow(
+        slice,
+        entityType,
+        pid,
+        2L,
+        timestamp,
+        timestamp,
+        Some(stringSerializer.toBinary(s"evt-$pid")),
+        stringSerializer.identifier,
+        "",
+        "bench-writer",
+        Set.empty,
+        None)
+      for {
+        _ <- snapshotDao.store(snapshotRow)
+        _ <- journalDao.writeEvents(Seq(eventRow))
+      } yield ()
+    }
+
+    println(s"Seeding $numberOfPersistenceIds persistence ids (1 snapshot + 1 trailing event each)...")
+    val seedStart = System.nanoTime()
+    (1 to numberOfPersistenceIds).grouped(seedConcurrency).foreach { chunk =>
+      Await.result(Future.traverse(chunk.toVector)(seedOne), 30.seconds)
+    }
+    println(s"Seeding done in ${(System.nanoTime() - seedStart) / 1000000} ms")
+
+    def runQuery(sys: ActorSystem[_], label: String): FiniteDuration = {
+      implicit val mat: akka.stream.Materializer = akka.stream.Materializer(sys)
+      val query = PersistenceQuery(sys).readJournalFor[R2dbcReadJournal](R2dbcReadJournal.Identifier)
+      val start = System.nanoTime()
+      val count = Await.result(
+        query
+          .currentEventsBySlicesStartingFromSnapshots[String, String](
+            entityType,
+            0,
+            persistenceExt.numberOfSlices - 1,
+            NoOffset,
+            identity)
+          .runWith(Sink.fold(0)((n, _) => n + 1)),
+        5.minutes)
+      val elapsed = (System.nanoTime() - start).nanos
+      require(count == numberOfPersistenceIds, s"expected $numberOfPersistenceIds envelopes, got $count")
+      val line = s"[$label] emitted $count envelopes in ${elapsed.toMillis} ms " +
+        s"(${if (elapsed.toMillis == 0) "n/a" else (count * 1000L / elapsed.toMillis).toString} envelopes/sec)"
+      println(line)
+      elapsed
+    }
+
+    val baselineElapsed = runQuery(baselineSystem, "batching disabled (baseline)")
+
+    val batchedSystem =
+      ActorSystem[Nothing](Behaviors.empty, "BatchingSnapshotLookupBenchmark-batched", batchedConfig)
+    val batchedElapsed =
+      try runQuery(batchedSystem, "batching enabled")
+      finally {
+        batchedSystem.terminate()
+        Await.result(batchedSystem.whenTerminated, 10.seconds)
+      }
+
+    val resultLine =
+      f"RESULT: baseline ${baselineElapsed.toMillis} ms vs batched ${batchedElapsed.toMillis} ms " +
+      f"(${baselineElapsed.toMillis.toDouble / math.max(1L, batchedElapsed.toMillis)}%.1fx)"
+    println(resultLine)
+
+    baselineSystem.terminate()
+    Await.result(baselineSystem.whenTerminated, 10.seconds)
+  }
+}

--- a/core/src/test/scala/akka/persistence/r2dbc/query/EventsBySliceStartingFromSnapshotSpec.scala
+++ b/core/src/test/scala/akka/persistence/r2dbc/query/EventsBySliceStartingFromSnapshotSpec.scala
@@ -52,14 +52,25 @@ object EventsBySliceStartingFromSnapshotSpec {
     """))
       .withFallback(TestConfig.config)
       .resolve()
+
+  // Same as `config`, but with the batched cache-miss lookup path enabled, so
+  // PostgresSnapshotDao.sequenceNumbersOfSnapshots's `= ANY(?)` SQL is exercised against a real
+  // database too, not just the plain per-id lookup. See BatchingEventsBySliceStartingFromSnapshotSpec.
+  def batchingConfig: Config =
+    ConfigFactory
+      .parseString("akka.persistence.r2dbc.query.start-from-snapshot.batching.enabled = true")
+      .withFallback(config)
+      .resolve()
 }
 
-class EventsBySliceStartingFromSnapshotSpec
-    extends ScalaTestWithActorTestKit(EventsBySliceStartingFromSnapshotSpec.config)
+class EventsBySliceStartingFromSnapshotSpec(testKitConfig: Config)
+    extends ScalaTestWithActorTestKit(testKitConfig)
     with AnyWordSpecLike
     with TestDbLifecycle
     with TestData
     with LogCapturing {
+  def this() = this(EventsBySliceStartingFromSnapshotSpec.config)
+
   import EventsBySliceStartingFromSnapshotSpec._
 
   override def typedSystem: ActorSystem[_] = system


### PR DESCRIPTION
## Summary

Adds an opt-in alternative to `StartingFromSnapshotStage` for `eventsBySlicesStartingFromSnapshots`. The original stage does one blocking, unpipelined DB round-trip per cache miss, which stalls the whole partition once the number of distinct persistence ids exceeds `cache-capacity`. `BatchingStartingFromSnapshotStage` batches misses into one round-trip per group and keeps pulling upstream while a batch is in flight.

Default is `start-from-snapshot.batching.enabled = false`. Behavior is unchanged unless it is turned on.

## Mechanism

 - `SnapshotDao.sequenceNumbersOfSnapshots` batches sequence-number lookups. The default falls back to concurrent per-id calls; `PostgresSnapshotDao` overrides it with a real `= ANY(?)` query grouped by data partition.
 - `BatchingStartingFromSnapshotStage` buffers envelopes in a single ordered queue and only ever decides from its head, so ordering matches the original stage.
 - H2 and SQL Server opt back into the concurrent fallback instead of inheriting the Postgres batched query.

## Testing

 - `BatchingStartingFromSnapshotStageSpec`: 5 unit tests, deterministic via hand-controlled `Promise`s, no database needed. Covers both races above plus ordering and the buffered-envelope bound.
 - Existing `EventsBySliceStartingFromSnapshotSpec` / `EventsByPersistenceIdStartingFromSnapshotSpec` pass unchanged with the default (off), and pass with batching forced on against real Postgres.
 - `BatchingSnapshotLookupBenchmark` (test sources, a plain `main`, not run by `sbt test`): seeds Postgres with a cache-miss-heavy dataset and measures throughput with batching on and off. Local runs show 25-45x.