### PR TITLE
fix: Retrieve more bucket counts directly when catching up

### DIFF
--- a/core/src/main/mima-filters/1.3.16.backwards.excludes/buckets.excludes
+++ b/core/src/main/mima-filters/1.3.16.backwards.excludes/buckets.excludes
@@ -1,0 +1,3 @@
+# internal
+ProblemFilters.exclude[DirectMissingMethodProblem]("akka.persistence.r2dbc.internal.BySliceQuery#Buckets.this")
+ProblemFilters.exclude[DirectMissingMethodProblem]("akka.persistence.r2dbc.internal.BySliceQuery#Buckets.add")

--- a/core/src/main/scala/akka/persistence/r2dbc/internal/BySliceQuery.scala
+++ b/core/src/main/scala/akka/persistence/r2dbc/internal/BySliceQuery.scala
@@ -119,6 +119,20 @@ import org.slf4j.Logger
     val Limit = 10000
 
     final case class Bucket(startTime: EpochSeconds, count: Count)
+
+    /**
+     * Upper bound (inclusive) of the time range for the bucket count query. The time range corresponds to `limit`
+     * number of buckets, or until `now` if that is earlier. No time range limit if `fromTimestamp` is `Instant.EPOCH`.
+     */
+    def countBucketsToTimestamp(fromTimestamp: Instant, limit: Int, now: Instant): Instant = {
+      if (fromTimestamp == Instant.EPOCH)
+        now
+      else {
+        // max buckets, just to have some upper bound
+        val t = fromTimestamp.plusSeconds(BucketDurationSeconds * limit + BucketDurationSeconds)
+        if (t.isAfter(now)) now else t
+      }
+    }
   }
 
   /**
@@ -129,10 +143,14 @@ import org.slf4j.Logger
    *
    * @param countByBucket
    *   Key is the epoch seconds for the start of the bucket. Value is the number of entries in the bucket.
+   * @param hasMore
+   *   `true` if the latest bucket count query was limited by its time range or number of buckets rather than by the
+   *   current time, i.e. more buckets can be retrieved immediately.
    */
   class Buckets(
       countByBucket: immutable.SortedMap[Buckets.EpochSeconds, Buckets.Count],
-      val createdAt: Instant = InstantFactory.now()) {
+      val createdAt: Instant = InstantFactory.now(),
+      val hasMore: Boolean = false) {
     import Buckets.{ Bucket, BucketDurationSeconds, Count, EpochSeconds }
 
     def findTimeForLimit(from: Instant, atLeastCounts: Int): Option[Instant] = {
@@ -161,14 +179,14 @@ import org.slf4j.Logger
 
     // Key is the epoch seconds for the start of the bucket.
     // Value is the number of entries in the bucket.
-    def add(bucketCounts: Seq[Bucket]): Buckets = {
+    def add(bucketCounts: Seq[Bucket], hasMore: Boolean = false): Buckets = {
       val newCountByBucket = countByBucket ++ bucketCounts.iterator.map { case Bucket(startTime, count) =>
         startTime -> count
       }
       if (newCountByBucket.size > Buckets.Limit)
-        new Buckets(newCountByBucket.drop(newCountByBucket.size - Buckets.Limit))
+        new Buckets(newCountByBucket.drop(newCountByBucket.size - Buckets.Limit), hasMore = hasMore)
       else
-        new Buckets(newCountByBucket)
+        new Buckets(newCountByBucket, hasMore = hasMore)
     }
 
     def clearUntil(time: Instant): Buckets = {
@@ -180,9 +198,13 @@ import org.slf4j.Logger
         if (newCountByBucket.size == countByBucket.size)
           this
         else if (newCountByBucket.isEmpty)
-          new Buckets(immutable.SortedMap(countByBucket.last), createdAt = this.createdAt) // keep last
+          new Buckets(
+            immutable.SortedMap(countByBucket.last),
+            createdAt = this.createdAt,
+            hasMore = this.hasMore
+          ) // keep last
         else
-          new Buckets(newCountByBucket, createdAt = this.createdAt)
+          new Buckets(newCountByBucket, createdAt = this.createdAt, hasMore = this.hasMore)
       }
     }
 
@@ -643,18 +665,15 @@ import org.slf4j.Logger
       minSlice: Int,
       maxSlice: Int,
       state: QueryState): Option[Future[QueryState]] = {
-    // Don't run this too frequently
-    if (settings.querySettings.estimateTimeRange &&
-      (state.buckets.isEmpty || JDuration
-        .between(state.buckets.createdAt, InstantFactory.now())
-        .compareTo(eventBucketCountInterval) > 0) &&
-      // For Durable State we always refresh the bucket counts at the interval. For Event Sourced we know
-      // that they don't change because events are append only.
-      (dao.countBucketsMayChange || state.buckets
-        .findTimeForLimit(state.latest.timestamp, settings.querySettings.bufferSize)
-        .isEmpty)) {
 
-      val fromTimestamp = state.buckets.nextStartTime match {
+    def enoughBuckets(buckets: Buckets): Boolean =
+      buckets.findTimeForLimit(state.latest.timestamp, settings.querySettings.bufferSize).isDefined
+
+    def retrievedRecently: Boolean =
+      JDuration.between(state.buckets.createdAt, InstantFactory.now()).compareTo(eventBucketCountInterval) <= 0
+
+    def retrieveBuckets(buckets: Buckets): Future[Buckets] = {
+      val fromTimestamp = buckets.nextStartTime match {
         case Some(t) if !dao.countBucketsMayChange => t
         case _ =>
           if (state.latestBacktracking.timestamp == Instant.EPOCH && state.latest.timestamp == Instant.EPOCH)
@@ -664,27 +683,50 @@ import org.slf4j.Logger
           else
             state.latestBacktracking.timestamp
       }
+      // the dao uses the same time range, but possibly with a slightly later `now`
+      val now = InstantFactory.now()
 
-      val futureState =
-        dao.countBuckets(entityType, minSlice, maxSlice, fromTimestamp, Buckets.Limit, correlationId).map { counts =>
-          val newBuckets = state.buckets.add(counts)
-          val newState = state.copy(buckets = newBuckets)
-          if (log.isDebugEnabled) {
-            val sum = counts.iterator.map { case Bucket(_, count) => count }.sum
-            log.debug(
-              "{} retrieved [{}] event count buckets, with a total of [{}], from time [{}]",
-              logPrefix,
-              counts.size,
-              sum,
-              fromTimestamp)
-          }
-          newState
+      dao.countBuckets(entityType, minSlice, maxSlice, fromTimestamp, Buckets.Limit, correlationId).flatMap { counts =>
+        val hasMore =
+          counts.size >= Buckets.Limit || Buckets.countBucketsToTimestamp(fromTimestamp, Buckets.Limit, now) != now
+        val newBuckets = buckets.add(counts, hasMore)
+        if (log.isDebugEnabled) {
+          val sum = counts.iterator.map { case Bucket(_, count) => count }.sum
+          log.debug(
+            "{} retrieved [{}] event count buckets, with a total of [{}], from time [{}], has more [{}]",
+            logPrefix,
+            counts.size,
+            sum,
+            fromTimestamp,
+            hasMore)
         }
-      Some(futureState)
-    } else {
-      // already enough buckets or retrieved recently
-      None
+
+        // For Event Sourced, continue with the next time range directly if there were too few events in this
+        // time range, otherwise the query would not have an upper bound. Only when making progress, to be safe.
+        if (!dao.countBucketsMayChange && hasMore && !enoughBuckets(newBuckets) &&
+          newBuckets.nextStartTime.exists(_.isAfter(fromTimestamp)))
+          retrieveBuckets(newBuckets)
+        else
+          Future.successful(newBuckets)
+      }
     }
+
+    val shouldRetrieveBuckets =
+      if (!settings.querySettings.estimateTimeRange)
+        false
+      else if (dao.countBucketsMayChange)
+        // For Durable State we always refresh the bucket counts at the interval.
+        state.buckets.isEmpty || !retrievedRecently
+      else
+        // For Event Sourced we know that they don't change because events are append only, so only retrieve more
+        // when needed. Don't run this too frequently, unless the previous retrieval was limited by its time range
+        // or number of buckets. Otherwise the queries will not have an upper bound when catching up a long backlog.
+        !enoughBuckets(state.buckets) && (state.buckets.isEmpty || state.buckets.hasMore || !retrievedRecently)
+
+    if (shouldRetrieveBuckets)
+      Some(retrieveBuckets(state.buckets).map(newBuckets => state.copy(buckets = newBuckets)))
+    else
+      None // already enough buckets or retrieved recently
   }
 
   // TODO Unit test in isolation

--- a/core/src/main/scala/akka/persistence/r2dbc/internal/postgres/PostgresDurableStateDao.scala
+++ b/core/src/main/scala/akka/persistence/r2dbc/internal/postgres/PostgresDurableStateDao.scala
@@ -872,15 +872,7 @@ private[r2dbc] class PostgresDurableStateDao(executorProvider: R2dbcExecutorProv
       correlationId: Option[String]): Future[Seq[Bucket]] = {
 
     val now = InstantFactory.now() // not important to use database time
-    val toTimestamp = {
-      if (fromTimestamp == Instant.EPOCH)
-        now
-      else {
-        // max buckets, just to have some upper bound
-        val t = fromTimestamp.plusSeconds(Buckets.BucketDurationSeconds * limit + Buckets.BucketDurationSeconds)
-        if (t.isAfter(now)) now else t
-      }
-    }
+    val toTimestamp = Buckets.countBucketsToTimestamp(fromTimestamp, limit, now)
 
     val executor = executorProvider.executorFor(minSlice)
     val result = executor.select(s"select bucket counts [$minSlice - $maxSlice]")(

--- a/core/src/main/scala/akka/persistence/r2dbc/internal/postgres/PostgresQueryDao.scala
+++ b/core/src/main/scala/akka/persistence/r2dbc/internal/postgres/PostgresQueryDao.scala
@@ -422,15 +422,7 @@ private[r2dbc] class PostgresQueryDao(executorProvider: R2dbcExecutorProvider) e
     val executor = executorProvider.executorFor(minSlice)
 
     val now = InstantFactory.now() // not important to use database time
-    val toTimestamp = {
-      if (fromTimestamp == Instant.EPOCH)
-        now
-      else {
-        // max buckets, just to have some upper bound
-        val t = fromTimestamp.plusSeconds(Buckets.BucketDurationSeconds * limit + Buckets.BucketDurationSeconds)
-        if (t.isAfter(now)) now else t
-      }
-    }
+    val toTimestamp = Buckets.countBucketsToTimestamp(fromTimestamp, limit, now)
 
     val result = executor.select(s"select bucket counts [$minSlice - $maxSlice]")(
       connection => {

--- a/core/src/test/scala/akka/persistence/r2dbc/internal/BySliceQueryBucketsSpec.scala
+++ b/core/src/test/scala/akka/persistence/r2dbc/internal/BySliceQueryBucketsSpec.scala
@@ -85,6 +85,12 @@ class BySliceQueryBucketsSpec extends AnyWordSpec with TestSuite with Matchers {
 
       // don't change createdAt
       buckets.clearUntil(firstBucketStartTime.plusSeconds(31)).createdAt shouldBe buckets.createdAt
+
+      // don't change hasMore
+      buckets.hasMore shouldBe false
+      val bucketsWithMore = buckets.add(Nil, hasMore = true)
+      bucketsWithMore.clearUntil(firstBucketStartTime.plusSeconds(31)).hasMore shouldBe true
+      bucketsWithMore.clearUntil(firstBucketStartTime.plusSeconds(100)).hasMore shouldBe true
     }
 
     "provide start time for next query" in {

--- a/core/src/test/scala/akka/persistence/r2dbc/internal/BySliceQueryEstimateTimeRangeSpec.scala
+++ b/core/src/test/scala/akka/persistence/r2dbc/internal/BySliceQueryEstimateTimeRangeSpec.scala
@@ -1,0 +1,237 @@
+/*
+ * Copyright (C) 2022 - 2025 Lightbend Inc. <https://akka.io>
+ */
+
+package akka.persistence.r2dbc.internal
+
+import java.time.Clock
+import java.time.Instant
+import java.util.concurrent.ConcurrentLinkedQueue
+
+import scala.annotation.tailrec
+import scala.concurrent.Await
+import scala.concurrent.Future
+import scala.concurrent.duration._
+import scala.jdk.CollectionConverters._
+
+import akka.NotUsed
+import akka.actor.testkit.typed.scaladsl.LogCapturing
+import akka.actor.testkit.typed.scaladsl.ScalaTestWithActorTestKit
+import akka.persistence.query.TimestampOffset
+import akka.persistence.r2dbc.R2dbcSettings
+import akka.persistence.r2dbc.TestConfig
+import akka.persistence.r2dbc.internal.BySliceQuery.Buckets
+import akka.persistence.r2dbc.internal.BySliceQuery.Buckets.Bucket
+import akka.stream.KillSwitches
+import akka.stream.scaladsl.Keep
+import akka.stream.scaladsl.Sink
+import akka.stream.scaladsl.Source
+import org.scalatest.wordspec.AnyWordSpecLike
+import org.slf4j.LoggerFactory
+
+object BySliceQueryEstimateTimeRangeSpec {
+  final case class TestRow(persistenceId: String, seqNr: Long, dbTimestamp: Instant, readDbTimestamp: Instant)
+      extends BySliceQuery.SerializedRow {
+    override def source: String = EnvelopeOrigin.SourceQuery
+  }
+
+  final case class TestEnvelope(offset: TimestampOffset, persistenceId: String, seqNr: Long)
+
+  final case class RowsQuery(
+      fromTimestamp: Instant,
+      toTimestamp: Option[Instant],
+      backtracking: Boolean,
+      rowCount: Int,
+      eventsAfterFromTimestamp: Int)
+
+  /**
+   * In-memory events, mimics the eventsBySlices and bucket count queries of PostgresQueryDao.
+   */
+  class InMemoryDao(events: Vector[TestRow], bufferSize: Int) extends BySliceQuery.Dao[TestRow] {
+    val rowsQueries = new ConcurrentLinkedQueue[RowsQuery]
+    val countBucketsQueries = new ConcurrentLinkedQueue[Instant]
+
+    // index of first event with dbTimestamp >= timestamp
+    private def indexFrom(timestamp: Instant): Int = {
+      @tailrec def search(low: Int, high: Int): Int =
+        if (low >= high) low
+        else {
+          val mid = (low + high) >>> 1
+          if (events(mid).dbTimestamp.isBefore(timestamp)) search(mid + 1, high)
+          else search(low, mid)
+        }
+      search(0, events.size)
+    }
+
+    override def currentDbTimestamp(slice: Int): Future[Instant] =
+      Future.successful(InstantFactory.now())
+
+    override def rowsBySlices(
+        entityType: String,
+        minSlice: Int,
+        maxSlice: Int,
+        fromTimestamp: Instant,
+        fromSeqNr: Option[Long],
+        toTimestamp: Option[Instant],
+        behindCurrentTime: FiniteDuration,
+        backtracking: Boolean,
+        correlationId: Option[String]): Source[TestRow, NotUsed] = {
+      val now = InstantFactory.now()
+      val fromIndex = indexFrom(fromTimestamp)
+      val rows = events
+        .drop(fromIndex)
+        .iterator
+        .filter(row => fromSeqNr.forall(seqNr => row.dbTimestamp != fromTimestamp || row.seqNr >= seqNr))
+        .takeWhile(row => toTimestamp.forall(t => !row.dbTimestamp.isAfter(t)))
+        .takeWhile(row =>
+          behindCurrentTime == Duration.Zero || row.dbTimestamp.isBefore(now.minusMillis(behindCurrentTime.toMillis)))
+        .take(bufferSize)
+        .map(_.copy(readDbTimestamp = now))
+        .toVector
+      rowsQueries.add(RowsQuery(fromTimestamp, toTimestamp, backtracking, rows.size, events.size - fromIndex))
+      Source(rows)
+    }
+
+    override def countBucketsMayChange: Boolean = false
+
+    override def countBuckets(
+        entityType: String,
+        minSlice: Int,
+        maxSlice: Int,
+        fromTimestamp: Instant,
+        limit: Int,
+        correlationId: Option[String]): Future[Seq[Bucket]] = {
+      countBucketsQueries.add(fromTimestamp)
+      val now = InstantFactory.now()
+      val toTimestamp = Buckets.countBucketsToTimestamp(fromTimestamp, limit, now)
+      val buckets = events
+        .drop(indexFrom(fromTimestamp))
+        .iterator
+        .takeWhile(row => !row.dbTimestamp.isAfter(toTimestamp))
+        .map(row => (row.dbTimestamp.getEpochSecond / Buckets.BucketDurationSeconds) * Buckets.BucketDurationSeconds)
+        .foldLeft(Vector.empty[Bucket]) { (acc, startTime) =>
+          if (acc.nonEmpty && acc.last.startTime == startTime)
+            acc.updated(acc.size - 1, Bucket(startTime, acc.last.count + 1))
+          else
+            acc :+ Bucket(startTime, 1)
+        }
+        .take(limit)
+
+      if (toTimestamp == now)
+        Future.successful(buckets)
+      else
+        Future.successful(appendEmptyBucketIfLastIsMissing(buckets, toTimestamp))
+    }
+  }
+}
+
+class BySliceQueryEstimateTimeRangeSpec
+    extends ScalaTestWithActorTestKit(TestConfig.config)
+    with AnyWordSpecLike
+    with LogCapturing {
+  import BySliceQueryEstimateTimeRangeSpec._
+
+  private val settings = R2dbcSettings(system.settings.config.getConfig("akka.persistence.r2dbc"))
+  private val bufferSize = settings.querySettings.bufferSize
+  private val log = LoggerFactory.getLogger(getClass)
+
+  private def everyTenSeconds(from: Instant, until: Instant): Iterator[Instant] =
+    Iterator.iterate(from)(_.plusSeconds(10)).takeWhile(_.isBefore(until))
+
+  private def createEvents(timestamps: Iterator[Instant]): Vector[TestRow] =
+    timestamps.zipWithIndex.map { case (t, i) =>
+      TestRow(s"TestEntity|p${i % 100}", seqNr = i / 100 + 1, t, Instant.EPOCH)
+    }.toVector
+
+  private def liveBySlices(dao: InMemoryDao, events: Vector[TestRow]): Source[TestEnvelope, NotUsed] = {
+    val bySliceQuery = new BySliceQuery[TestRow, TestEnvelope](
+      dao,
+      createEnvelope = (offset, row) => TestEnvelope(offset, row.persistenceId, row.seqNr),
+      extractOffset = _.offset,
+      createHeartbeat = _ => None,
+      Clock.systemUTC(),
+      settings,
+      log)(system.executionContext)
+
+    val initialOffset = TimestampOffset(events.head.dbTimestamp.minusMillis(1), Map.empty)
+    bySliceQuery.liveBySlices("[test]", None, "TestEntity", 0, 1023, initialOffset)
+  }
+
+  private def runUntilLastEvent(dao: InMemoryDao, events: Vector[TestRow]): Unit = {
+    val last = events.last
+    val done = liveBySlices(dao, events)
+      .takeWhile(env => !(env.persistenceId == last.persistenceId && env.seqNr == last.seqNr), inclusive = true)
+      .runWith(Sink.ignore)
+    Await.result(done, 60.seconds)
+  }
+
+  private def assertBoundedQueries(dao: InMemoryDao, maxCountBucketsQueries: Int): Unit = {
+    val queries = dao.rowsQueries.asScala.toVector.filterNot(_.backtracking)
+    // a query without upper bound is expensive when there are many events after the fromTimestamp
+    val expensive = queries.filter(q => q.toTimestamp.isEmpty && q.eventsAfterFromTimestamp > 2 * bufferSize)
+    withClue(
+      s"[${expensive.size}] of [${queries.size}] queries without upper bound, " +
+      s"[${dao.countBucketsQueries.size}] bucket count queries: ") {
+      expensive shouldBe empty
+      dao.countBucketsQueries.size should be <= maxCountBucketsQueries
+    }
+  }
+
+  "BySliceQuery with estimate-time-range" should {
+
+    "use upper bound when catching up a long backlog" in {
+      val endTime = InstantFactory.now().minusSeconds(3600)
+      val startTime = endTime.minusSeconds(4 * 24 * 3600)
+      val events = createEvents(everyTenSeconds(startTime, endTime))
+      val dao = new InMemoryDao(events, bufferSize)
+
+      runUntilLastEvent(dao, events)
+
+      // each bucket count query covers ~28 hours, so 4 are needed
+      assertBoundedQueries(dao, maxCountBucketsQueries = 6)
+    }
+
+    "use upper bound when catching up a backlog with a gap of few events" in {
+      val endTime = InstantFactory.now().minusSeconds(3600)
+      val gapEnd = endTime.minusSeconds(24 * 3600)
+      val gapStart = gapEnd.minusSeconds(5 * 24 * 3600)
+      val startTime = gapStart.minusSeconds(24 * 3600)
+      val sparse = Iterator.iterate(gapStart)(_.plusSeconds(12 * 3600)).takeWhile(_.isBefore(gapEnd))
+      val events =
+        createEvents(everyTenSeconds(startTime, gapStart) ++ sparse ++ everyTenSeconds(gapEnd, endTime))
+      val dao = new InMemoryDao(events, bufferSize)
+
+      runUntilLastEvent(dao, events)
+
+      // each bucket count query covers ~28 hours, so 7 are needed, also for the gap
+      assertBoundedQueries(dao, maxCountBucketsQueries = 10)
+    }
+
+    "not count buckets for each query when caught up" in {
+      val endTime = InstantFactory.now().minusSeconds(3600)
+      val startTime = endTime.minusSeconds(2 * 24 * 3600)
+      val events = createEvents(everyTenSeconds(startTime, endTime))
+      val dao = new InMemoryDao(events, bufferSize)
+      val last = events.last
+
+      val (killSwitch, _) =
+        liveBySlices(dao, events).viaMat(KillSwitches.single)(Keep.right).toMat(Sink.ignore)(Keep.both).run()
+
+      try {
+        eventually {
+          dao.rowsQueries.asScala.exists(q => !q.backtracking && q.fromTimestamp == last.dbTimestamp) shouldBe true
+        }
+        val countBucketsQueriesWhenCaughtUp = dao.countBucketsQueries.size
+        val rowsQueriesWhenCaughtUp = dao.rowsQueries.size
+        // refresh-interval is 1s
+        eventually {
+          dao.rowsQueries.size should be >= rowsQueriesWhenCaughtUp + 3
+        }
+        dao.countBucketsQueries.size shouldBe countBucketsQueriesWhenCaughtUp
+      } finally {
+        killSwitch.shutdown()
+      }
+    }
+  }
+
+}


### PR DESCRIPTION
* eventsBySlices queries could run without the `db_timestamp <= ?` upper bound when catching up a long backlog, resulting in expensive sequential scans
* one bucket count query covers at most ~28 hours, which a catching up projection can consume well within the 60 seconds before the next bucket count query was allowed
* a time range with too few events didn't give any upper bound either
* now the next buckets are retrieved immediately when the previous bucket count query was limited by its time range or number of buckets, rather than by current time
* and it continues directly with the next time range if there were too few events
* the 60 seconds interval still applies once caught up
* BySliceQueryEstimateTimeRangeSpec reproduces it with an in-memory dao
